### PR TITLE
feat(cli): npm 配布の akc CLI + MCP サーバーを追加 (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,30 @@ Terminal               AI KeyChain Proxy          API Server
 
 The proxy runs on `localhost` only. Keys never leave the Keychain into environment variables.
 
+## CLI & MCP Server (npm)
+
+The [`aikeychain`](cli/) npm package provides a standalone CLI (`akc`) and an MCP server — no GUI app required:
+
+```bash
+npm install -g aikeychain    # or: npx aikeychain
+
+# Secret Reference workflow
+export OPENAI_API_KEY=keychain://OPENAI_API_KEY
+akc run -- claude            # real value injected into the child process only
+
+akc list                     # key names (never prints values)
+akc set GITHUB_TOKEN         # hidden prompt, overwrites in place
+akc doctor                   # diagnose env + ~/.zshrc references
+```
+
+Let AI agents (Claude Code, Codex, ...) use AI KeyChain correctly via MCP:
+
+```bash
+claude mcp add aikeychain -- npx -y aikeychain mcp
+```
+
+The MCP tools (`usage_guide`, `list_keys`, `check_key`, `get_secret_reference`, `set_secret`, `delete_secret`, `doctor`) **never return raw secret values to the model** — agents get `keychain://` references and run workloads through `akc run`. See [cli/README.md](cli/README.md) for details.
+
 ## Supported Services
 
 | Category | Services |
@@ -225,6 +249,29 @@ Terminal               AI KeyChain Proxy          API Server
 ```
 
 プロキシは `localhost` のみで動作。キーが環境変数に露出することはありません。
+
+### CLI & MCP サーバー（npm）
+
+GUI アプリなしでも使える CLI（`akc`）と MCP サーバーを npm パッケージ [`aikeychain`](cli/) として提供しています。
+
+```bash
+npm install -g aikeychain    # または npx aikeychain
+
+export OPENAI_API_KEY=keychain://OPENAI_API_KEY
+akc run -- claude            # 実際の値は子プロセスにのみ注入
+
+akc list                     # キー名一覧（値は表示しない）
+akc set GITHUB_TOKEN         # 隠し入力で登録（重複エントリを作らず上書き）
+akc doctor                   # env / ~/.zshrc の参照を診断
+```
+
+AI エージェント（Claude Code / Codex 等）から正しく使わせるには MCP サーバーを登録します：
+
+```bash
+claude mcp add aikeychain -- npx -y aikeychain mcp
+```
+
+MCP ツールは**シークレットの生値をモデルに返さない**設計です（`keychain://` 参照 + `akc run` 注入で完結）。詳細は [cli/README.md](cli/README.md) を参照。
 
 ### 対応サービス
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,76 @@
+# aikeychain
+
+**CLI & MCP server for [AI KeyChain](https://github.com/aieo-product/AIkeychain)** — use API keys stored in the macOS Keychain without ever writing them to `.env` files, shell config, or code. Works standalone (no GUI app required).
+
+```bash
+npm install -g aikeychain   # or use npx aikeychain
+```
+
+> macOS only (uses the `security` command). Node.js 18+.
+
+## Why
+
+AI agents (Claude, Codex, ...) and humans keep mishandling secrets: pasting them into `.env`, hardcoding them, or reading the Keychain the wrong way. `akc` gives both a safe, uniform interface:
+
+- Env vars hold **references** (`keychain://KEY_NAME`), never values
+- `akc run` resolves references and injects real values **only into the child process**
+- The bundled **MCP server** teaches AI agents the correct usage and never returns raw secret values to the model
+
+## CLI
+
+```bash
+# Run anything with secrets injected (parent env never sees values)
+export OPENAI_API_KEY=keychain://OPENAI_API_KEY
+akc run -- claude
+
+# Preview what would resolve (values masked)
+akc run --dry-run
+
+# Manage keys
+akc list                  # key names only — never prints values
+akc check GITHUB_TOKEN    # exists? in which store?
+akc get GITHUB_TOKEN      # prints keychain://GITHUB_TOKEN (use --reveal for the raw value)
+akc set GITHUB_TOKEN      # hidden prompt (or pipe via stdin); overwrites in place, no duplicates
+akc delete GITHUB_TOKEN
+
+# Diagnose your setup (env + ~/.zshrc), including the -a "$USER" pitfall
+akc doctor
+
+# Print the usage guide for AI agents
+akc guide
+```
+
+### Keychain lookup order
+
+1. `service="com.aieo.aikeychain"`, `account=<KEY>` — the AI KeyChain GUI store
+2. `service=<KEY>` with **no account** — manually-registered keys
+
+Manual keys are looked up by service only because `acct` attributes are inconsistent across entries; pinning `-a` can return a stale duplicate ([issue #91](https://github.com/aieo-product/AIkeychain/issues/91)).
+
+## MCP server
+
+```bash
+# Claude Code
+claude mcp add aikeychain -- npx -y aikeychain mcp
+
+# Codex CLI (~/.codex/config.toml)
+# [mcp_servers.aikeychain]
+# command = "npx"
+# args = ["-y", "aikeychain", "mcp"]
+```
+
+| Tool | Returns | Raw secret exposed to model? |
+|---|---|---|
+| `usage_guide` | How to handle secrets on this machine | No |
+| `list_keys` | Key names + which store | No |
+| `check_key` | Existence + store | No |
+| `get_secret_reference` | `keychain://KEY` + usage snippet | No |
+| `set_secret` | Save confirmation | Input only (prefer `akc set` by the user) |
+| `delete_secret` | Deletion result (requires `confirm: true`) | No |
+| `doctor` | Masked diagnosis of env + shell config | No |
+
+**There is intentionally no tool that returns a secret value.** Agents obtain a `keychain://` reference and execute workloads through `akc run`, so values stay out of the model context entirely.
+
+## License
+
+MIT

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// akc — AI KeyChain CLI
+// Secret-reference resolver + key management + MCP server for AI agents.
+
+import { createRequire } from 'node:module';
+import {
+  assertMacOS,
+  keyExists,
+  listKeys,
+  resolveKey,
+  setKey,
+  deleteKey,
+  maskValue,
+  KeychainError,
+} from '../src/keychain.js';
+import { cmdRun } from '../src/run.js';
+import { runDoctor, formatReport } from '../src/doctor.js';
+import { USAGE_GUIDE } from '../src/usage-guide.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
+
+const USAGE = `akc — AI KeyChain CLI (secret references, key management, MCP server)
+
+Usage:
+  akc run [--dry-run] -- <command> [args...]
+  akc list
+  akc check <KEY>
+  akc get <KEY> [--reveal]
+  akc set <KEY> [--manual]
+  akc delete <KEY>
+  akc doctor
+  akc guide
+  akc mcp
+  akc version
+  akc help
+
+Commands:
+  run      Resolve keychain:// env references and execute a command
+  list     List known key names (never prints values)
+  check    Check whether a key exists and in which store
+  get      Print the keychain:// reference for a key (--reveal prints the raw value)
+  set      Store/update a key (value via hidden prompt, or piped stdin)
+  delete   Delete a key from the Keychain
+  doctor   Diagnose env + ~/.zshrc keychain references (values masked)
+  guide    Print the AI KeyChain usage guide
+  mcp      Start the MCP server on stdio (for Claude Code / Codex etc.)
+
+Examples:
+  export OPENAI_API_KEY=keychain://OPENAI_API_KEY
+  akc run -- claude
+  akc set GITHUB_TOKEN            # prompts for the value (hidden)
+  claude mcp add aikeychain -- npx -y aikeychain mcp
+`;
+
+function readSecretFromTTY(promptText) {
+  return new Promise((resolve, reject) => {
+    process.stderr.write(promptText);
+    const stdin = process.stdin;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+    let value = '';
+    const cleanup = () => {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.off('data', onData);
+    };
+    const onData = (chunk) => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n' || ch === '\u0004') {
+          cleanup();
+          process.stderr.write('\n');
+          resolve(value);
+          return;
+        }
+        if (ch === '\u0003') {
+          cleanup();
+          process.stderr.write('\n');
+          reject(new KeychainError('cancelled'));
+          return;
+        }
+        if (ch === '\u007f' || ch === '\b') {
+          value = value.slice(0, -1);
+        } else {
+          value += ch;
+        }
+      }
+    };
+    stdin.on('data', onData);
+  });
+}
+
+async function readSecret(keyName) {
+  if (!process.stdin.isTTY) {
+    let data = '';
+    for await (const chunk of process.stdin) data += chunk;
+    return data.replace(/\r?\n$/, '');
+  }
+  return readSecretFromTTY(`Enter value for ${keyName} (input hidden): `);
+}
+
+async function cmdList() {
+  const keys = await listKeys();
+  if (keys.length === 0) {
+    process.stdout.write('No keys found.\n');
+    return 0;
+  }
+  for (const { name, sources } of keys) {
+    process.stdout.write(`  ${name}  [${sources.join(', ')}]\n`);
+  }
+  return 0;
+}
+
+async function cmdCheck(name) {
+  const result = await keyExists(name);
+  if (result.exists) {
+    const stores = [result.app && 'AI KeyChain store', result.manual && 'manual entry']
+      .filter(Boolean)
+      .join(', ');
+    process.stdout.write(`✅ ${name} exists (${stores})\n`);
+    return 0;
+  }
+  process.stdout.write(`❌ ${name} not found in Keychain\n`);
+  return 1;
+}
+
+async function cmdGet(name, { reveal }) {
+  if (!reveal) {
+    const result = await keyExists(name);
+    if (!result.exists) {
+      process.stderr.write(`akc: ${name} not found in Keychain\n`);
+      return 1;
+    }
+    process.stdout.write(`keychain://${name}\n`);
+    return 0;
+  }
+  const value = await resolveKey(name);
+  if (value === null) {
+    process.stderr.write(`akc: ${name} not found in Keychain\n`);
+    return 1;
+  }
+  if (process.stdout.isTTY) {
+    process.stderr.write('akc: printing raw secret value to terminal\n');
+  }
+  process.stdout.write(`${value}\n`);
+  return 0;
+}
+
+async function cmdSet(name, { manual }) {
+  const value = await readSecret(name);
+  if (!value) {
+    process.stderr.write('akc: empty value, nothing saved\n');
+    return 1;
+  }
+  const saved = await setKey(name, value, { manual });
+  process.stdout.write(
+    `✅ Saved ${name} (${maskValue(value)}) to service "${saved.service}"\n`
+  );
+  return 0;
+}
+
+async function cmdDelete(name) {
+  const deleted = await deleteKey(name);
+  if (deleted.length === 0) {
+    process.stderr.write(`akc: ${name} not found in Keychain\n`);
+    return 1;
+  }
+  process.stdout.write(`✅ Deleted ${name} (${deleted.join(', ')})\n`);
+  return 0;
+}
+
+function requireKeyArg(argv, command) {
+  const name = argv.find((a) => !a.startsWith('--'));
+  if (!name) {
+    process.stderr.write(`akc: missing key name\nUsage: akc ${command} <KEY>\n`);
+    return null;
+  }
+  return name;
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+
+  switch (command ?? 'help') {
+    case 'help':
+    case '--help':
+    case '-h':
+      process.stdout.write(USAGE);
+      return 0;
+    case 'version':
+    case '--version':
+    case '-V':
+      process.stdout.write(`akc ${version}\n`);
+      return 0;
+    case 'guide':
+      process.stdout.write(USAGE_GUIDE);
+      return 0;
+  }
+
+  assertMacOS();
+
+  switch (command) {
+    case 'run':
+      return cmdRun(rest);
+    case 'list':
+      return cmdList();
+    case 'check': {
+      const name = requireKeyArg(rest, 'check');
+      return name === null ? 1 : cmdCheck(name);
+    }
+    case 'get': {
+      const name = requireKeyArg(rest, 'get');
+      return name === null ? 1 : cmdGet(name, { reveal: rest.includes('--reveal') });
+    }
+    case 'set': {
+      const name = requireKeyArg(rest, 'set');
+      return name === null ? 1 : cmdSet(name, { manual: rest.includes('--manual') });
+    }
+    case 'delete': {
+      const name = requireKeyArg(rest, 'delete');
+      return name === null ? 1 : cmdDelete(name);
+    }
+    case 'doctor': {
+      const report = await runDoctor();
+      process.stdout.write(`${formatReport(report)}\n`);
+      return report.ok ? 0 : 1;
+    }
+    case 'mcp': {
+      const { startMcpServer } = await import('../src/mcp-server.js');
+      await startMcpServer();
+      return new Promise(() => {}); // serve until the transport closes the process
+    }
+    default:
+      process.stderr.write(`akc: unknown command: ${command}\n`);
+      process.stderr.write(USAGE);
+      return 1;
+  }
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    if (err instanceof KeychainError) {
+      process.stderr.write(`akc: ${err.message}\n`);
+    } else {
+      process.stderr.write(`akc: unexpected error: ${err?.stack ?? err}\n`);
+    }
+    process.exitCode = 1;
+  });

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,1164 @@
+{
+  "name": "aikeychain",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aikeychain",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^3.25.0"
+      },
+      "bin": {
+        "aikeychain": "bin/akc.js",
+        "akc": "bin/akc.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "aikeychain",
+  "version": "0.1.0",
+  "description": "AI KeyChain CLI & MCP server — resolve keychain:// secret references from macOS Keychain and let AI agents use them safely",
+  "type": "module",
+  "bin": {
+    "akc": "bin/akc.js",
+    "aikeychain": "bin/akc.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test 'test/*.test.js'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aieo-product/AIkeychain.git",
+    "directory": "cli"
+  },
+  "keywords": [
+    "keychain",
+    "secrets",
+    "api-keys",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "macos"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/aieo-product/AIkeychain/issues"
+  },
+  "homepage": "https://github.com/aieo-product/AIkeychain#readme",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.0"
+  }
+}

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -1,0 +1,115 @@
+// `akc doctor` — diagnose whether keychain:// references and shell config can
+// resolve correctly. Secret values are never printed (masked only).
+
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { collectRefs, resolveRefs } from './run.js';
+import { listKeys, resolveKey, KeychainError } from './keychain.js';
+
+/** Extract keychain://KEY and `security find-generic-password -s "KEY"` keys from shell config text. */
+export function scanShellConfig(text) {
+  const keys = new Set();
+  const warnings = [];
+  for (const m of text.matchAll(/keychain:\/\/([A-Za-z0-9_.-]+)/g)) {
+    keys.add(m[1]);
+  }
+  for (const line of text.split('\n')) {
+    if (line.trimStart().startsWith('#')) continue;
+    const find = line.match(/security\s+find-generic-password\s+([^\n]*)/);
+    if (!find) continue;
+    const svc = find[1].match(/-s\s+"?([A-Za-z0-9_.-]+)"?/);
+    if (svc) keys.add(svc[1]);
+    if (/-a\s+"\$USER"|-a\s+\$USER/.test(find[1])) {
+      warnings.push(
+        `uses -a "$USER" — account attributes are inconsistent; look up by service only (issue #91): ${line.trim()}`
+      );
+    }
+  }
+  return { keys: [...keys].sort(), warnings };
+}
+
+export async function runDoctor({ env = process.env, zshrcPath } = {}) {
+  const report = { platform: process.platform, checks: [], warnings: [], ok: true };
+  const check = (name, ok, detail) => {
+    report.checks.push({ name, ok, detail });
+    if (!ok) report.ok = false;
+  };
+
+  if (process.platform !== 'darwin') {
+    check('platform', false, 'not macOS — the `security` command is unavailable');
+    return report;
+  }
+  check('platform', true, 'macOS');
+
+  // GUI / manual store reachability (names only)
+  let appKeyCount = null;
+  try {
+    const keys = await listKeys();
+    appKeyCount = keys.filter((k) => k.sources.includes('app')).length;
+    check('keychain access', true, `${keys.length} key(s) visible (${appKeyCount} in AI KeyChain store)`);
+  } catch (err) {
+    if (err instanceof KeychainError) {
+      check('keychain access', false, err.message);
+    } else {
+      throw err;
+    }
+  }
+
+  // Environment keychain:// references
+  const refs = collectRefs(env);
+  if (refs.length === 0) {
+    check('env references', true, 'no keychain:// references in current environment');
+  } else {
+    const { resolved, failed } = await resolveRefs(refs);
+    check(
+      'env references',
+      failed.length === 0,
+      `${Object.keys(resolved).length}/${refs.length} resolved` +
+        (failed.length ? ` — missing: ${failed.map((f) => f.keyName).join(', ')}` : '')
+    );
+  }
+
+  // ~/.zshrc scan
+  const path = zshrcPath ?? join(homedir(), '.zshrc');
+  let text = null;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch {
+    check('shell config', true, `${path} not found (skipped)`);
+  }
+  if (text !== null) {
+    const { keys, warnings } = scanShellConfig(text);
+    report.warnings.push(...warnings);
+    if (keys.length === 0) {
+      check('shell config', true, `no keychain references in ${path}`);
+    } else {
+      const missing = [];
+      for (const key of keys) {
+        const value = await resolveKey(key);
+        if (!value) missing.push(key);
+      }
+      check(
+        'shell config',
+        missing.length === 0,
+        `${keys.length - missing.length}/${keys.length} key(s) in ${path} resolvable` +
+          (missing.length ? ` — missing: ${missing.join(', ')}` : '')
+      );
+    }
+  }
+
+  return report;
+}
+
+export function formatReport(report) {
+  const lines = [];
+  for (const { name, ok, detail } of report.checks) {
+    lines.push(`  ${ok ? '✅' : '❌'} ${name}: ${detail}`);
+  }
+  for (const warning of report.warnings) {
+    lines.push(`  ⚠️  ${warning}`);
+  }
+  lines.push('');
+  lines.push(report.ok ? 'All checks passed.' : 'Some checks failed. See above.');
+  return lines.join('\n');
+}

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -21,8 +21,11 @@ export function scanShellConfig(text) {
     const svc = find[1].match(/-s\s+"?([A-Za-z0-9_.-]+)"?/);
     if (svc) keys.add(svc[1]);
     if (/-a\s+"\$USER"|-a\s+\$USER/.test(find[1])) {
+      // Report the service name only — never echo the raw shell line, which
+      // could contain inline secrets or other sensitive content.
       warnings.push(
-        `uses -a "$USER" — account attributes are inconsistent; look up by service only (issue #91): ${line.trim()}`
+        `${svc ? svc[1] : '(unknown key)'}: lookup uses -a "$USER" — account attributes are ` +
+          'inconsistent; look up by service only (issue #91)'
       );
     }
   }

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -1,0 +1,134 @@
+// Thin wrapper around the macOS `security` CLI.
+// Lookup order matches scripts/akc (issue #91):
+//   1. service="com.aieo.aikeychain" account="<KEY>"  (AI KeyChain GUI store)
+//   2. service="<KEY>" with NO account               (manually-registered keys)
+// Manual keys are looked up by service only because their `acct` attribute is
+// not consistent ($USER or the service name) — pinning -a can grab a stale
+// duplicate entry and return an invalid value.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const pExecFile = promisify(execFile);
+
+export const GUI_SERVICE = 'com.aieo.aikeychain';
+// Manual entries are identified by env-var-shaped service names (e.g. GITHUB_TOKEN).
+export const MANUAL_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+export class KeychainError extends Error {}
+
+export function assertMacOS() {
+  if (process.platform !== 'darwin') {
+    throw new KeychainError(
+      'aikeychain requires macOS: secrets are stored in the macOS Keychain via the `security` command.'
+    );
+  }
+}
+
+async function security(args) {
+  try {
+    const { stdout, stderr } = await pExecFile('security', args, {
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (err) {
+    return { ok: false, stdout: err.stdout ?? '', stderr: err.stderr ?? String(err) };
+  }
+}
+
+function stripTrailingNewline(s) {
+  return s.endsWith('\n') ? s.slice(0, -1) : s;
+}
+
+/** Resolve a key to its secret value, or null if not found. */
+export async function resolveKey(name) {
+  let r = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
+  if (r.ok) {
+    const value = stripTrailingNewline(r.stdout);
+    if (value) return value;
+  }
+  r = await security(['find-generic-password', '-s', name, '-w']);
+  if (r.ok) {
+    const value = stripTrailingNewline(r.stdout);
+    if (value) return value;
+  }
+  return null;
+}
+
+/** Check where a key exists without reading its secret value. */
+export async function keyExists(name) {
+  const app = (await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name])).ok;
+  const manual = (await security(['find-generic-password', '-s', name])).ok;
+  return { name, app, manual, exists: app || manual };
+}
+
+/**
+ * Store a key. Defaults to the AI KeyChain GUI store so the entry shows up in
+ * the app. `-U` updates in place to avoid acct-mismatched duplicates.
+ */
+export async function setKey(name, value, { manual = false } = {}) {
+  if (!name) throw new KeychainError('key name is required');
+  if (!value) throw new KeychainError('refusing to store an empty value');
+  const service = manual ? name : GUI_SERVICE;
+  const r = await security(['add-generic-password', '-U', '-s', service, '-a', name, '-w', value]);
+  if (!r.ok) {
+    throw new KeychainError(`failed to save "${name}": ${r.stderr.trim() || 'unknown error'}`);
+  }
+  return { service, account: name };
+}
+
+/** Delete a key from the GUI store and/or the manual store. Returns which stores were deleted. */
+export async function deleteKey(name, { app = true, manual = true } = {}) {
+  const deleted = [];
+  if (app) {
+    const r = await security(['delete-generic-password', '-s', GUI_SERVICE, '-a', name]);
+    if (r.ok) deleted.push('app');
+  }
+  if (manual) {
+    const r = await security(['delete-generic-password', '-s', name]);
+    if (r.ok) deleted.push('manual');
+  }
+  return deleted;
+}
+
+/** Parse `security dump-keychain` output into { service, account } records. */
+export function parseDump(dump) {
+  const records = [];
+  for (const block of dump.split(/^keychain: /m)) {
+    if (!/^class: "genp"/m.test(block)) continue;
+    const svce = block.match(/"svce"<blob>="([^"\n]*)"/);
+    const acct = block.match(/"acct"<blob>="([^"\n]*)"/);
+    records.push({ service: svce ? svce[1] : null, account: acct ? acct[1] : null });
+  }
+  return records;
+}
+
+/**
+ * List known keys (names only — secret values are never read).
+ * Returns [{ name, sources: ['app'|'manual', ...] }] sorted by name.
+ */
+export async function listKeys() {
+  const r = await security(['dump-keychain']);
+  if (!r.ok) {
+    throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
+  }
+  const keys = new Map();
+  const add = (name, source) => {
+    if (!keys.has(name)) keys.set(name, new Set());
+    keys.get(name).add(source);
+  };
+  for (const { service, account } of parseDump(r.stdout)) {
+    if (service === GUI_SERVICE && account) {
+      add(account, 'app');
+    } else if (service && service !== GUI_SERVICE && MANUAL_NAME_PATTERN.test(service)) {
+      add(service, 'manual');
+    }
+  }
+  return [...keys.entries()]
+    .map(([name, sources]) => ({ name, sources: [...sources].sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function maskValue(value) {
+  return `****** (${value.length} chars)`;
+}

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -65,6 +65,10 @@ export async function keyExists(name) {
 /**
  * Store a key. Defaults to the AI KeyChain GUI store so the entry shows up in
  * the app. `-U` updates in place to avoid acct-mismatched duplicates.
+ * Limitation: `security add-generic-password` only accepts the value via -w,
+ * so the secret is briefly visible in the `security` child's argv to other
+ * processes of the same user. The security CLI has no stdin mode; avoiding
+ * this would require a native Keychain API helper.
  */
 export async function setKey(name, value, { manual = false } = {}) {
   if (!name) throw new KeychainError('key name is required');

--- a/cli/src/mcp-server.js
+++ b/cli/src/mcp-server.js
@@ -1,0 +1,143 @@
+// MCP (Model Context Protocol) server over stdio: `akc mcp`
+// Design rule: no tool ever returns a raw secret value to the model.
+// Agents get keychain:// references and run workloads through `akc run`.
+
+import { createRequire } from 'node:module';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { keyExists, listKeys, setKey, deleteKey } from './keychain.js';
+import { runDoctor, formatReport } from './doctor.js';
+import { USAGE_GUIDE } from './usage-guide.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
+
+const text = (s) => ({ content: [{ type: 'text', text: s }] });
+const json = (o) => text(JSON.stringify(o, null, 2));
+
+const keyNameSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_.-]+$/, 'key name must match [A-Za-z0-9_.-]+')
+  .describe('Key name, usually an env-var-style name like GITHUB_TOKEN');
+
+export function buildServer() {
+  const server = new McpServer({ name: 'aikeychain', version });
+
+  server.registerTool(
+    'usage_guide',
+    {
+      description:
+        'How to use AI KeyChain correctly (keychain:// references, akc run, security CLI rules). ' +
+        'Call this first if you are unsure how secrets are managed on this machine.',
+      inputSchema: {},
+    },
+    async () => text(USAGE_GUIDE)
+  );
+
+  server.registerTool(
+    'list_keys',
+    {
+      description:
+        'List key names stored in the macOS Keychain (AI KeyChain GUI store + manually-registered ' +
+        'env-var-style keys). Returns names and where they live — never secret values.',
+      inputSchema: {},
+    },
+    async () => json(await listKeys())
+  );
+
+  server.registerTool(
+    'check_key',
+    {
+      description:
+        'Check whether a key exists in the Keychain and in which store (app = AI KeyChain GUI, ' +
+        'manual = service-name entry). Does not read the secret value.',
+      inputSchema: { name: keyNameSchema },
+    },
+    async ({ name }) => json(await keyExists(name))
+  );
+
+  server.registerTool(
+    'get_secret_reference',
+    {
+      description:
+        'Get the keychain:// reference string for a key. Use the reference as an env var value and ' +
+        'run the workload via `akc run -- <command>` — the raw secret is injected into the child ' +
+        'process only and never enters the model context.',
+      inputSchema: { name: keyNameSchema },
+    },
+    async ({ name }) => {
+      const exists = await keyExists(name);
+      return json({
+        reference: `keychain://${name}`,
+        exists: exists.exists,
+        stores: { app: exists.app, manual: exists.manual },
+        usage: `export ${name}=keychain://${name} && akc run -- <command>`,
+      });
+    }
+  );
+
+  server.registerTool(
+    'set_secret',
+    {
+      description:
+        'Store or update a key in the AI KeyChain store (overwrites in place, no duplicates). ' +
+        'CAUTION: the secret value passes through the model context when you call this tool — ' +
+        'prefer asking the user to run `akc set <KEY>` themselves unless they explicitly pasted ' +
+        'the value into the conversation already.',
+      inputSchema: {
+        name: keyNameSchema,
+        value: z.string().min(1).describe('The secret value to store'),
+        manual: z
+          .boolean()
+          .optional()
+          .describe('Store as a manual entry (service=<name>) instead of the AI KeyChain GUI store'),
+      },
+    },
+    async ({ name, value, manual }) => {
+      const saved = await setKey(name, value, { manual: manual ?? false });
+      return json({ saved: true, service: saved.service, account: saved.account });
+    }
+  );
+
+  server.registerTool(
+    'delete_secret',
+    {
+      description:
+        'Delete a key from the Keychain (both the AI KeyChain store and manual entries). ' +
+        'Destructive — requires confirm=true, and you should confirm with the user first.',
+      inputSchema: {
+        name: keyNameSchema,
+        confirm: z.boolean().describe('Must be true to actually delete'),
+      },
+    },
+    async ({ name, confirm }) => {
+      if (!confirm) {
+        return json({ deleted: [], note: 'confirm=true is required to delete' });
+      }
+      const deleted = await deleteKey(name);
+      return json({ deleted, found: deleted.length > 0 });
+    }
+  );
+
+  server.registerTool(
+    'doctor',
+    {
+      description:
+        'Diagnose the local setup: keychain access, keychain:// references in the current ' +
+        'environment, and ~/.zshrc patterns (including the -a "$USER" pitfall). Values are masked.',
+      inputSchema: {},
+    },
+    async () => {
+      const report = await runDoctor();
+      return text(formatReport(report));
+    }
+  );
+
+  return server;
+}
+
+export async function startMcpServer() {
+  const server = buildServer();
+  await server.connect(new StdioServerTransport());
+}

--- a/cli/src/mcp-server.js
+++ b/cli/src/mcp-server.js
@@ -68,11 +68,14 @@ export function buildServer() {
     },
     async ({ name }) => {
       const exists = await keyExists(name);
+      const exportable = /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
       return json({
         reference: `keychain://${name}`,
         exists: exists.exists,
         stores: { app: exists.app, manual: exists.manual },
-        usage: `export ${name}=keychain://${name} && akc run -- <command>`,
+        usage: exportable
+          ? `export ${name}=keychain://${name} && akc run -- <command>`
+          : `env '${name}=keychain://${name}' akc run -- <command>`,
       });
     }
   );

--- a/cli/src/run.js
+++ b/cli/src/run.js
@@ -1,0 +1,107 @@
+// `akc run [--dry-run] -- <command> [args...]`
+// Resolves keychain:// references in the environment and runs the command with
+// the resolved values injected. The parent process env is never modified.
+// Behavior is compatible with scripts/akc (bash).
+
+import { spawn } from 'node:child_process';
+import { resolveKey, maskValue } from './keychain.js';
+
+export const REF_PREFIX = 'keychain://';
+
+/** Collect keychain:// references from an env object. */
+export function collectRefs(env) {
+  return Object.entries(env)
+    .filter(([, value]) => typeof value === 'string' && value.startsWith(REF_PREFIX))
+    .map(([varName, value]) => ({ varName, keyName: value.slice(REF_PREFIX.length) }));
+}
+
+/** Resolve refs sequentially (parallel lookups can stack keychain auth prompts). */
+export async function resolveRefs(refs) {
+  const resolved = {};
+  const failed = [];
+  for (const { varName, keyName } of refs) {
+    const value = await resolveKey(keyName);
+    if (value) {
+      resolved[varName] = value;
+    } else {
+      failed.push({ varName, keyName });
+    }
+  }
+  return { resolved, failed };
+}
+
+export async function cmdRun(argv) {
+  let dryRun = false;
+  let hasSeparator = false;
+  let i = 0;
+  for (; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--') {
+      hasSeparator = true;
+      i++;
+      break;
+    } else {
+      process.stderr.write(`akc: unknown option: ${arg}\n`);
+      process.stderr.write('Usage: akc run [--dry-run] -- <command> [args...]\n');
+      return 1;
+    }
+  }
+  const command = argv.slice(i);
+
+  if (!dryRun && !hasSeparator) {
+    process.stderr.write("akc: missing '--' separator before command\n");
+    process.stderr.write('Usage: akc run [--dry-run] -- <command> [args...]\n');
+    return 1;
+  }
+
+  const refs = collectRefs(process.env);
+  const { resolved, failed } = await resolveRefs(refs);
+
+  if (dryRun) {
+    for (const { varName, keyName } of refs) {
+      if (varName in resolved) {
+        process.stdout.write(
+          `  ✅ ${varName} = ${maskValue(resolved[varName])} (from keychain://${keyName})\n`
+        );
+      } else {
+        process.stderr.write(`  ❌ ${varName} — keychain://${keyName} not found in Keychain\n`);
+      }
+    }
+    process.stdout.write(`\nResolved: ${Object.keys(resolved).length}, Failed: ${failed.length}\n`);
+    if (failed.length > 0) {
+      process.stdout.write('Register missing keys in AI KeyChain or macOS Keychain.\n');
+    }
+    return 0;
+  }
+
+  if (failed.length > 0) {
+    for (const { varName, keyName } of failed) {
+      process.stderr.write(`  ❌ ${varName} — keychain://${keyName} not found in Keychain\n`);
+    }
+    process.stderr.write(`akc: ${failed.length} keychain reference(s) could not be resolved\n`);
+    process.stderr.write("akc: run 'akc run --dry-run' to see details\n");
+    return 1;
+  }
+
+  if (command.length === 0) {
+    process.stderr.write("akc: no command specified after '--'\n");
+    return 1;
+  }
+
+  const child = spawn(command[0], command.slice(1), {
+    stdio: 'inherit',
+    env: { ...process.env, ...resolved },
+  });
+
+  return new Promise((resolve) => {
+    child.on('error', (err) => {
+      process.stderr.write(`akc: failed to run ${command[0]}: ${err.message}\n`);
+      resolve(127);
+    });
+    child.on('exit', (code, signal) => {
+      resolve(code ?? (signal ? 1 : 0));
+    });
+  });
+}

--- a/cli/src/run.js
+++ b/cli/src/run.js
@@ -4,6 +4,7 @@
 // Behavior is compatible with scripts/akc (bash).
 
 import { spawn } from 'node:child_process';
+import { constants as osConstants } from 'node:os';
 import { resolveKey, maskValue } from './keychain.js';
 
 export const REF_PREFIX = 'keychain://';
@@ -95,13 +96,23 @@ export async function cmdRun(argv) {
     env: { ...process.env, ...resolved },
   });
 
+  // Unlike the bash version (which execs), a wrapper process remains: forward
+  // termination signals to the child and reproduce conventional exit codes.
+  const forwarded = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+  const forward = (sig) => child.kill(sig);
+
   return new Promise((resolve) => {
+    const done = (code) => {
+      for (const sig of forwarded) process.off(sig, forward);
+      resolve(code);
+    };
+    for (const sig of forwarded) process.on(sig, forward);
     child.on('error', (err) => {
       process.stderr.write(`akc: failed to run ${command[0]}: ${err.message}\n`);
-      resolve(127);
+      done(127);
     });
     child.on('exit', (code, signal) => {
-      resolve(code ?? (signal ? 1 : 0));
+      done(signal ? 128 + (osConstants.signals[signal] ?? 1) : code ?? 0);
     });
   });
 }

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -22,8 +22,9 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    stale/invalid duplicate (AIkeychain issue #91).
 4. To save/update a key, overwrite with -U so no duplicate entries are created:
      security add-generic-password -s "KEY_NAME" -a "KEY_NAME" -w "<value>" -U
-   (or use \`akc set KEY_NAME\`, which prompts for the value without exposing it
-   in shell history or process arguments.)
+   (or use \`akc set KEY_NAME\`, which prompts for the value so it never enters
+   your shell history. Note: macOS \`security\` only accepts values via argv, so
+   the value is briefly visible to same-user processes while it saves.)
 
 ## Where keys live
 

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -1,0 +1,61 @@
+// Canonical "how to use AI KeyChain correctly" guide, exposed to AI agents via
+// the `usage_guide` MCP tool and `akc guide`. This is the single place where
+// the rules live so every model/session gets the same instructions.
+
+export const USAGE_GUIDE = `# AI KeyChain — usage guide for AI agents and humans
+
+AI KeyChain stores API keys/tokens in the macOS Keychain (encrypted at rest).
+Secrets must NEVER be written to .env files, shell scripts, code, or commits.
+
+## The golden rules
+
+1. NEVER write a secret value into a file (.env, .zshrc, source code, logs).
+2. To use secrets in a process, prefer keychain:// references + \`akc run\`:
+   - Set env vars to a reference, not a value:  export OPENAI_API_KEY=keychain://OPENAI_API_KEY
+   - Launch tools through akc:                  akc run -- <command>
+   - akc resolves the references from the macOS Keychain and injects the real
+     values ONLY into the child process. The parent shell never sees them.
+3. When reading a key manually with the security CLI, look it up by SERVICE
+   NAME ONLY — do NOT pin the account with -a "$USER":
+     security find-generic-password -s "ENV_VAR_NAME" -w
+   Account attributes are inconsistent across entries; pinning -a can return a
+   stale/invalid duplicate (AIkeychain issue #91).
+4. To save/update a key, overwrite with -U so no duplicate entries are created:
+     security add-generic-password -s "KEY_NAME" -a "KEY_NAME" -w "<value>" -U
+   (or use \`akc set KEY_NAME\`, which prompts for the value without exposing it
+   in shell history or process arguments.)
+
+## Where keys live
+
+| Store | service attribute | account attribute |
+|---|---|---|
+| AI KeyChain GUI store | com.aieo.aikeychain | <KEY_NAME> |
+| Manually-registered keys | <KEY_NAME> | (varies — do not rely on it) |
+
+\`akc\` looks up the GUI store first, then falls back to service-only lookup.
+
+## CLI quick reference
+
+  akc run -- <command>        run a command with keychain:// refs resolved
+  akc run --dry-run           show which env vars would resolve (values masked)
+  akc list                    list known key names (never prints values)
+  akc check <KEY>             check whether a key exists and where
+  akc set <KEY>               store/update a key (value via hidden prompt or stdin)
+  akc delete <KEY>            delete a key
+  akc doctor                  diagnose env + ~/.zshrc keychain references
+  akc mcp                     start the MCP server (stdio)
+
+## MCP setup (Claude Code)
+
+  claude mcp add aikeychain -- npx -y aikeychain mcp
+
+The MCP tools intentionally never return raw secret values to the model.
+Get a keychain:// reference with get_secret_reference, then run the actual
+workload through \`akc run\` so values stay out of the model context.
+
+## Three modes of AI KeyChain (GUI app)
+
+- Standard:        keys exported in .zshrc via security find-generic-password
+- Secret Reference: keychain:// refs + akc run (recommended for AI agents)
+- Proxy:           local proxy injects auth headers; keys never enter env
+`;

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -1,5 +1,5 @@
 // CLI integration tests. A stub `security` command is placed first on PATH so
-// these run without touching the real Keychain (and on any OS in CI).
+// these run without touching the real Keychain.
 import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
@@ -116,6 +116,17 @@ test('run --dry-run masks values and reports counts', async () => {
 test('run propagates the child exit code', async () => {
   const r = await runAkc(['run', '--', process.execPath, '-e', 'process.exit(3)']);
   assert.equal(r.code, 3);
+});
+
+test('run maps a signal-terminated child to 128+signum', async () => {
+  const r = await runAkc([
+    'run',
+    '--',
+    process.execPath,
+    '-e',
+    'process.kill(process.pid, "SIGTERM"); setTimeout(() => {}, 5000)',
+  ]);
+  assert.equal(r.code, 143); // 128 + SIGTERM(15)
 });
 
 test('check reports store and missing keys', async () => {

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -1,0 +1,154 @@
+// CLI integration tests. A stub `security` command is placed first on PATH so
+// these run without touching the real Keychain (and on any OS in CI).
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pExecFile = promisify(execFile);
+const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js');
+
+let stubDir;
+
+// The stub knows one GUI-store key (GOOD_KEY) and one manual key (MANUAL_KEY).
+const STUB = `#!/bin/bash
+cmd="$1"; shift
+svc=""; acct=""; want_value=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s) svc="$2"; shift 2 ;;
+    -a) acct="$2"; shift 2 ;;
+    -w) want_value=true; shift ;;
+    *) shift ;;
+  esac
+done
+case "$cmd" in
+  find-generic-password)
+    if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "GOOD_KEY" ]; then
+      $want_value && echo "stub-good-value"; exit 0
+    fi
+    if [ "$svc" = "MANUAL_KEY" ]; then
+      $want_value && echo "stub-manual-value"; exit 0
+    fi
+    exit 44 ;;
+  *) exit 1 ;;
+esac
+`;
+
+before(async () => {
+  stubDir = await mkdtemp(join(tmpdir(), 'akc-stub-'));
+  const stubPath = join(stubDir, 'security');
+  await writeFile(stubPath, STUB);
+  await chmod(stubPath, 0o755);
+});
+
+function runAkc(args, env = {}) {
+  return pExecFile(process.execPath, [AKC, ...args], {
+    env: { PATH: `${stubDir}:${process.env.PATH}`, ...env },
+  }).then(
+    (r) => ({ code: 0, ...r }),
+    (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
+  );
+}
+
+test('version / help / unknown command', async () => {
+  const v = await runAkc(['version']);
+  assert.equal(v.code, 0);
+  assert.match(v.stdout, /^akc \d+\.\d+\.\d+/);
+
+  const h = await runAkc(['help']);
+  assert.equal(h.code, 0);
+  assert.match(h.stdout, /Usage:/);
+
+  const bad = await runAkc(['nope']);
+  assert.equal(bad.code, 1);
+  assert.match(bad.stderr, /unknown command/);
+});
+
+test('run requires -- separator', async () => {
+  const r = await runAkc(['run']);
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /missing '--' separator/);
+});
+
+test('run rejects unknown options', async () => {
+  const r = await runAkc(['run', '--invalid-flag', '--', 'true']);
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /unknown option/);
+});
+
+test('run passes through when no refs exist', async () => {
+  const r = await runAkc(['run', '--', 'echo', 'hello']);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /hello/);
+});
+
+test('run resolves GUI-store and manual refs into the child env only', async () => {
+  const r = await runAkc(
+    ['run', '--', process.execPath, '-e', 'console.log(process.env.MY_TOKEN, process.env.OTHER)'],
+    { MY_TOKEN: 'keychain://GOOD_KEY', OTHER: 'keychain://MANUAL_KEY' }
+  );
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /stub-good-value stub-manual-value/);
+});
+
+test('run fails with exit 1 when a ref cannot be resolved', async () => {
+  const r = await runAkc(['run', '--', 'true'], { MY_TOKEN: 'keychain://MISSING_KEY' });
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /MISSING_KEY not found/);
+});
+
+test('run --dry-run masks values and reports counts', async () => {
+  const r = await runAkc(['run', '--dry-run'], {
+    MY_TOKEN: 'keychain://GOOD_KEY',
+    BAD: 'keychain://MISSING_KEY',
+  });
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /\*{6} \(\d+ chars\)/);
+  assert.doesNotMatch(r.stdout, /stub-good-value/);
+  assert.match(r.stdout, /Resolved: 1, Failed: 1/);
+});
+
+test('run propagates the child exit code', async () => {
+  const r = await runAkc(['run', '--', process.execPath, '-e', 'process.exit(3)']);
+  assert.equal(r.code, 3);
+});
+
+test('check reports store and missing keys', async () => {
+  const good = await runAkc(['check', 'GOOD_KEY']);
+  assert.equal(good.code, 0);
+  assert.match(good.stdout, /AI KeyChain store/);
+
+  const missing = await runAkc(['check', 'NOPE_KEY']);
+  assert.equal(missing.code, 1);
+});
+
+test('get prints a reference by default, raw value only with --reveal', async () => {
+  const ref = await runAkc(['get', 'GOOD_KEY']);
+  assert.equal(ref.code, 0);
+  assert.equal(ref.stdout.trim(), 'keychain://GOOD_KEY');
+  assert.doesNotMatch(ref.stdout, /stub-good-value/);
+
+  const raw = await runAkc(['get', 'GOOD_KEY', '--reveal']);
+  assert.equal(raw.code, 0);
+  assert.equal(raw.stdout.trim(), 'stub-good-value');
+});
+
+test('set stores a value piped via stdin', async () => {
+  // The stub's add-generic-password exits 1, so failure proves the value path
+  // reached `security` without appearing in argv of akc itself.
+  const r = await pExecFile(
+    'bash',
+    ['-c', `echo "piped-secret" | ${process.execPath} ${AKC} set NEW_KEY`],
+    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+  ).then(
+    (r) => ({ code: 0, ...r }),
+    (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
+  );
+  assert.equal(r.code, 1); // stub rejects add-generic-password
+  assert.match(r.stderr, /failed to save/);
+});

--- a/cli/test/mcp.test.js
+++ b/cli/test/mcp.test.js
@@ -1,0 +1,135 @@
+// MCP server integration test: speaks JSON-RPC over stdio to `akc mcp` and
+// verifies the toolset — in particular that no tool can return a raw secret.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js');
+
+function mcpSession(messages, { timeoutMs = 10000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [AKC, 'mcp'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const responses = [];
+    let buffer = '';
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`timed out; got ${responses.length} responses`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      buffer += chunk;
+      let nl;
+      while ((nl = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (!line.trim()) continue;
+        responses.push(JSON.parse(line));
+        const expected = messages.filter((m) => m.id !== undefined).length;
+        if (responses.length >= expected) {
+          clearTimeout(timer);
+          child.kill();
+          resolve(responses);
+          return;
+        }
+      }
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    for (const message of messages) {
+      child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+  });
+}
+
+test('mcp server lists the expected tools and none returns raw values', async () => {
+  const responses = await mcpSession([
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'akc-test', version: '0.0.0' },
+      },
+    },
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+  ]);
+
+  const init = responses.find((r) => r.id === 1);
+  assert.equal(init.result.serverInfo.name, 'aikeychain');
+
+  const toolsResult = responses.find((r) => r.id === 2);
+  const names = toolsResult.result.tools.map((t) => t.name).sort();
+  assert.deepEqual(names, [
+    'check_key',
+    'delete_secret',
+    'doctor',
+    'get_secret_reference',
+    'list_keys',
+    'set_secret',
+    'usage_guide',
+  ]);
+  // No tool name suggests raw value retrieval.
+  assert.ok(!names.some((n) => /get_secret$|get_value|reveal/.test(n)));
+});
+
+test('usage_guide returns the agent guide text', async () => {
+  const responses = await mcpSession([
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'akc-test', version: '0.0.0' },
+      },
+    },
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'usage_guide', arguments: {} },
+    },
+  ]);
+  const call = responses.find((r) => r.id === 2);
+  const guideText = call.result.content[0].text;
+  assert.match(guideText, /keychain:\/\//);
+  assert.match(guideText, /akc run/);
+  assert.match(guideText, /-a "\$USER"/);
+});
+
+test('delete_secret refuses without confirm=true', async () => {
+  const responses = await mcpSession([
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'akc-test', version: '0.0.0' },
+      },
+    },
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'delete_secret', arguments: { name: 'WHATEVER_KEY', confirm: false } },
+    },
+  ]);
+  const call = responses.find((r) => r.id === 2);
+  const payload = JSON.parse(call.result.content[0].text);
+  assert.deepEqual(payload.deleted, []);
+  assert.match(payload.note, /confirm=true/);
+});

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDump, maskValue, MANUAL_NAME_PATTERN, GUI_SERVICE } from '../src/keychain.js';
+import { collectRefs } from '../src/run.js';
+import { scanShellConfig } from '../src/doctor.js';
+
+const SAMPLE_DUMP = `keychain: "/Users/x/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    0x00000007 <blob>="com.aieo.aikeychain"
+    "acct"<blob>="GITHUB_TOKEN"
+    "svce"<blob>="com.aieo.aikeychain"
+keychain: "/Users/x/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    "acct"<blob>="takehiro"
+    "svce"<blob>="QIITA_TOKEN"
+keychain: "/Users/x/Library/Keychains/login.keychain-db"
+version: 512
+class: "inet"
+attributes:
+    "acct"<blob>="ignored"
+    "srvr"<blob>="example.com"
+keychain: "/Users/x/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    "acct"<blob>="user@example.com"
+    "svce"<blob>="com.apple.something"
+`;
+
+test('parseDump extracts genp service/account pairs only', () => {
+  const records = parseDump(SAMPLE_DUMP);
+  assert.equal(records.length, 3); // inet record excluded
+  assert.deepEqual(records[0], { service: GUI_SERVICE, account: 'GITHUB_TOKEN' });
+  assert.deepEqual(records[1], { service: 'QIITA_TOKEN', account: 'takehiro' });
+});
+
+test('MANUAL_NAME_PATTERN accepts env-var names and rejects bundle ids', () => {
+  assert.ok(MANUAL_NAME_PATTERN.test('GITHUB_TOKEN'));
+  assert.ok(MANUAL_NAME_PATTERN.test('X_POCOLOCO_CONSUMER_KEY'));
+  assert.ok(!MANUAL_NAME_PATTERN.test('com.apple.something'));
+  assert.ok(!MANUAL_NAME_PATTERN.test('lowercase_token'));
+});
+
+test('maskValue never includes the value', () => {
+  assert.equal(maskValue('super-secret'), '****** (12 chars)');
+});
+
+test('collectRefs picks only keychain:// values', () => {
+  const refs = collectRefs({
+    GITHUB_TOKEN: 'keychain://GITHUB_TOKEN',
+    RENAMED: 'keychain://OTHER_KEY',
+    PLAIN: 'not-a-ref',
+    EMPTY: '',
+  });
+  assert.deepEqual(refs, [
+    { varName: 'GITHUB_TOKEN', keyName: 'GITHUB_TOKEN' },
+    { varName: 'RENAMED', keyName: 'OTHER_KEY' },
+  ]);
+});
+
+test('scanShellConfig finds refs, security lookups, and the -a $USER pitfall', () => {
+  const { keys, warnings } = scanShellConfig(`
+export GITHUB_TOKEN=keychain://GITHUB_TOKEN
+export QIITA_TOKEN=$(security find-generic-password -s "QIITA_TOKEN" -w)
+export BAD_TOKEN=$(security find-generic-password -s "BAD_TOKEN" -a "$USER" -w)
+# export COMMENTED=$(security find-generic-password -s "COMMENTED" -w)
+`);
+  assert.deepEqual(keys, ['BAD_TOKEN', 'GITHUB_TOKEN', 'QIITA_TOKEN']);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /BAD_TOKEN/);
+});

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
           text: 'ユーザーガイド',
           items: [
             { text: 'はじめに', link: '/guide/' },
+            { text: 'CLI & MCP サーバー', link: '/guide/cli-mcp' },
           ]
         }
       ],

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -1,0 +1,74 @@
+# CLI & MCP サーバー（npm パッケージ `aikeychain`）
+
+GUI アプリなしで AI KeyChain のワークフローを使える CLI（`akc`）と、AI エージェント向け MCP サーバーを npm パッケージとして提供する。
+
+## インストール
+
+```bash
+npm install -g aikeychain
+# または都度実行
+npx aikeychain <command>
+```
+
+要件: macOS（`security` コマンド使用）、Node.js 18+。
+
+## CLI コマンド
+
+| コマンド | 機能 |
+|---|---|
+| `akc run [--dry-run] -- <cmd>` | env の `keychain://` 参照を解決してコマンド実行（値は子プロセスのみに注入） |
+| `akc list` | キー名一覧（値は一切表示しない） |
+| `akc check <KEY>` | キーの存在・格納先（app / manual）確認 |
+| `akc get <KEY>` | `keychain://<KEY>` 参照を出力（`--reveal` で生値） |
+| `akc set <KEY>` | キー登録・更新（隠し入力 or stdin。`-U` 相当の上書きで重複防止） |
+| `akc delete <KEY>` | キー削除 |
+| `akc doctor` | env / `~/.zshrc` の参照診断（`-a "$USER"` 落とし穴の検出含む） |
+| `akc guide` | AI エージェント向け使い方ガイド表示 |
+| `akc mcp` | MCP サーバー起動（stdio） |
+
+### ルックアップ順序
+
+bash 版 `scripts/akc` と互換（issue #91 対応済み）:
+
+1. `service="com.aieo.aikeychain"` + `account=<KEY>`（GUI ストア）
+2. `service=<KEY>` のみ・**account 非指定**（手動登録キー）
+
+## MCP サーバー
+
+### 登録
+
+```bash
+# Claude Code
+claude mcp add aikeychain -- npx -y aikeychain mcp
+```
+
+```toml
+# Codex CLI (~/.codex/config.toml)
+[mcp_servers.aikeychain]
+command = "npx"
+args = ["-y", "aikeychain", "mcp"]
+```
+
+### 提供ツール
+
+| ツール | 内容 | 生値の露出 |
+|---|---|---|
+| `usage_guide` | 正しいシークレット運用ガイド | なし |
+| `list_keys` | キー名と格納先の一覧 | なし |
+| `check_key` | キーの存在確認 | なし |
+| `get_secret_reference` | `keychain://` 参照と利用例 | なし |
+| `set_secret` | キーの保存（上書き） | 入力のみ（ユーザー自身の `akc set` を推奨） |
+| `delete_secret` | キーの削除（`confirm: true` 必須） | なし |
+| `doctor` | 設定診断（マスク表示） | なし |
+
+### セキュリティ設計
+
+**生値を返すツールは存在しない。** エージェントは `get_secret_reference` で参照を取得し、実際のワークロードは `akc run` 経由で実行する。これによりシークレット値はモデルのコンテキストに一切載らない。
+
+```
+AI エージェント                akc run                    子プロセス
+  │ get_secret_reference         │                            │
+  │ → keychain://GITHUB_TOKEN    │                            │
+  │ Bash: akc run -- <cmd> ────▶ │── Keychain 解決 ──▶        │
+  │   (モデルは値を見ない)         │── 値を env 注入 ─────────▶ │
+```


### PR DESCRIPTION
## 概要
Closes #92

AI エージェント（Claude / Codex）が AI KeyChain を正しく使えるようにする npm パッケージ `aikeychain` を新設。UI レスの CLI（`akc`）と MCP サーバー（`akc mcp`）を提供する。

## 変更内容

| # | Issue | 変更概要 |
|---|-------|---------|
| 1 | #92 | npm 配布可能な CLI `akc`（run / list / check / get / set / delete / doctor / guide） |
| 2 | #92 | MCP サーバー `akc mcp`（stdio、7 ツール、生値非露出設計） |
| 3 | #92 | README / VitePress docs にセットアップ手順追記 |

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `cli/package.json` | npm パッケージ `aikeychain` v0.1.0（bin: `akc` / `aikeychain`、Node 18+） |
| `cli/bin/akc.js` | CLI エントリポイント。`get` はデフォルトで `keychain://` 参照を返し、生値は `--reveal` 明示時のみ |
| `cli/src/keychain.js` | `security` ラッパー。bash 版互換の 2 段階ルックアップ（GUI ストア → サービス名のみ・`-a` 非指定 / issue #91 仕様）。`list` は `dump-keychain` の属性のみ参照（値は読まない） |
| `cli/src/run.js` | `akc run [--dry-run] -- <cmd>`。keychain:// 解決→子プロセスのみに注入、親 env 非汚染、終了コード伝播 |
| `cli/src/doctor.js` | env / `~/.zshrc` の参照診断。`-a "$USER"` 落とし穴の警告（マスク表示のみ） |
| `cli/src/mcp-server.js` | MCP stdio サーバー。`usage_guide` / `list_keys` / `check_key` / `get_secret_reference` / `set_secret` / `delete_secret`（`confirm: true` 必須）/ `doctor` |
| `cli/src/usage-guide.js` | AI エージェント向け正規ガイド（CLAUDE.md のルールを単一ソース化） |
| `cli/test/*.test.js` | `node --test` 19 件: security スタブによる CLI 統合テスト + JSON-RPC 直叩きの MCP プロトコルテスト + ユニットテスト |
| `README.md` / `docs/guide/cli-mcp.md` / `docs/.vitepress/config.mjs` | CLI & MCP セットアップ手順（EN/JA）、docs ナビ追加 |

## セキュリティ設計（重要）

- **MCP に生値を返すツールは存在しない**。エージェントは `get_secret_reference` で `keychain://` 参照を取得し、ワークロードは `akc run` 経由で実行 → 値はモデルコンテキストに載らない
- `akc list` / `check` は `security` の属性のみ参照（`-w` を使わない）
- `akc set` は値を隠し対話入力 or stdin で受け取り、引数・シェル履歴に残さない。`-U` 上書きで acct 違いの重複エントリを防止
- `delete_secret` は `confirm: true` 必須

## テスト計画
- [x] `npm test` 19/19 PASS（unit + CLI 統合 + MCP プロトコル）
- [x] 実 Keychain でのスモークテスト: `list`（26 キー検出）/ `check` / `get`（参照のみ）/ `run --dry-run`（マスク表示）/ `run`（実値注入を長さのみで確認）/ `doctor`（実 `.zshrc` の `-a "$USER"` 警告を検出）
- [x] VitePress docs ビルド確認（既存の dead link は main 由来・本 PR 対象外）
- [ ] `npm publish`（スコープ外: マージ後に npm 認証を持つ人間が実施。パッケージ名 `aikeychain` は取得可能なことを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
