### PR TITLE
docs: 設計書を v1.6.0 (3モード構成) に同期

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -31,7 +31,7 @@ export default defineConfig({
           items: [
             { text: 'セットアップ', link: '/dev/' },
             { text: 'パッケージング', link: '/dev/packaging' },
-            { text: 'ロードマップ', link: '/dev/roadmap' },
+            { text: 'リリース履歴', link: '/dev/roadmap' },
           ]
         }
       ],

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,7 +1,5 @@
 # アーキテクチャ設計
 
-> GitHub Issue: [#1 アプリケーションアーキテクチャ設計書](https://github.com/aieo-product/AIkeychain/issues/1) → [#53 設計書更新](https://github.com/aieo-product/AIkeychain/issues/53)
-
 ## レイヤー構成
 
 ```mermaid
@@ -14,7 +12,8 @@ graph TB
         EditorView["KeyEditorView"]
         ShareKeysView["ShareKeysView"]
         EnvImportView["EnvImportView"]
-        OtherViews["ModeSelect / Cleanup<br/>Recovery / Help<br/>CategoryManager"]
+        ActivityView["ActivityView<br/>(Proxy ログ)"]
+        OtherViews["ModeSelect / Cleanup<br/>Recovery / Help<br/>CategoryManager / Export"]
     end
 
     subgraph ViewModel["ViewModel Layer (@Observable)"]
@@ -28,12 +27,14 @@ graph TB
         direction LR
         AppState["AppState<br/>(Singleton)"]
         ProxyServer["ProxyServer<br/>(NWListener)"]
+        ProxyLogStore["ProxyLogStore<br/>(In-memory)"]
         KeychainSvc["KeychainService"]
         SetupMgr["SetupManager"]
         ZshrcExp["ZshrcExporter"]
         KeyShareSvc["KeyShareService<br/>(P-256 ECDH)"]
         HTTPParser["HTTPRequestParser"]
         CustomStore["CustomKeyStore"]
+        L10n["L10n<br/>(ja / en)"]
     end
 
     subgraph System["System Layer"]
@@ -44,24 +45,31 @@ graph TB
         CryptoKit["CryptoKit<br/>(P-256 / AES-GCM)"]
     end
 
+    subgraph CLI["External CLI"]
+        Akc["akc<br/>(scripts/akc)"]
+    end
+
     Presentation --> ViewModel
     ViewModel --> Service
     Service --> System
+    Akc -.->|security コマンド| Keychain
 
     style Presentation fill:#E8D5FF,stroke:#7C3AED
     style ViewModel fill:#DBEAFE,stroke:#0284C7
     style Service fill:#D1FAE5,stroke:#059669
     style System fill:#FEF3C7,stroke:#F59E0B
+    style CLI fill:#FCE7F3,stroke:#DB2777
 ```
 
 ### レイヤー責務
 
 | レイヤー | 責務 | 主要コンポーネント |
 |---------|------|------------------|
-| **Presentation** | UI 表示・ユーザー操作受付 | MainView, MenuBarView, OnboardingView, KeyEditorView 他 |
+| **Presentation** | UI 表示・ユーザー操作受付 | MainView, MenuBarView, OnboardingView, KeyEditorView, ActivityView 他 |
 | **ViewModel** | 画面状態管理・ビジネスロジック | KeyListViewModel, KeyEditorViewModel, OnboardingViewModel |
-| **Service** | アプリ固有の処理・外部連携 | AppState, ProxyServer, KeychainService, SetupManager, KeyShareService |
+| **Service** | アプリ固有の処理・外部連携 | AppState, ProxyServer, ProxyLogStore, KeychainService, SetupManager, KeyShareService, L10n |
 | **System** | OS フレームワーク | Security.framework, Network.framework, CryptoKit, ServiceManagement |
+| **External CLI** | Secret Reference 解決 | `akc` (Bash スクリプト) |
 
 ## データフロー
 
@@ -84,6 +92,30 @@ sequenceDiagram
     Shell->>API: curl -H "x-api-key: $ANTHROPIC_API_KEY"
 ```
 
+### Secret Reference モード
+
+```mermaid
+sequenceDiagram
+    participant Shell as ユーザー Shell
+    participant Zshrc as .zshrc
+    participant Akc as akc run
+    participant Security as security コマンド
+    participant Keychain as macOS Keychain
+    participant Child as 子プロセス
+    participant API as AI API
+
+    Shell->>Zshrc: source ~/.zshrc
+    Zshrc->>Shell: export ANTHROPIC_API_KEY="keychain://ANTHROPIC_API_KEY"
+    Shell->>Akc: akc run -- claude
+    Akc->>Akc: env をスキャン (keychain:// プレフィックス検出)
+    Akc->>Security: security find-generic-password -s ANTHROPIC_API_KEY -a "$USER" -w
+    Security->>Keychain: SecItemCopyMatching
+    Keychain-->>Security: シークレット値
+    Security-->>Akc: 値を返却
+    Akc->>Child: env を上書きして exec (親 env は変更しない)
+    Child->>API: curl -H "x-api-key: $ANTHROPIC_API_KEY"
+```
+
 ### Proxy モード
 
 ```mermaid
@@ -94,11 +126,13 @@ sequenceDiagram
     participant Route as ProxyRoute
     participant KS as KeychainService
     participant Keychain as macOS Keychain
+    participant Log as ProxyLogStore
     participant API as Upstream API
 
-    App->>Proxy: POST http://localhost:18121/v1/messages
+    App->>Proxy: POST http://localhost:18121/v1/messages<br/>X-AIKeyChain-Token: <session>
     Proxy->>Parser: 生データをパース
     Parser-->>Proxy: ParsedRequest (host, headers, body)
+    Proxy->>Proxy: セッショントークン検証 (一致しなければ 403)
     Proxy->>Route: route(for: host)
     Route-->>Proxy: ProxyRoute (keychainAccount, headerName)
     Proxy->>KS: retrieve("ANTHROPIC_API_KEY")
@@ -107,8 +141,15 @@ sequenceDiagram
     KS-->>Proxy: API キー
     Proxy->>API: HTTPS リクエスト + 認証ヘッダー注入
     API-->>Proxy: レスポンス
+    Proxy->>Log: append(ProxyLog) — メソッド/パス/ステータス/レイテンシ
     Proxy-->>App: レスポンス転送
 ```
+
+::: tip セッショントークン
+プロキシ起動ごとに UUID を生成し、`~/.aikeychain_proxy` に `AIKEYCHAIN_SESSION_TOKEN` として書き出す。
+クライアントは `X-AIKeyChain-Token` ヘッダで提示し、不一致は 403 で拒否される。
+これにより同じ localhost に同居する他プロセスからの不正利用を防止する。
+:::
 
 ### デバイス間キー転送
 
@@ -148,20 +189,23 @@ AIkeychain/
 │
 ├── Models/
 │   ├── APIKey.swift                 # キー情報 (プリセット + カスタム)
-│   ├── ServiceType.swift            # 20 サービス定義 (6 カテゴリ)
+│   ├── ServiceType.swift            # 17 サービス定義 (6 カテゴリ)
 │   ├── KeyCategory.swift            # 6 カテゴリ定義
-│   ├── OnboardingStep.swift         # 5 ステップ定義
+│   ├── OnboardingStep.swift         # 6 ステップ定義 (language を含む)
 │   ├── CustomKeyStore.swift         # カスタムキー・カテゴリ永続化
-│   └── ProxyRoute.swift             # プロキシルーティング定義
+│   ├── ProxyRoute.swift             # プロキシルーティング定義
+│   ├── ProxyLog.swift               # プロキシ通過ログ + ProxyLogStore
+│   └── AppLanguage.swift            # アプリ表示言語 (ja / en)
 │
 ├── Services/
-│   ├── AppState.swift               # グローバル状態 (シングルトン, デュアルモード)
-│   ├── ProxyServer.swift            # NWListener HTTP プロキシ
+│   ├── AppState.swift               # グローバル状態 (シングルトン, 3 モード)
+│   ├── ProxyServer.swift            # NWListener HTTP プロキシ + セッショントークン
 │   ├── KeychainService.swift        # Keychain CRUD (Protocol ベース)
-│   ├── SetupManager.swift           # .zshrc / プロキシ設定ライフサイクル
+│   ├── SetupManager.swift           # .zshrc / プロキシ設定ファイル ライフサイクル
 │   ├── KeyShareService.swift        # P-256 ECDH + AES-256-GCM キー転送
 │   ├── HTTPRequestParser.swift      # HTTP/1.1 リクエストパーサー
-│   └── ZshrcExporter.swift          # .zshrc / .env エクスポート生成
+│   ├── ZshrcExporter.swift          # .zshrc / Secret Reference / .env エクスポート
+│   └── L10n.swift                   # 多言語化テーブル (ja / en)
 │
 ├── ViewModels/
 │   ├── KeyListViewModel.swift       # キー一覧管理・フィルタリング
@@ -171,18 +215,18 @@ AIkeychain/
 ├── Views/
 │   ├── Main/
 │   │   ├── MainView.swift           # ルート (NavigationSplitView)
-│   │   ├── SidebarView.swift        # カテゴリナビゲーション
+│   │   ├── SidebarView.swift        # カテゴリ + Activity ナビゲーション
 │   │   ├── KeyListView.swift        # キーグリッド + 検索
 │   │   └── KeyRowView.swift         # キーセル
 │   ├── Editor/
 │   │   └── KeyEditorView.swift      # 追加・編集フォーム
 │   ├── Onboarding/
-│   │   ├── OnboardingView.swift     # ステップコンテナ
-│   │   └── SetupView.swift          # シェル設定ガイド
+│   │   └── OnboardingView.swift     # 6 ステップウィザードコンテナ
 │   ├── Export/
-│   │   └── ExportView.swift         # .zshrc/.env エクスポート
+│   │   └── ExportView.swift         # .zshrc / Secret Reference / .env エクスポート
+│   ├── ActivityView.swift           # プロキシリクエストログ表示
 │   ├── MenuBarView.swift            # メニューバーポップオーバー
-│   ├── ModeSelectView.swift         # Standard / Proxy 選択
+│   ├── ModeSelectView.swift         # Standard / Secret Reference / Proxy 選択
 │   ├── ShareKeysView.swift          # 暗号化キー転送 (P-256)
 │   ├── EnvImportView.swift          # 4 ステップ env インポート
 │   ├── CategoryManagerView.swift    # カスタムカテゴリ管理
@@ -199,6 +243,9 @@ AIkeychain/
     ├── AppColors.swift              # カラーパレット
     ├── AppFonts.swift               # タイポグラフィ
     └── AppAnimations.swift          # トランジションアニメーション
+
+scripts/
+└── akc                              # Secret Reference 解決 CLI (Bash)
 ```
 
 ## 状態管理方針
@@ -211,16 +258,23 @@ macOS 14+ の **Observation framework** (`@Observable`) を採用。
 @Observable
 final class AppState {
     static let shared = AppState()
+    static let defaultPort: UInt16 = 18121
 
-    var keyManagementMode: KeyManagementMode  // .standard or .proxy
-    var proxyPort: UInt16 = 18121
-    var proxyServer: ProxyServer
+    let proxyServer = ProxyServer()
+    let proxyLogStore = ProxyLogStore()
+
+    var keyManagementMode: KeyManagementMode  // .standard / .secretReference / .proxy
+    var appLanguage: AppLanguage              // .ja / .en
     var hasProxyConsent: Bool
+    var proxyPort: UInt16                     // デフォルト 18121
     var launchAtLogin: Bool                   // SMAppService 連携
 
-    func startProxyIfNeeded()                 // アプリ起動時の自動開始
-    func stopProxy()                          // プロキシ停止
-    func switchMode(to:)                      // モード切替 + プロキシ再起動
+    var isProxyMode: Bool { keyManagementMode == .proxy }
+    var isSecretRefMode: Bool { keyManagementMode == .secretReference }
+
+    func startProxyIfNeeded()                 // アプリ起動時の自動開始 (Proxy モード時のみ)
+    func stopProxy()                          // プロキシ停止 + 設定ファイル削除
+    func switchMode(to:)                      // モード切替 + プロキシ起動/停止
     func changePort(to:)                      // ポート変更 + 再起動
 }
 ```
@@ -253,7 +307,9 @@ final class KeyListViewModel {
 | カスタムキー・カテゴリ | UserDefaults (JSON) | 軽量な構造化データ |
 | オンボーディング完了フラグ | UserDefaults | 単純なブール値 |
 | モード選択・ポート番号 | UserDefaults | アプリ設定 |
-| プロキシ設定 | ~/.aikeychain_proxy | シェルから参照するため |
+| アプリ表示言語 | UserDefaults (`app_language`) | 起動時に復元 |
+| プロキシ設定 (BASE_URL / Session token) | `~/.aikeychain_proxy` | シェルから参照、起動時生成・停止時削除 |
+| プロキシリクエストログ | メモリのみ | セキュリティ要件 (ディスクに残さない) |
 
 ## エラーハンドリング方針
 
@@ -282,9 +338,13 @@ enum KeychainError: LocalizedError {
 | 状況 | ハンドリング |
 |------|------------|
 | ポート使用中 | `lastError` に記録、MenuBar に表示 |
+| セッショントークン不一致 / 未提示 | HTTP 403 を返却 |
+| ルート未定義 | HTTP 502 を返却 (任意のホストへの転送を防止) |
+| Keychain 読取失敗 | HTTP 401 を返却 (キーなしで上流に送信しない) |
 | 上流 API 接続失敗 | HTTP 502 をクライアントに返却 |
-| ルート未定義 | HTTP 404 をクライアントに返却 |
-| Keychain 読取失敗 | HTTP 500 + エラーメッセージ返却 |
+| リクエストパース失敗 | HTTP 400 を返却 |
+
+すべてのレスポンスは `ProxyLogStore` に追記され、Activity 画面とメニューバーに反映される。
 
 ### SetupManager エラー
 
@@ -295,7 +355,7 @@ enum KeychainError: LocalizedError {
 | security コマンド失敗 | isConfigured を false に設定 |
 
 ::: warning 設計方針
-- エラーは可能な限り **ユーザーに可視化** する（MenuBar ステータス、アラート）
+- エラーは可能な限り **ユーザーに可視化** する（MenuBar ステータス、Activity、アラート）
 - プロキシのエラーは **リクエスト単位で隔離** し、サーバー全体を停止しない
 - Keychain エラーは `LocalizedError` で日本語メッセージを提供
 :::

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -1,11 +1,12 @@
 # データモデル設計
 
-> GitHub Issue: [#2 データモデル設計](https://github.com/aieo-product/AIkeychain/issues/2) → [#53 設計書更新](https://github.com/aieo-product/AIkeychain/issues/53)
-
 ## モデル関連図
 
 ```mermaid
 erDiagram
+    AppState ||--|| KeyManagementMode : "選択"
+    AppState ||--|| AppLanguage : "選択"
+    AppState ||--|| ProxyLogStore : "owns"
     APIKey ||--o| ServiceType : "preset"
     APIKey ||--o| CustomKey : "custom"
     ServiceType ||--|| KeyCategory : "belongs to"
@@ -13,6 +14,15 @@ erDiagram
     CustomKeyStore ||--|{ CustomKey : "manages"
     CustomKeyStore ||--|{ CustomCategory : "manages"
     ProxyRoute ||--|| ServiceType : "routes"
+    ProxyLogStore ||--|{ ProxyLog : "appends"
+
+    KeyManagementMode {
+        String rawValue "standard | secretReference | proxy"
+    }
+
+    AppLanguage {
+        String rawValue "ja | en"
+    }
 
     APIKey {
         UUID id
@@ -60,11 +70,51 @@ erDiagram
         String headerName
         String headerValuePrefix
     }
+
+    ProxyLog {
+        UUID id
+        Date timestamp
+        String service
+        String method
+        String path
+        Int statusCode
+        TimeInterval latency
+        Bool isError
+    }
 ```
+
+## KeyManagementMode
+
+ユーザーが選択するキー管理モード。`UserDefaults` キー `key_management_mode` に永続化される。
+
+```swift
+enum KeyManagementMode: String {
+    case standard          // .zshrc で security 直接参照
+    case secretReference   // keychain:// 参照を akc run で実行時解決
+    case proxy             // ローカルプロキシで認証ヘッダ注入
+}
+```
+
+| Mode | displayName | アプリ常駐 | 親 env への露出 | 子 env への露出 |
+|------|-------------|:----:|:----:|:----:|
+| `.standard` | "Standard" | 不要 | キー値 | キー値 |
+| `.secretReference` | "Secret Reference" | 不要 | 参照パス | キー値 (`akc run` 実行時のみ) |
+| `.proxy` | "Proxy" | 必要 | `*_BASE_URL` のみ | なし |
+
+## AppLanguage
+
+```swift
+enum AppLanguage: String, CaseIterable {
+    case ja
+    case en
+}
+```
+
+`UserDefaults` キー `app_language` に永続化される。`L10n.t(_:)` 経由で UI 文言を切り替える。
 
 ## ServiceType
 
-20 サービスを 6 カテゴリに分類。
+17 サービスを 6 カテゴリに分類。
 
 ### プロパティ
 
@@ -86,7 +136,7 @@ erDiagram
 | Service | displayName | envVarName | tokenPrefix | category |
 |---------|------------|------------|-------------|----------|
 | anthropic | Anthropic (Claude) | ANTHROPIC_API_KEY | `sk-ant-` | ai |
-| openAI | OpenAI (GPT) | OPENAI_API_KEY | `sk-` | ai |
+| openAI | OpenAI | OPENAI_API_KEY | `sk-` | ai |
 | xAI | xAI (Grok) | XAI_API_KEY | `xai-` | ai |
 | higgsfield | Higgsfield | HIGGSFIELD_API_KEY | - | ai |
 
@@ -94,7 +144,7 @@ erDiagram
 
 | Service | displayName | envVarName | loginURL |
 |---------|------------|------------|----------|
-| anthropicWeb | Anthropic Web | ANTHROPIC_WEB_AUTH | claude.ai |
+| anthropicWeb | Anthropic Console | ANTHROPIC_WEB_AUTH | claude.ai |
 | openAIWeb | OpenAI Platform | OPENAI_WEB_AUTH | platform.openai.com |
 | googleAIStudio | Google AI Studio | GOOGLE_AI_STUDIO_AUTH | aistudio.google.com |
 | huggingFace | Hugging Face | HUGGINGFACE_AUTH | huggingface.co |
@@ -236,24 +286,58 @@ struct ProxyRoute {
 | api.openai.com | OPENAI_API_KEY | Authorization | Bearer |
 | api.x.ai | XAI_API_KEY | Authorization | Bearer |
 
-## OnboardingStep
+## ProxyLog / ProxyLogStore
 
-5 段階のオンボーディングウィザード。
+プロキシを通過したリクエストの可視化用ログ。**ディスクには永続化せず、メモリ上のみで保持** する（セキュリティ要件）。
 
 ```swift
-enum OnboardingStep: Int, CaseIterable {
-    case welcome = 0
-    case modeSelect       // Standard / Proxy 選択
-    case registerKeys     // キー登録案内 (スキップ可)
-    case setupShell       // シェル設定 (スキップ可)
-    case completion
+struct ProxyLog: Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let service: String       // "api.anthropic.com" など (host 値)
+    let method: String        // GET / POST など
+    let path: String          // /v1/messages など
+    let statusCode: Int
+    let latency: TimeInterval
+    let isError: Bool
+}
+
+@Observable
+final class ProxyLogStore {
+    var logs: [ProxyLog] = []
+    var todayCount: Int { ... }
+    var todayErrorCount: Int { ... }
+    func append(_ log: ProxyLog)
+    func clear()
 }
 ```
 
-| Step | title | canSkip |
-|------|-------|---------|
-| welcome | "AI KeyChain へようこそ" | false |
-| modeSelect | "モード選択" | false |
-| registerKeys | "キー登録" | true |
-| setupShell | "シェル設定" | true |
-| completion | "セットアップ完了" | false |
+::: warning 設計ポイント
+- **トークン値・リクエストボディは含めない**（漏洩リスク回避）
+- **アプリ終了で消える**（ディスクログなし）
+- Activity 画面・メニューバーから参照
+:::
+
+## OnboardingStep
+
+6 段階のオンボーディングウィザード。
+
+```swift
+enum OnboardingStep: Int, CaseIterable {
+    case language = 0     // 表示言語選択 (ja / en)
+    case welcome          // ウェルカム
+    case modeSelect       // Standard / Secret Reference / Proxy 選択
+    case registerKeys     // キー登録案内 (スキップ可)
+    case setupShell       // シェル設定 (スキップ可)
+    case completion       // 完了
+}
+```
+
+| Step | systemImage | canSkip |
+|------|-------------|---------|
+| language | globe | false |
+| welcome | key.fill | false |
+| modeSelect | switch.2 | false |
+| registerKeys | plus.circle | true |
+| setupShell | terminal | true |
+| completion | checkmark.seal.fill | false |

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -146,9 +146,9 @@ enum AppLanguage: String, CaseIterable {
 |---------|------------|------------|----------|
 | anthropicWeb | Anthropic Console | ANTHROPIC_WEB_AUTH | claude.ai |
 | openAIWeb | OpenAI Platform | OPENAI_WEB_AUTH | platform.openai.com |
-| googleAIStudio | Google AI Studio | GOOGLE_AI_STUDIO_AUTH | aistudio.google.com |
-| huggingFace | Hugging Face | HUGGINGFACE_AUTH | huggingface.co |
-| replicateWeb | Replicate | REPLICATE_AUTH | replicate.com |
+| googleAIStudio | Google AI Studio | GOOGLE_AI_WEB_AUTH | aistudio.google.com |
+| huggingFace | Hugging Face | HUGGINGFACE_TOKEN | huggingface.co |
+| replicateWeb | Replicate | REPLICATE_API_TOKEN | replicate.com |
 
 #### Code & Git
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,15 +1,15 @@
 # 設計書 概要
 
-AI KeyChain の設計ドキュメント一覧です。
+AI KeyChain の設計ドキュメント一覧です。本ドキュメントは v1.6.0 時点の実装に対応しています。
 
 ## ドキュメント構成
 
 | ドキュメント | 概要 |
 |------------|------|
 | [アーキテクチャ](./architecture) | レイヤー構成・データフロー・ファイル構成・状態管理・エラーハンドリング |
-| [データモデル](./data-model) | ServiceType / KeyCategory / APIKey / CustomKeyStore / ProxyRoute |
-| [UI/UXデザイン](./ui-ux) | 画面設計・フロー・カラーパレット・メニューバー |
-| [セキュリティ](./security) | 脅威モデル・Proxy セキュリティ・暗号化キー転送・Entitlements |
+| [データモデル](./data-model) | KeyManagementMode / ServiceType / KeyCategory / APIKey / CustomKeyStore / ProxyRoute / ProxyLog |
+| [UI/UXデザイン](./ui-ux) | 画面設計・フロー・カラーパレット・メニューバー・Activity ログ |
+| [セキュリティ](./security) | 脅威モデル・3 モード比較・Proxy セキュリティ・暗号化キー転送・Entitlements |
 
 ## 技術スタック
 
@@ -17,10 +17,12 @@ AI KeyChain の設計ドキュメント一覧です。
 |------|------|
 | UI | SwiftUI (macOS 14+) |
 | 状態管理 | @Observable (Observation framework) |
+| ローカライズ | 独自 L10n (ja / en、UserDefaults 永続化) |
 | Keychain | Security.framework 直接利用 |
 | プロキシ | Network.framework (NWListener) |
 | 暗号化 | CryptoKit (P-256 ECDH + AES-256-GCM) |
 | ログイン起動 | ServiceManagement (SMAppService) |
+| Secret Reference 解決 | `akc` シェルスクリプト (`scripts/akc`) |
 | 最小 OS | macOS 14 Sonoma |
 | Xcode | 15+ |
 | 言語 | Swift 5.9+ |
@@ -30,20 +32,25 @@ AI KeyChain の設計ドキュメント一覧です。
 ```mermaid
 graph LR
     User["ユーザー"] --> |Standard| Shell[".zshrc<br/>security コマンド"]
+    User --> |Secret Reference| Akc["akc run<br/>(scripts/akc)"]
     User --> |Proxy| App["AI KeyChain<br/>ProxyServer"]
     Shell --> Keychain["macOS<br/>Keychain"]
+    Akc --> Keychain
     App --> Keychain
     App --> |HTTPS + 認証ヘッダー| API["AI API<br/>(Anthropic, OpenAI, xAI)"]
     Shell --> |環境変数| Code["開発コード"]
+    Akc --> |子プロセス env| Code
     Code --> API
 
     style Keychain fill:#FEF3C7,stroke:#F59E0B
     style App fill:#D1FAE5,stroke:#059669
+    style Akc fill:#DBEAFE,stroke:#0284C7
 ```
 
-### デュアルモード設計
+### 3 モード設計
 
-| モード | 仕組み | セキュリティ | 要件 |
-|--------|--------|------------|------|
-| **Standard** | .zshrc から `security` コマンドで Keychain 参照 | 環境変数に値が露出 | アプリ常駐不要 |
-| **Proxy** | localhost HTTP プロキシが認証ヘッダーを注入 | 環境変数に値が露出しない | アプリ常駐必要 |
+| モード | 仕組み | 親プロセス env への露出 | 子プロセス env への露出 | 要件 |
+|--------|--------|:----:|:----:|------|
+| **Standard** | `.zshrc` から `security` コマンドで Keychain 参照 | キー値 | キー値 | アプリ常駐不要 |
+| **Secret Reference** | `keychain://KEY` を `.zshrc` に export し、`akc run` が実行時に解決 | 参照パスのみ | キー値 | アプリ常駐不要 |
+| **Proxy** | localhost HTTP プロキシが認証ヘッダーを注入 | `*_BASE_URL` のみ | キー値なし | アプリ常駐必要 |

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -1,7 +1,5 @@
 # セキュリティ設計
 
-> GitHub Issue: [#15 セキュリティ設計書](https://github.com/aieo-product/AIkeychain/issues/15) → [#53 設計書更新](https://github.com/aieo-product/AIkeychain/issues/53)
-
 ## 脅威モデル
 
 ```mermaid
@@ -14,16 +12,18 @@ graph TB
         T4["デバイス間転送<br/>(キーの平文送信)"]
         T5["メモリダンプ<br/>(スワップ, コアダンプ)"]
         T6["不正アプリ<br/>(Keychain アクセス)"]
+        T7["同居プロセスからの不正利用<br/>(localhost プロキシ悪用)"]
     end
 
     subgraph Defenses["AI KeyChain 防御策"]
         direction LR
-        D1["Proxy モード<br/>(環境変数にキー露出なし)"]
+        D1["Proxy / Secret Reference モード<br/>(親 env にキー値露出なし)"]
         D2["Keychain 専用保存<br/>(ファイル書き出しなし)"]
         D3["localhost 限定バインド<br/>(外部接続拒否)"]
         D4["P-256 ECDH + AES-GCM<br/>(暗号化転送)"]
         D5["都度取得・最小保持<br/>(メモリ露出最小化)"]
         D6["アクセスグループ制限<br/>(ThisDeviceOnly)"]
+        D7["セッショントークン認証<br/>(X-AIKeyChain-Token)"]
     end
 
     T1 -.->|対策| D1
@@ -32,6 +32,7 @@ graph TB
     T4 -.->|対策| D4
     T5 -.->|対策| D5
     T6 -.->|対策| D6
+    T7 -.->|対策| D7
 
     style Threats fill:#FEE2E2,stroke:#DC2626
     style Defenses fill:#D1FAE5,stroke:#059669
@@ -39,12 +40,13 @@ graph TB
 
 ## セキュリティレベル比較
 
-| 方式 | 環境変数露出 | ファイル露出 | ネットワーク | 利便性 |
-|------|:----------:|:----------:|:----------:|:-----:|
-| .env ファイル | ✅ 露出 | ✅ 露出 | - | ★★★ |
-| .zshrc export | ✅ 露出 | ✅ 露出 | - | ★★☆ |
-| **Standard モード** | ✅ 露出 | ❌ なし | - | ★★☆ |
-| **Proxy モード** | ❌ なし | ❌ なし | localhost のみ | ★★★ |
+| 方式 | 親 env キー値 | 子 env キー値 | ファイル露出 | ネットワーク | 利便性 |
+|------|:----:|:----:|:----:|:----:|:-----:|
+| .env ファイル | ✅ 露出 | ✅ 露出 | ✅ 露出 | - | ★★★ |
+| .zshrc 平文 export | ✅ 露出 | ✅ 露出 | ✅ 露出 | - | ★★☆ |
+| **Standard モード** | ✅ 露出 | ✅ 露出 | ❌ なし | - | ★★☆ |
+| **Secret Reference モード** | ❌ 参照のみ | ✅ 露出 (`akc run` 子プロセス内) | ❌ なし | - | ★★★ |
+| **Proxy モード** | ❌ なし (`*_BASE_URL` のみ) | ❌ なし | ❌ なし | localhost のみ | ★★★ |
 
 ## Keychain アクセス制御
 
@@ -77,6 +79,25 @@ let query: [String: Any] = [
 ]
 ```
 
+## Secret Reference モードのセキュリティ
+
+`akc run` (`scripts/akc`) が `keychain://KEY_NAME` 形式の環境変数を実行時に解決する。
+
+### 設計ポイント
+
+| 項目 | 内容 |
+|------|------|
+| 親プロセス env | `keychain://KEY_NAME` の参照文字列のみ。キー値は含まれない |
+| 解決タイミング | `akc run -- <command>` 実行時に `security find-generic-password` を呼び出す |
+| 子プロセス env | `akc` が `exec` で起動する子プロセス環境にのみ実値を注入 |
+| 親 env の変更 | しない（`akc` プロセスのみが実値を保持し終了で消える） |
+| ドライラン | `akc run --dry-run` で対象キーをマスク表示（値は出力しない） |
+
+::: tip Standard モードとの違い
+Standard モードでは `.zshrc` の `export ANTHROPIC_API_KEY=$(security ...)` が **シェル全体に値を export** するため、`env` コマンドや `/proc` で値が見える。
+Secret Reference モードでは親シェル env には参照文字列しか残らず、`akc run` で起動した子プロセスの中だけに値が存在する。
+:::
+
 ## Proxy サーバーセキュリティ
 
 ### localhost 限定バインド
@@ -84,27 +105,54 @@ let query: [String: Any] = [
 ```swift
 let params = NWParameters.tcp
 params.acceptLocalOnly = true  // 外部ネットワークからの接続を拒否
+params.requiredLocalEndpoint = NWEndpoint.hostPort(
+    host: .ipv4(.loopback),
+    port: NWEndpoint.Port(rawValue: port)!
+)
 
-let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+let listener = try NWListener(using: params)
 ```
 
-- `acceptLocalOnly = true` により、`127.0.0.1` からの接続のみ受付
+- `acceptLocalOnly = true` + `loopback` バインドにより、`127.0.0.1` からの接続のみ受付
 - 外部ネットワークからのリクエストは OS レベルで拒否される
 - ファイアウォール設定不要
+
+### セッショントークン認証
+
+localhost に同居する他プロセスからの不正利用を防止するため、プロキシは起動ごとに UUID トークンを生成する。
+
+| 項目 | 内容 |
+|------|------|
+| 生成タイミング | `ProxyServer.start()` 時に `UUID().uuidString` |
+| ヘッダ名 | `X-AIKeyChain-Token` |
+| クライアント側 | `~/.aikeychain_proxy` に `AIKEYCHAIN_SESSION_TOKEN` として export |
+| 検証 | 不一致 / 未提示の場合は HTTP 403 で拒否 |
+| ライフサイクル | プロキシ停止時にメモリ・設定ファイルから消去 |
 
 ### リクエスト処理の安全性
 
 | チェック | 内容 |
 |---------|------|
-| ホスト検証 | `ProxyRoute.route(for:)` に一致するホストのみ転送 |
-| ルート未定義 | 404 を返却 (任意のホストへの転送を防止) |
-| Keychain 失敗 | 500 を返却 (キーなしで上流に送信しない) |
+| セッショントークン | `X-AIKeyChain-Token` 不一致は 403 |
+| ホスト検証 | `ProxyRoute.route(for:)` に一致するホストのみ転送、未定義は 502 |
+| Keychain 失敗 | 401 を返却 (キーなしで上流に送信しない) |
 | HTTPS 強制 | 上流への転送は常に `https://` |
 
 ### プロキシ設定ファイルのライフサイクル
 
 ```
 ~/.aikeychain_proxy  ← プロキシ起動時に生成、停止時に削除
+```
+
+ファイル内容:
+
+```bash
+# AI KeyChain Proxy — this file is auto-managed
+# Deleted when proxy stops. Do not edit manually.
+export ANTHROPIC_BASE_URL=http://localhost:18121
+export OPENAI_BASE_URL=http://localhost:18121
+export XAI_BASE_URL=http://localhost:18121
+export AIKEYCHAIN_SESSION_TOKEN=<UUID>
 ```
 
 `.zshrc` のフックはプロキシのヘルスチェックを行い、応答がない場合は設定ファイルを自動削除:
@@ -125,6 +173,12 @@ fi
 プロキシ未稼働時に `BASE_URL` 環境変数が残ると、全ての AI API 呼び出しが失敗する。
 ヘルスチェック + 自動削除でこの問題を防止している。
 :::
+
+### ProxyLog のセキュリティ要件
+
+- **ディスクへの書き出しを行わない**（`ProxyLogStore` はメモリ上の `[ProxyLog]` のみ）
+- **トークン値・リクエストボディを記録しない**（メソッド / パス / ステータス / レイテンシ のみ）
+- アプリ終了でログは消える
 
 ## デバイス間キー転送の暗号化
 
@@ -250,9 +304,12 @@ func copyToClipboard(_ value: String) {
 - [x] クリップボード 30 秒自動クリア
 - [x] Keychain アクセスグループ制限
 - [x] ThisDeviceOnly で iCloud 同期無効
-- [x] Proxy: localhost 限定バインド (acceptLocalOnly)
+- [x] Proxy: localhost 限定バインド (acceptLocalOnly + loopback)
+- [x] Proxy: セッショントークン認証 (X-AIKeyChain-Token)
 - [x] Proxy: HTTPS 強制 (上流転送)
 - [x] Proxy: ヘルスチェック付き設定ファイルライフサイクル
+- [x] Proxy: ログをメモリ上のみで保持 (ディスクなし、ボディ未記録)
+- [x] Secret Reference: 親 env にキー値を露出させず子プロセスのみに注入
 - [x] 転送: P-256 ECDH + AES-256-GCM 暗号化
 - [x] 転送: エフェメラルキーによる前方秘匿性
 - [x] Export 時の平文警告表示

--- a/docs/design/ui-ux.md
+++ b/docs/design/ui-ux.md
@@ -41,7 +41,7 @@
 
 | 画面 | ファイル | 種別 | 説明 |
 |------|---------|------|------|
-| MenuBarView | MenuBarView.swift | MenuBarExtra | プロキシ状態・モード切替・ポート変更・Activity サマリ |
+| MenuBarView | MenuBarView.swift | MenuBarExtra | プロキシ状態・モード切替・ポート変更・累計リクエスト数 |
 
 ## 画面フロー
 
@@ -153,8 +153,7 @@ graph TB
 │ Mode: 🛡️ Proxy           │
 │ Status: 🟢 Running       │
 │ Port: 18121               │
-│ Today: 42 requests        │
-│ Errors: 0                 │
+│ Requests: 42              │
 ├──────────────────────────┤
 │ Change Mode...            │
 │ Stop Proxy                │

--- a/docs/design/ui-ux.md
+++ b/docs/design/ui-ux.md
@@ -1,7 +1,5 @@
 # UI/UX デザイン
 
-> GitHub Issue: [#3 UI/UXデザイン](https://github.com/aieo-product/AIkeychain/issues/3) → [#53 設計書更新](https://github.com/aieo-product/AIkeychain/issues/53)
-
 ## 画面一覧
 
 ### メインウィンドウ
@@ -9,16 +7,17 @@
 | 画面 | ファイル | 種別 | 説明 |
 |------|---------|------|------|
 | MainView | Main/MainView.swift | Root | NavigationSplitView (Sidebar + Detail) |
-| SidebarView | Main/SidebarView.swift | Sidebar | カテゴリナビゲーション + キー数バッジ |
+| SidebarView | Main/SidebarView.swift | Sidebar | カテゴリ + Activity ナビゲーション + キー数バッジ |
 | KeyListView | Main/KeyListView.swift | Detail | キーグリッド + 検索 + インポート |
 | KeyRowView | Main/KeyRowView.swift | Cell | サービスアイコン + 名前 + ステータス |
+| ActivityView | ActivityView.swift | Detail | プロキシリクエストログのリアルタイム表示 |
 
 ### エディタ・シート
 
 | 画面 | ファイル | 種別 | 説明 |
 |------|---------|------|------|
 | KeyEditorView | Editor/KeyEditorView.swift | Sheet | キー追加・編集フォーム |
-| ExportView | Export/ExportView.swift | Sheet | .zshrc / .env エクスポート |
+| ExportView | Export/ExportView.swift | Sheet | .zshrc / Secret Reference / .env エクスポート |
 | ShareKeysView | ShareKeysView.swift | Sheet | P-256 暗号化キー転送 (3 タブ) |
 | EnvImportView | EnvImportView.swift | Sheet | 4 ステップ env インポートウィザード |
 | CategoryManagerView | CategoryManagerView.swift | Sheet | カスタムカテゴリ CRUD |
@@ -27,7 +26,7 @@
 
 | 画面 | ファイル | 種別 | 説明 |
 |------|---------|------|------|
-| ModeSelectView | ModeSelectView.swift | Sheet | Standard / Proxy モード選択カード |
+| ModeSelectView | ModeSelectView.swift | Sheet | Standard / Secret Reference / Proxy のカード選択 |
 | CleanupView | CleanupView.swift | Sheet | .zshrc クリーンアップガイド |
 | RecoveryView | RecoveryView.swift | Sheet | プロキシ復旧ガイド (3 手段) |
 | HelpView | HelpView.swift | Sheet | ユーザーマニュアル |
@@ -36,14 +35,13 @@
 
 | 画面 | ファイル | 種別 | 説明 |
 |------|---------|------|------|
-| OnboardingView | Onboarding/OnboardingView.swift | Sheet | 5 ステップウィザードコンテナ |
-| SetupView | Onboarding/SetupView.swift | Step | シェル設定ガイド |
+| OnboardingView | Onboarding/OnboardingView.swift | Sheet | 6 ステップウィザードコンテナ (言語選択を含む) |
 
 ### メニューバー
 
 | 画面 | ファイル | 種別 | 説明 |
 |------|---------|------|------|
-| MenuBarView | MenuBarView.swift | MenuBarExtra | プロキシ状態・モード切替・ポート変更 |
+| MenuBarView | MenuBarView.swift | MenuBarExtra | プロキシ状態・モード切替・ポート変更・Activity サマリ |
 
 ## 画面フロー
 
@@ -56,7 +54,8 @@ graph TB
     Check -- No --> Main
 
     subgraph Onboarding["オンボーディング (Sheet)"]
-        Welcome["Welcome"] --> ModeSelect["モード選択"]
+        Language["言語選択"] --> Welcome["Welcome"]
+        Welcome --> ModeSelect["モード選択<br/>Standard / Secret Reference / Proxy"]
         ModeSelect --> RegisterKeys["キー登録案内"]
         RegisterKeys --> SetupShell["シェル設定"]
         SetupShell --> Completion["完了"]
@@ -66,7 +65,8 @@ graph TB
 
     subgraph Main["メイン画面"]
         direction TB
-        Sidebar["SidebarView<br/>カテゴリ一覧"] --> KeyList["KeyListView<br/>キーグリッド"]
+        Sidebar["SidebarView<br/>カテゴリ + Activity"] --> KeyList["KeyListView<br/>キーグリッド"]
+        Sidebar --> Activity["ActivityView<br/>プロキシログ"]
     end
 
     Main --> Editor["KeyEditorView<br/>追加・編集"]
@@ -92,24 +92,25 @@ graph TB
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│ ツールバー: [Proxy ● Active] [Transfer] [Help ▾]        │
+│ ツールバー: [Mode ● Status] [Transfer] [Help ▾]         │
 ├──────────────┬──────────────────────────────────────────┤
-│ Sidebar      │ KeyList                                   │
+│ Sidebar      │ KeyList / ActivityView                    │
 │              │                                           │
-│ All Keys (20)│ AI API                    3 keys          │
-│              │ ┌─────────────────────────────────────┐  │
-│ AI API    (4)│ │ 🧠 Anthropic (Claude)    ✅        │  │
-│ AI Web    (5)│ │    ANTHROPIC_API_KEY                │  │
-│ Code&Git  (2)│ ├─────────────────────────────────────┤  │
-│ Cloud     (3)│ │ 🤖 OpenAI (GPT)         ⚠️        │  │
-│ Comm      (2)│ │    OPENAI_API_KEY                   │  │
-│ DevTools  (1)│ ├─────────────────────────────────────┤  │
-│              │ │ ...                                  │  │
-│ ─────────── │ └─────────────────────────────────────┘  │
+│ All Keys     │ AI API                    3 keys          │
+│ Activity     │ ┌─────────────────────────────────────┐  │
+│              │ │ 🧠 Anthropic (Claude)    ✅        │  │
+│ AI API    (4)│ │    ANTHROPIC_API_KEY                │  │
+│ AI Web    (5)│ ├─────────────────────────────────────┤  │
+│ Code&Git  (2)│ │ 🤖 OpenAI               ⚠️        │  │
+│ Cloud     (3)│ │    OPENAI_API_KEY                   │  │
+│ Comm      (2)│ ├─────────────────────────────────────┤  │
+│ DevTools  (1)│ │ ...                                  │  │
+│              │ └─────────────────────────────────────┘  │
+│ ─────────── │                                           │
 │ Custom Cat   │                                           │
 │              │                                           │
 │ [Manage]     │                                           │
-│ ✅ 12  ⚠️ 8 │ [Import .env]              [+ Add Key]   │
+│ ✅ 12  ⚠️ 5 │ [Import .env]              [+ Add Key]   │
 └──────────────┴──────────────────────────────────────────┘
 ```
 
@@ -126,6 +127,23 @@ graph TB
 | 削除ボタン | 編集時のみ表示 (赤色) |
 | 保存ボタン | "Keychain に保存" |
 
+## Activity 画面
+
+プロキシモード時にリクエストの状況を可視化する。
+
+| 要素 | 内容 |
+|------|------|
+| サマリヘッダ | `Today: N requests` / `Errors: N` (赤 / 緑で状態色分け) |
+| ログ一覧 | 時刻 / サービス名 / メソッド / パス / ステータスコード / レイテンシ |
+| エラー強調 | `isError = true` のログは行全体を赤系で表示 |
+| Clear ボタン | メモリ内ログを全消去 |
+
+::: warning ログの取扱い
+- ディスクには一切書き出されない（メモリ上のみ）
+- トークン値・リクエストボディは記録しない
+- アプリ再起動でログは消える
+:::
+
 ## メニューバー UI
 
 ```
@@ -135,7 +153,8 @@ graph TB
 │ Mode: 🛡️ Proxy           │
 │ Status: 🟢 Running       │
 │ Port: 18121               │
-│ Requests: 42              │
+│ Today: 42 requests        │
+│ Errors: 0                 │
 ├──────────────────────────┤
 │ Change Mode...            │
 │ Stop Proxy                │
@@ -157,7 +176,8 @@ graph TB
 | モード | アイコン | 特徴 |
 |--------|---------|------|
 | **Standard** | 🔑 key.fill | Keychain 直接参照、シンプル、常駐不要 |
-| **Proxy** | 🛡️ shield.lefthalf.filled | 環境変数にキーが露出しない、アプリ常駐必要 |
+| **Secret Reference** | 🔗 link | `keychain://` 参照を `akc run` が解決、親 env にキー値を露出させない |
+| **Proxy** | 🛡️ shield.lefthalf.filled | 環境変数にキー値を一切露出させない、アプリ常駐必要 |
 
 Proxy モード選択時は **同意シート** を表示:
 - プロキシの常時起動が必要な旨の警告
@@ -181,6 +201,21 @@ Proxy モード選択時は **同意シート** を表示:
 | 3 | インポート対象のプレビュー |
 | 4 | Keychain インポート結果表示 |
 
+## ExportView (3 形式)
+
+| 形式 | 用途 |
+|------|------|
+| `.zshrc (Keychain reference)` | Standard モード用。`security find-generic-password ...` の export 行を生成 |
+| `.zshrc (Secret Reference)` | Secret Reference モード用。`export KEY="keychain://KEY"` を生成 |
+| `.env (plaintext)` | 値は `<VALUE>` プレースホルダで出力（平文書き出し回避） |
+
+## ローカライズ (ja / en)
+
+- 表示言語は `AppState.appLanguage` (`ja` / `en`) で切替
+- 文字列は `L10n.t("key")` 経由で取得
+- 言語選択はオンボーディング初回ステップ、または設定画面から変更可
+- `MainView` などは `.id(appState.appLanguage)` で言語切替時に再描画
+
 ## カラーパレット
 
 ### カテゴリカラー
@@ -200,6 +235,7 @@ Proxy モード選択時は **同意シート** を表示:
 |-----------|--------|-----|
 | 設定済み | Emerald | `#10B981` |
 | 未設定 | Amber | `#F59E0B` |
+| エラー | Red | `#DC2626` |
 
 ### アクセントグラデーション
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -25,13 +25,33 @@ npm run docs:dev
 
 ## Xcode プロジェクト
 
+`project.yml` から XcodeGen でプロジェクトを生成する構成。
+
 ```bash
+xcodegen generate
 open AIkeychain.xcodeproj
 ```
 
-::: info
-Xcode プロジェクトは [Issue #4](https://github.com/aieo-product/AIkeychain/issues/4) で作成予定です。
-:::
+## Swift Package Manager によるビルド
+
+```bash
+swift build -c release
+```
+
+## `akc` CLI (Secret Reference 解決)
+
+`scripts/akc` が `keychain://KEY_NAME` 形式の環境変数を実行時に解決する Bash スクリプト。
+Secret Reference モードで利用する。
+
+```bash
+# 解決対象を確認 (値はマスク)
+./scripts/akc run --dry-run
+
+# コマンドを実行
+./scripts/akc run -- claude
+```
+
+PATH に通すには `~/.local/bin` などにコピー / シンボリックリンクを作成する。
 
 ## ブランチ戦略
 
@@ -41,3 +61,4 @@ Xcode プロジェクトは [Issue #4](https://github.com/aieo-product/AIkeychai
 | `feature/xxx` | 機能開発 |
 | `fix/xxx` | バグ修正 |
 | `docs/xxx` | ドキュメント |
+| `test/xxx` | テスト・検証 |

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -1,61 +1,59 @@
-# ロードマップ
+# リリース履歴
 
-## Phase 概要
+リリース済みバージョンの主な変更点。詳細は [`CHANGELOG.md`](https://github.com/aieo-product/AIkeychain/blob/main/CHANGELOG.md) を参照。
 
-```
-Phase 1          Phase 2          Phase 3          Phase 4
-設計・基盤       コア機能         UI/オンボーディング  テスト・リリース
-───────────▶   ───────────▶   ───────────▶   ───────────▶
-```
+## v1.6.0 — Secret Reference モード対応
 
-## Phase 1: 設計・基盤構築
+### 追加
+- **Secret Reference モード** — `keychain://KEY_NAME` 参照を `akc run` が実行時に解決し、親 env にキー値を露出させない
+- **`akc` CLI** (`scripts/akc`) — `--dry-run` で対象キーをマスク表示
+- **Activity 画面** — プロキシ通過リクエストのリアルタイム表示 (時刻 / ホスト / メソッド / パス / ステータス / レイテンシ)
+- **`ProxyLogStore`** — メモリ上のみで保持されるリクエストログ (ディスク永続化なし)
+- **セッショントークン認証** — `X-AIKeyChain-Token` ヘッダで localhost 同居プロセスからの不正利用を防止
+- **アプリ表示言語切替 (ja / en)** — オンボーディング初回ステップで選択、`L10n` テーブル経由で全画面を切替
+- **オンボーディングに言語選択ステップを追加** — 6 ステップ構成
 
-| Issue | タイトル | ステータス |
-|-------|---------|-----------|
-| [#1](https://github.com/aieo-product/AIkeychain/issues/1) | アーキテクチャ設計書 | :construction: |
-| [#2](https://github.com/aieo-product/AIkeychain/issues/2) | データモデル設計 | :construction: |
-| [#3](https://github.com/aieo-product/AIkeychain/issues/3) | UI/UXデザイン | :construction: |
-| [#15](https://github.com/aieo-product/AIkeychain/issues/15) | セキュリティ設計書 | :construction: |
-| [#4](https://github.com/aieo-product/AIkeychain/issues/4) | Xcodeプロジェクト初期セットアップ | :white_circle: |
+### 変更
+- ExportView に **Secret Reference 形式** を追加 (`.zshrc / Secret Reference / .env` の 3 形式)
+- ModeSelectView を 3 モード (Standard / Secret Reference / Proxy) のカード選択に再構成
 
-## Phase 2: コア機能実装
+## v1.1.0 — モード選択と復旧 UX
 
-| Issue | タイトル | ステータス |
-|-------|---------|-----------|
-| [#5](https://github.com/aieo-product/AIkeychain/issues/5) | KeychainService - Keychain CRUD | :white_circle: |
-| [#6](https://github.com/aieo-product/AIkeychain/issues/6) | Theme定義 | :white_circle: |
-| [#7](https://github.com/aieo-product/AIkeychain/issues/7) | メイン画面 - キー一覧 | :white_circle: |
-| [#8](https://github.com/aieo-product/AIkeychain/issues/8) | キー編集画面 | :white_circle: |
-| [#10](https://github.com/aieo-product/AIkeychain/issues/10) | Export機能 | :white_circle: |
+### 追加
+- Standard / Proxy モード選択
+- Proxy モード同意画面
+- Recovery Guide / Shell Cleanup ツール
+- プロキシ設定ファイルのライフサイクル管理 (`~/.aikeychain_proxy`)
+- 強制終了時のフォールバック (`.zshrc` フックでヘルスチェック → 古い設定を自動削除)
+- ポート設定 UI、ポート永続化
+- アニメーション付きオンボーディング モード比較
+- DMG インストーラ (背景画像つき)
+- アドホックコード署名
 
-## Phase 3: UI/オンボーディング
+### 変更
+- デフォルトポート 9999 → 18121
+- `.zshrc` への自動書き込み廃止 (ライフサイクルファイル経由に統一)
 
-| Issue | タイトル | ステータス |
-|-------|---------|-----------|
-| [#9](https://github.com/aieo-product/AIkeychain/issues/9) | オンボーディング - チュートリアル | :white_circle: |
-| [#11](https://github.com/aieo-product/AIkeychain/issues/11) | ContentView ルーター | :white_circle: |
-| [#18](https://github.com/aieo-product/AIkeychain/issues/18) | アプリアイコン作成 | :white_circle: |
+### 修正
+- プロキシ未稼働時に残った `ANTHROPIC_BASE_URL` 起因の ECONNREFUSED
 
-## Phase 4: テスト・リリース
+## v1.0.0 — 初回リリース
 
-| Issue | タイトル | ステータス |
-|-------|---------|-----------|
-| [#12](https://github.com/aieo-product/AIkeychain/issues/12) | ユニットテスト・UIテスト | :white_circle: |
-| [#13](https://github.com/aieo-product/AIkeychain/issues/13) | ビルド・配布準備 (DMG) | :white_circle: |
-| [#16](https://github.com/aieo-product/AIkeychain/issues/16) | CI/CD GitHub Actions | :white_circle: |
+### 追加
+- macOS Keychain 統合 (Security.framework CRUD)
+- ローカル認証プロキシ (`NWListener`)
+- 主要 AI / Git / Cloud / Communication / Dev Tools サービス対応
+- メニューバー常駐
+- 5 ステップのオンボーディング
+- キーエディタ (プレフィックス検証)
+- カテゴリサイドバー
+- `.zshrc` / `.env` エクスポート
+- ヘルプ画面
+- Launch at Login (`SMAppService`)
 
-## その他
+## v0.1.0 — プロジェクトスキャフォールド
 
-| Issue | タイトル | ステータス |
-|-------|---------|-----------|
-| [#14](https://github.com/aieo-product/AIkeychain/issues/14) | 技術ブログ連載計画 | :white_circle: |
-| [#17](https://github.com/aieo-product/AIkeychain/issues/17) | 4/10 LT登壇資料準備 | :white_circle: |
-
-## マイルストーン
-
-| 日付 | マイルストーン |
-|------|-------------|
-| 3/23 | Phase 1-2 完了 (設計 + コア機能) |
-| 3/30 | Phase 3 完了 (UI/オンボーディング) |
-| 4/5 | Phase 4 完了 (テスト・リリース) |
-| **4/10** | **LT 登壇** |
+### 追加
+- Swift Package Manager + XcodeGen 構成
+- VitePress 設計ドキュメントサイト
+- Cloudflare Pages デプロイ


### PR DESCRIPTION
## 概要

AI KeyChain v1.6.0 の実装に対し、設計書 (`docs/design/`) と開発ガイド (`docs/dev/`) が古い 2 モード前提・未着手 Issue 一覧の状態だったため、現状の実装に合わせて全面更新する。

## 変更内容

| # | 観点 | 変更概要 |
|---|------|---------|
| 1 | モード構成 | デュアルモード (Standard / Proxy) → **3 モード** (Standard / Secret Reference / Proxy) |
| 2 | Secret Reference | `keychain://` 参照と `scripts/akc` CLI のフロー・セキュリティ特性を追記 |
| 3 | Activity / ログ | `ActivityView` / `ProxyLog` / `ProxyLogStore` を追加 |
| 4 | Proxy セキュリティ | セッショントークン認証 (`X-AIKeyChain-Token`) を追記 |
| 5 | オンボーディング | 5 ステップ → **6 ステップ** (言語選択を追加) |
| 6 | ローカライズ | `AppLanguage` / `L10n` を追記 |
| 7 | TODO 的記述削除 | Issue 参照ヘッダー (`> GitHub Issue: ...`) / "construction" / "予定" を全削除 |
| 8 | ロードマップ | 未着手 Issue 一覧 → **リリース履歴** (v1.6.0 / v1.1.0 / v1.0.0 / v0.1.0) に置換 |

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `docs/design/index.md` | 3 モード比較表 + 技術スタック更新 |
| `docs/design/architecture.md` | レイヤー図に ActivityView / ProxyLogStore / akc CLI を追加、Secret Reference シーケンス追加 |
| `docs/design/data-model.md` | `KeyManagementMode` / `AppLanguage` / `ProxyLog` / `OnboardingStep` (6 ステップ) を追記 |
| `docs/design/ui-ux.md` | ActivityView 章 / Export 3 形式 / ローカライズ章を追加 |
| `docs/design/security.md` | Secret Reference のセキュリティ特性 / セッショントークン / ProxyLog 取扱を追記 |
| `docs/dev/index.md` | XcodeGen / `akc` CLI セクション追加、TODO 的記述削除 |
| `docs/dev/roadmap.md` | 未着手 Issue 一覧 → リリース履歴に置換 |
| `docs/.vitepress/config.mjs` | サイドバー「ロードマップ」→「リリース履歴」 |

## テスト計画

- [x] VitePress ビルドで本 PR の変更による新規 dead link / シンタックスエラーが発生しないこと (本 PR 適用前から残存する `test/v1.6.0-final.md` 内の dead link は本 PR と無関係)
- [ ] レビュアーが docs サイトで 3 モードの説明・Activity / Secret Reference の記述を確認

## 補足

- ソースは触っていない (ドキュメントのみの変更)
- `CHANGELOG.md` は既に v1.6.0 まで更新済みのため変更不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)