### PR TITLE
fix(akc) + chore: resolve GUI Keychain refs and align MARKETING_VERSION to 1.6.1

### DIFF
--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -555,7 +555,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;
@@ -653,7 +653,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to AI KeyChain are documented in this file.
 
-## [Unreleased]
+## [1.6.1] - 2026-05-13
 
 ### Fixed
-- **`akc` CLI** — `keychain://KEY_NAME` references registered via the AI KeyChain GUI (stored under `service=com.aieo.aikeychain` / `account=<KEY_NAME>`) could not be resolved by `akc run`; only manually-registered keys (`service=<KEY_NAME>` / `account=$USER`) were looked up. `resolve_keychain` now checks the GUI scheme first and falls back to the manual scheme, so Secret Reference mode works end-to-end with keys added through the app
+- **`akc` CLI** — `keychain://KEY_NAME` references registered via the AI KeyChain GUI (stored under `service=com.aieo.aikeychain` / `account=<KEY_NAME>`) could not be resolved by `akc run`; only manually-registered keys (`service=<KEY_NAME>` / `account=$USER`) were looked up. `resolve_keychain` now checks the GUI scheme first and falls back to the manual scheme, so Secret Reference mode works end-to-end with keys added through the app (#90)
+- **`MARKETING_VERSION` drift** — `project.yml` and the generated `AIkeychain.xcodeproj` had been frozen at `1.0.0` even though the project was released as `v1.5.1` / `v1.6.0`. Bumped to `1.6.1` to align with the Git tag and CHANGELOG. `scripts/akc` `VERSION` is now also aligned to the app version
 
 ## [1.6.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to AI KeyChain are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **`akc` CLI** — `keychain://KEY_NAME` references registered via the AI KeyChain GUI (stored under `service=com.aieo.aikeychain` / `account=<KEY_NAME>`) could not be resolved by `akc run`; only manually-registered keys (`service=<KEY_NAME>` / `account=$USER`) were looked up. `resolve_keychain` now checks the GUI scheme first and falls back to the manual scheme, so Secret Reference mode works end-to-end with keys added through the app
+
 ## [1.6.0] - 2026-04-21
 
 ### Added

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aieo.aikeychain
-        MARKETING_VERSION: "1.0.0"
+        MARKETING_VERSION: "1.6.1"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/scripts/akc
+++ b/scripts/akc
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.1"
+VERSION="1.6.1"
 
 usage() {
     cat <<'USAGE'

--- a/scripts/akc
+++ b/scripts/akc
@@ -9,10 +9,14 @@
 # Environment variables with values matching "keychain://<KEY_NAME>" are resolved
 # via macOS Keychain (security find-generic-password) and injected into the
 # child process environment. The parent process env is never modified.
+#
+# Lookup order:
+#   1. service="com.aieo.aikeychain" account="<KEY_NAME>"  (AI KeyChain GUI store)
+#   2. service="<KEY_NAME>"          account="$USER"        (manually-registered keys)
 
 set -euo pipefail
 
-VERSION="1.0.0"
+VERSION="1.0.1"
 
 usage() {
     cat <<'USAGE'
@@ -40,6 +44,11 @@ USAGE
 
 resolve_keychain() {
     local key_name="$1"
+    local value
+
+    value=$(security find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null) \
+        && [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+
     security find-generic-password -s "$key_name" -a "$USER" -w 2>/dev/null
 }
 


### PR DESCRIPTION
## Summary
- **fix(akc):** `keychain://KEY_NAME` references registered via the AI KeyChain GUI could not be resolved by `akc run` (Secret Reference mode broken end-to-end for app-registered keys)
- **chore(version):** `MARKETING_VERSION` had been frozen at `1.0.0` since v0 even though v1.5.1 / v1.6.0 were already tagged — sync it (and `scripts/akc`) to `1.6.1`
- CHANGELOG finalized as `[1.6.1] - 2026-05-13`

## Root cause of the akc bug
- The GUI stores entries as `service=com.aieo.aikeychain` / `account=<KEY_NAME>`
- `resolve_keychain()` only looked under the manual-registration scheme (`service=<KEY_NAME>` / `account=$USER`)
- → GUI keys silently failed to resolve

## Reproduction (before the fix)
1. Open AI KeyChain, switch to Secret Reference mode, register `CLOUDFLARE_API_TOKEN`
2. `export CLOUDFLARE_API_TOKEN=keychain://CLOUDFLARE_API_TOKEN`
3. `akc run --dry-run`
4. Result: `❌ CLOUDFLARE_API_TOKEN — keychain://CLOUDFLARE_API_TOKEN not found in Keychain` even though `security find-generic-password -s com.aieo.aikeychain -a CLOUDFLARE_API_TOKEN -w` returns the value

## Changes
- `scripts/akc` `resolve_keychain()` — lookup order: GUI scheme → manual scheme; header comment documents the order; `VERSION` bumped to `1.6.1`
- `project.yml` `MARKETING_VERSION`: `1.0.0` → `1.6.1`
- `AIkeychain.xcodeproj/project.pbxproj` `MARKETING_VERSION` (×2): `1.0.0` → `1.6.1`
- `CHANGELOG.md` — `[1.6.1] - 2026-05-13` section with both Fixed entries

## Test plan
- [x] `akc version` → `akc 1.6.1`
- [x] `akc run --dry-run` resolves a GUI-registered `CLOUDFLARE_API_TOKEN` (40 chars)
- [x] Fallback verified: synthetic manual-scheme key (`security add-generic-password -s AKC_TEST_FALLBACK -a $USER ...`) resolves correctly (22 chars)
- [x] `akc run -- wrangler pages project list` authenticates and lists projects
- [x] `akc run -- wrangler pages project create akc-secretref-test` succeeds
- [x] `akc run -- wrangler pages deploy ...` deploys; `https://akc-secretref-test.pages.dev` returns HTTP 200
- [ ] (Manual) Xcode build → "About AI KeyChain" shows `Version 1.6.1`

## Cleanup after merge
- Delete the throwaway Pages project `akc-secretref-test` (created only for the E2E proof)
- Tag `v1.6.1` once the build is verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)