### PR TITLE
docs: Secret Reference モード E2E 動作確認エビデンス追加 (#64)

### DIFF
--- a/docs/test/captures/v1.6.0-secretref-e2e/akc_e2e_test.log
+++ b/docs/test/captures/v1.6.0-secretref-e2e/akc_e2e_test.log
@@ -1,0 +1,86 @@
+========================================================================
+Secret Reference Mode — End-to-End Verification
+Date: 2026-04-21 16:38:07 JST
+akc: scripts/akc (akc 1.0.0)
+macOS: 26.2 / arm64
+========================================================================
+
+## Test setup
+  security add-generic-password -s AIKC_TEST_DUMMY -a $USER -w test-value-12345 -U
+
+========================================================================
+## SR-E2E-1: dry-run with registered key (masked output)
+========================================================================
+  ✅ AIKC_TEST_DUMMY = ****** (16 chars) (from keychain://AIKC_TEST_DUMMY)
+
+Resolved: 1, Failed: 0
+
+========================================================================
+## SR-E2E-2: actual run — inject resolved value into child env
+========================================================================
+$ AIKC_TEST_DUMMY="keychain://AIKC_TEST_DUMMY" akc run -- bash -c echo "$AIKC_TEST_DUMMY"
+child sees: test-value-12345
+
+========================================================================
+## SR-E2E-3: parent env is NOT modified (child-only injection)
+========================================================================
+parent AIKC_TEST_DUMMY (should be empty): '<unset>'
+
+========================================================================
+## SR-E2E-4: printenv inside child — confirms env table injection
+========================================================================
+$ AIKC_TEST_DUMMY="keychain://AIKC_TEST_DUMMY" akc run -- printenv AIKC_TEST_DUMMY
+test-value-12345
+
+========================================================================
+## SR-E2E-5: unregistered key → error with exit 1
+========================================================================
+  ❌ AIKC_TEST_NONEXISTENT — keychain://AIKC_TEST_NONEXISTENT not found in Keychain
+akc: 1 keychain reference(s) could not be resolved
+akc: run 'akc run --dry-run' to see details
+(exited with code: 1)
+
+========================================================================
+## SR-E2E-6: non-keychain vars pass through unchanged
+========================================================================
+keychain: test-value-12345
+normal:   plain-value
+
+========================================================================
+## SR-E2E-7: byte-exact resolved value (no trailing chars)
+========================================================================
+Registered 3-char value 'abc'. Expecting wc -c == 3 and od -c shows only 'a b c'.
+$ akc run -- bash -c printf "%s" "$AIKC_TEST_DUMMY" | wc -c
+       3
+$ akc run -- bash -c printf "%s" "$AIKC_TEST_DUMMY" | od -c
+0000000    a   b   c                                                    
+0000003
+
+========================================================================
+## Cleanup
+========================================================================
+keychain: "/Users/takehiro/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    0x00000007 <blob>="AIKC_TEST_DUMMY"
+    0x00000008 <blob>=<NULL>
+    "acct"<blob>="takehiro"
+    "cdat"<timedate>=0x32303236303432313037333734385A00  "20260421073748Z\000"
+    "crtr"<uint32>=<NULL>
+    "cusi"<sint32>=<NULL>
+    "desc"<blob>=<NULL>
+    "gena"<blob>=<NULL>
+    "icmt"<blob>=<NULL>
+    "invi"<sint32>=<NULL>
+    "mdat"<timedate>=0x32303236303432313037333830375A00  "20260421073807Z\000"
+    "nega"<sint32>=<NULL>
+    "prot"<blob>=<NULL>
+    "scrp"<sint32>=<NULL>
+    "svce"<blob>="AIKC_TEST_DUMMY"
+    "type"<uint32>=<NULL>
+Keychain entry AIKC_TEST_DUMMY deleted.
+
+========================================================================
+RESULT: ALL 7 SCENARIOS PASS
+========================================================================

--- a/docs/test/v1.6.0-final.md
+++ b/docs/test/v1.6.0-final.md
@@ -142,6 +142,66 @@ AI API カテゴリ選択で該当 4 件のみ表示（3/4 Configured）。
 | エラー総数カウント | 不正確 | 正確 |
 | 受信リクエスト総数 (`requestCount`) | upstream 到達のみ | 受信全件 |
 
+## Secret Reference モード E2E 動作確認 (2026-04-21 追加)
+
+試験仕様書 `docs/test/v1.6.0.md` では SR-001〜005（`scripts/akc` の静的確認）のみ実施済みで、「Keychain に実キー登録 → `akc run` 経由で子プロセス env に解決値が注入される」という end-to-end フローは **未実施（手動確認で対応）** と記載されていた。本節でこれを補完する。
+
+### 検証方法
+
+ダミーキー `AIKC_TEST_DUMMY` を Keychain に一時登録し、`scripts/akc` が値を解決して子プロセス env に注入することを 7 シナリオで確認。
+
+実行ログ全文: [`captures/v1.6.0-secretref-e2e/akc_e2e_test.log`](/test/captures/v1.6.0-secretref-e2e/akc_e2e_test.log)
+
+### 結果サマリ
+
+| No | シナリオ | 期待 | 結果 |
+|----|---------|------|------|
+| SR-E2E-1 | `--dry-run` で登録済みキー | マスク表示 `****** (N chars)` | **OK** |
+| SR-E2E-2 | `akc run -- bash -c 'echo "$VAR"'` | 子プロセスで実値 `test-value-12345` を参照 | **OK** |
+| SR-E2E-3 | 親プロセスの env 変更有無 | 親 env は未変更（`<unset>`） | **OK** |
+| SR-E2E-4 | `akc run -- printenv VAR` | env テーブル注入を確認 | **OK** |
+| SR-E2E-5 | 未登録キーで実行 | `keychain://... not found` + exit 1 | **OK** |
+| SR-E2E-6 | 非 keychain:// 変数のパススルー | `NORMAL_VAR=plain-value` がそのまま届く | **OK** |
+| SR-E2E-7 | バイト一致（3 文字 `abc` 登録） | `wc -c` == 3 / `od -c` で trailing char なし | **OK** |
+
+### 主要ログ抜粋
+
+```
+## SR-E2E-2: actual run — inject resolved value into child env
+$ AIKC_TEST_DUMMY="keychain://AIKC_TEST_DUMMY" akc run -- bash -c 'echo "$AIKC_TEST_DUMMY"'
+child sees: test-value-12345
+
+## SR-E2E-4: printenv inside child
+$ AIKC_TEST_DUMMY="keychain://AIKC_TEST_DUMMY" akc run -- printenv AIKC_TEST_DUMMY
+test-value-12345
+
+## SR-E2E-5: unregistered key → error with exit 1
+  ❌ AIKC_TEST_NONEXISTENT — keychain://AIKC_TEST_NONEXISTENT not found in Keychain
+akc: 1 keychain reference(s) could not be resolved
+(exited with code: 1)
+
+## SR-E2E-7: byte-exact resolved value
+$ akc run -- bash -c 'printf "%s" "$AIKC_TEST_DUMMY" | wc -c'
+       3
+$ akc run -- bash -c 'printf "%s" "$AIKC_TEST_DUMMY" | od -c'
+0000000    a   b   c
+0000003
+```
+
+### 所見
+
+- `security find-generic-password -w` 出力の末尾改行は、`scripts/akc` の bash command substitution (`$(...)`) で剥がされ、子プロセス env にはバイト一致で注入される（SR-E2E-7 で確定）。
+- 親プロセス env には `keychain://...` 参照のみが残り、実値が漏れないことを確認（SR-E2E-3）。ModeComparison の「親プロセス env = パスのみ」の表記と整合。
+- 試験終了後、ダミーの Keychain エントリは削除済み。
+
+### 事後処理
+
+```bash
+security delete-generic-password -s "AIKC_TEST_DUMMY" -a "$USER"
+```
+
+---
+
 ## Xcode ユニットテスト
 
 PR #85 で Xcode テストターゲットを追加（project.yml 更新 + XcodeGen 再生成）。

--- a/docs/test/v1.6.0.md
+++ b/docs/test/v1.6.0.md
@@ -204,7 +204,7 @@ $ grep -n "acceptLocalOnly" AIkeychain/Services/ProxyServer.swift
 | 項目 | 理由 | 対応方針 |
 |------|------|---------|
 | computer-use E2E テスト | 通知センターがクリックをブロック | 手動確認で代替 |
-| Secret Reference 実キー解決 | Keychain にテスト用キーが必要 | 手動で akc run 確認 |
+| Secret Reference 実キー解決 | Keychain にテスト用キーが必要 | ~~手動で akc run 確認~~ → 2026-04-21 に実施済み ([v1.6.0-final.md#Secret-Reference-モード-E2E-動作確認](v1.6.0-final.md)) |
 | Proxy モード統合テスト | プロキシサーバー起動が必要 | v1.5.1 テスト結果を流用 |
 | Xcode ユニットテスト | Xcode ライセンス未承諾 | CI で実行 |
 


### PR DESCRIPTION
## Summary
試験仕様書 `docs/test/v1.6.0.md` で「未実施 / 手動確認で対応」と記載されていた Secret Reference モードの **end-to-end 動作確認** を 2026-04-21 に実施し、エビデンスを追加。

**補完した検証:** Keychain に実キーを一時登録 → `akc run` 経由で子プロセス env に解決値が注入されることを、親 env 未変更・バイト一致・非 keychain:// 変数のパススルーまで含めて確認。

## 結果

全 7 シナリオ PASS ✅

| No | シナリオ | 結果 |
|----|---------|------|
| SR-E2E-1 | dry-run でマスク表示 | OK |
| SR-E2E-2 | 子プロセスで実値参照 | OK |
| SR-E2E-3 | 親プロセス env は未変更 | OK |
| SR-E2E-4 | `printenv` で env テーブル注入確認 | OK |
| SR-E2E-5 | 未登録キーで exit 1 | OK |
| SR-E2E-6 | 非 keychain:// 変数のパススルー | OK |
| SR-E2E-7 | 解決値バイト一致（trailing char 混入なし） | OK |

## 変更内容
- `docs/test/v1.6.0-final.md` — 「Secret Reference モード E2E 動作確認」セクション新設
- `docs/test/v1.6.0.md` — 「未実施項目」表の該当行を「実施済み」に更新
- `docs/test/captures/v1.6.0-secretref-e2e/akc_e2e_test.log` — 実行ログ全文（86 行）

## 背景
v1.6.0 リリース後の質問「Secret Reference モードって動作確認出来てる？」を受けて検証を実施。リリース自体は維持（機能は正常動作）、ドキュメント上の穴を埋める対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)