### PR TITLE
fix(cli): akc set のシークレット値を security の argv から排除 (#94)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -30,7 +30,9 @@ akc run --dry-run
 akc list                  # key names only — never prints values
 akc check GITHUB_TOKEN    # exists? in which store?
 akc get GITHUB_TOKEN      # prints keychain://GITHUB_TOKEN (use --reveal for the raw value)
-akc set GITHUB_TOKEN      # hidden prompt (or pipe via stdin); overwrites in place, no duplicates
+akc set GITHUB_TOKEN      # hidden prompt (or pipe via stdin); the value never
+                          # appears in any process's argv — fed to `security -i`
+                          # via stdin as hex. Overwrites in place, no duplicates
 akc delete GITHUB_TOKEN
 
 # Diagnose your setup (env + ~/.zshrc), including the -a "$USER" pitfall

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aikeychain",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI KeyChain CLI & MCP server — resolve keychain:// secret references from macOS Keychain and let AI agents use them safely",
   "type": "module",
   "bin": {

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -64,6 +64,11 @@ export async function keyExists(name) {
   return { name, app, manual, exists: app || manual };
 }
 
+/** Redact hex-encoded secret material from text destined for errors/logs. */
+export function redactSecrets(text) {
+  return text.replace(/-X\s+[0-9a-fA-F]+/g, '-X <redacted>');
+}
+
 /** Run a command through `security -i`, which reads commands from stdin. */
 function securityInteractive(commandLine) {
   return new Promise((resolve) => {
@@ -105,14 +110,19 @@ export async function setKey(name, value, { manual = false } = {}) {
     `add-generic-password -U -s "${service}" -a "${name}" -X ${hex}`
   );
   if (!r.ok) {
-    throw new KeychainError(`failed to save "${name}": ${r.stderr.trim() || 'unknown error'}`);
+    // `security -i` stderr could in principle echo the command line (which
+    // carries the hex value) — redact before it reaches CLI stderr / MCP.
+    throw new KeychainError(`failed to save "${name}": ${redactSecrets(r.stderr.trim()) || 'unknown error'}`);
   }
-  // Read-back verification: -U on a mismatched-ACL item can fail silently in
-  // odd keychain states, so confirm the entry is actually findable.
-  const exists = await keyExists(name);
-  const stored = manual ? exists.manual : exists.app;
-  if (!stored) {
-    throw new KeychainError(`save reported success but "${name}" is not findable — check Keychain state`);
+  // Read-back verification against the exact target item: -U can report
+  // success in odd keychain states while leaving a stale value behind.
+  // (`find -w` prints hex for non-ASCII payloads, so accept that form too.)
+  const readBack = await security(['find-generic-password', '-s', service, '-a', name, '-w']);
+  const got = readBack.ok ? stripTrailingNewline(readBack.stdout) : null;
+  if (got !== value && got?.toLowerCase() !== hex) {
+    throw new KeychainError(
+      `save reported success but reading "${name}" back returned a different value — check Keychain state`
+    );
   }
   return { service, account: name };
 }

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -6,10 +6,12 @@
 // not consistent ($USER or the service name) — pinning -a can grab a stale
 // duplicate entry and return an invalid value.
 
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const pExecFile = promisify(execFile);
+
+export const KEY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
 export const GUI_SERVICE = 'com.aieo.aikeychain';
 // Manual entries are identified by env-var-shaped service names (e.g. GITHUB_TOKEN).
@@ -62,21 +64,55 @@ export async function keyExists(name) {
   return { name, app, manual, exists: app || manual };
 }
 
+/** Run a command through `security -i`, which reads commands from stdin. */
+function securityInteractive(commandLine) {
+  return new Promise((resolve) => {
+    const child = spawn('security', ['-i'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.on('error', (err) => resolve({ ok: false, stdout, stderr: String(err) }));
+    child.on('close', (code) => resolve({ ok: code === 0, stdout, stderr }));
+    child.stdin.write(`${commandLine}\n`);
+    child.stdin.end();
+  });
+}
+
 /**
  * Store a key. Defaults to the AI KeyChain GUI store so the entry shows up in
  * the app. `-U` updates in place to avoid acct-mismatched duplicates.
- * Limitation: `security add-generic-password` only accepts the value via -w,
- * so the secret is briefly visible in the `security` child's argv to other
- * processes of the same user. The security CLI has no stdin mode; avoiding
- * this would require a native Keychain API helper.
+ *
+ * The secret never appears in any process's argv (issue #94): the command is
+ * fed to `security -i` via stdin, and the value is hex-encoded with -X so no
+ * quoting of the interactive command line is needed.
  */
 export async function setKey(name, value, { manual = false } = {}) {
   if (!name) throw new KeychainError('key name is required');
+  if (!KEY_NAME_PATTERN.test(name)) {
+    throw new KeychainError('key name must match [A-Za-z0-9_.-]+');
+  }
   if (!value) throw new KeychainError('refusing to store an empty value');
+  // Control characters would store fine but `find-generic-password -w` falls
+  // back to hex output for them, breaking round-trips — reject up front.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(value)) {
+    throw new KeychainError('value must not contain control characters (newlines, tabs, NUL)');
+  }
   const service = manual ? name : GUI_SERVICE;
-  const r = await security(['add-generic-password', '-U', '-s', service, '-a', name, '-w', value]);
+  const hex = Buffer.from(value, 'utf8').toString('hex');
+  const r = await securityInteractive(
+    `add-generic-password -U -s "${service}" -a "${name}" -X ${hex}`
+  );
   if (!r.ok) {
     throw new KeychainError(`failed to save "${name}": ${r.stderr.trim() || 'unknown error'}`);
+  }
+  // Read-back verification: -U on a mismatched-ACL item can fail silently in
+  // odd keychain states, so confirm the entry is actually findable.
+  const exists = await keyExists(name);
+  const stored = manual ? exists.manual : exists.app;
+  if (!stored) {
+    throw new KeychainError(`save reported success but "${name}" is not findable — check Keychain state`);
   }
   return { service, account: name };
 }

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -22,9 +22,9 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    stale/invalid duplicate (AIkeychain issue #91).
 4. To save/update a key, overwrite with -U so no duplicate entries are created:
      security add-generic-password -s "KEY_NAME" -a "KEY_NAME" -w "<value>" -U
-   (or use \`akc set KEY_NAME\`, which prompts for the value so it never enters
-   your shell history. Note: macOS \`security\` only accepts values via argv, so
-   the value is briefly visible to same-user processes while it saves.)
+   (prefer \`akc set KEY_NAME\`: the value is read from a hidden prompt or stdin
+   and handed to \`security -i\` via stdin as hex — it never appears in any
+   process's argv, shell history, or logs.)
 
 ## Where keys live
 

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -14,9 +14,20 @@ const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js')
 
 let stubDir;
 
-// The stub knows one GUI-store key (GOOD_KEY) and one manual key (MANUAL_KEY).
+// The stub knows one GUI-store key (GOOD_KEY), one manual key (MANUAL_KEY),
+// and accepts interactive (-i) add-generic-password for NEW_KEY — but only
+// when the value arrives via stdin as -X hex (never as argv).
 const STUB = `#!/bin/bash
 cmd="$1"; shift
+if [ "$cmd" = "-i" ]; then
+  read -r line
+  case "$line" in
+    add-generic-password*-a\\ \\"NEW_KEY\\"*-X\\ *)
+      exit 0 ;;
+    *)
+      echo "stub -i: unexpected command: $line" >&2; exit 1 ;;
+  esac
+fi
 svc=""; acct=""; want_value=false
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -31,10 +42,15 @@ case "$cmd" in
     if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "GOOD_KEY" ]; then
       $want_value && echo "stub-good-value"; exit 0
     fi
+    if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "NEW_KEY" ]; then
+      $want_value && echo "stub-new-value"; exit 0
+    fi
     if [ "$svc" = "MANUAL_KEY" ]; then
       $want_value && echo "stub-manual-value"; exit 0
     fi
     exit 44 ;;
+  add-generic-password)
+    echo "stub: secret passed via argv — forbidden (issue #94)" >&2; exit 99 ;;
   *) exit 1 ;;
 esac
 `;
@@ -149,9 +165,9 @@ test('get prints a reference by default, raw value only with --reveal', async ()
   assert.equal(raw.stdout.trim(), 'stub-good-value');
 });
 
-test('set stores a value piped via stdin', async () => {
-  // The stub's add-generic-password exits 1, so failure proves the value path
-  // reached `security` without appearing in argv of akc itself.
+test('set stores a piped value via security -i stdin, never argv', async () => {
+  // The stub only accepts add-generic-password through -i (stdin) with -X hex;
+  // an argv-based add-generic-password fails loudly (exit 99, issue #94).
   const r = await pExecFile(
     'bash',
     ['-c', `echo "piped-secret" | ${process.execPath} ${AKC} set NEW_KEY`],
@@ -160,6 +176,31 @@ test('set stores a value piped via stdin', async () => {
     (r) => ({ code: 0, ...r }),
     (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
   );
-  assert.equal(r.code, 1); // stub rejects add-generic-password
-  assert.match(r.stderr, /failed to save/);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /✅ Saved NEW_KEY/);
+  assert.doesNotMatch(r.stdout, /piped-secret/);
+});
+
+test('set rejects invalid names and control characters before touching security', async () => {
+  const badName = await pExecFile(
+    'bash',
+    ['-c', `echo "v" | ${process.execPath} ${AKC} set 'BAD KEY'`],
+    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+  ).then(
+    () => ({ code: 0 }),
+    (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })
+  );
+  assert.equal(badName.code, 1);
+  assert.match(badName.stderr, /key name must match/);
+
+  const ctrl = await pExecFile(
+    'bash',
+    ['-c', `printf 'line1\\nline2\\n' | ${process.execPath} ${AKC} set NEW_KEY`],
+    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+  ).then(
+    () => ({ code: 0 }),
+    (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })
+  );
+  assert.equal(ctrl.code, 1);
+  assert.match(ctrl.stderr, /control characters/);
 });

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -14,16 +14,23 @@ const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js')
 
 let stubDir;
 
-// The stub knows one GUI-store key (GOOD_KEY), one manual key (MANUAL_KEY),
-// and accepts interactive (-i) add-generic-password for NEW_KEY — but only
-// when the value arrives via stdin as -X hex (never as argv).
+// The stub knows one GUI-store key (GOOD_KEY) and one manual key (MANUAL_KEY).
+// Interactive (-i) add-generic-password is accepted only with -X hex via stdin
+// (never argv): NEW_KEY round-trips through a state file so read-back
+// verification sees the value actually written; ECHO_KEY simulates a failure
+// whose stderr leaks the full command line including the hex value.
 const STUB = `#!/bin/bash
+state_dir="$(cd "$(dirname "$0")" && pwd)"
 cmd="$1"; shift
 if [ "$cmd" = "-i" ]; then
   read -r line
   case "$line" in
     add-generic-password*-a\\ \\"NEW_KEY\\"*-X\\ *)
+      printf '%s' "\${line##* }" | xxd -r -p > "$state_dir/state-NEW_KEY"
       exit 0 ;;
+    add-generic-password*-a\\ \\"ECHO_KEY\\"*-X\\ *)
+      echo "security: SecKeychainItemCreateFromContent failed: $line" >&2
+      exit 1 ;;
     *)
       echo "stub -i: unexpected command: $line" >&2; exit 1 ;;
   esac
@@ -42,8 +49,8 @@ case "$cmd" in
     if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "GOOD_KEY" ]; then
       $want_value && echo "stub-good-value"; exit 0
     fi
-    if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "NEW_KEY" ]; then
-      $want_value && echo "stub-new-value"; exit 0
+    if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "NEW_KEY" ] && [ -f "$state_dir/state-NEW_KEY" ]; then
+      $want_value && { cat "$state_dir/state-NEW_KEY"; echo; }; exit 0
     fi
     if [ "$svc" = "MANUAL_KEY" ]; then
       $want_value && echo "stub-manual-value"; exit 0
@@ -179,6 +186,24 @@ test('set stores a piped value via security -i stdin, never argv', async () => {
   assert.equal(r.code, 0);
   assert.match(r.stdout, /✅ Saved NEW_KEY/);
   assert.doesNotMatch(r.stdout, /piped-secret/);
+});
+
+test('set failure stderr never leaks the value, even when security echoes the command', async () => {
+  const value = 'echo-secret-value';
+  const hex = Buffer.from(value, 'utf8').toString('hex');
+  const r = await pExecFile(
+    'bash',
+    ['-c', `printf '%s' "${value}" | ${process.execPath} ${AKC} set ECHO_KEY`],
+    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+  ).then(
+    () => ({ code: 0, stdout: '', stderr: '' }),
+    (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
+  );
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /failed to save/);
+  assert.doesNotMatch(r.stderr, new RegExp(value));
+  assert.doesNotMatch(r.stderr, new RegExp(hex, 'i'));
+  assert.match(r.stderr, /<redacted>/);
 });
 
 test('set rejects invalid names and control characters before touching security', async () => {

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -20,7 +20,7 @@ npx aikeychain <command>
 | `akc list` | キー名一覧（値は一切表示しない） |
 | `akc check <KEY>` | キーの存在・格納先（app / manual）確認 |
 | `akc get <KEY>` | `keychain://<KEY>` 参照を出力（`--reveal` で生値） |
-| `akc set <KEY>` | キー登録・更新（隠し入力 or stdin。`-U` 相当の上書きで重複防止） |
+| `akc set <KEY>` | キー登録・更新（隠し入力 or stdin。値は `security -i` に stdin + hex で渡すため**どのプロセスの argv にも露出しない**。`-U` 相当の上書きで重複防止） |
 | `akc delete <KEY>` | キー削除 |
 | `akc doctor` | env / `~/.zshrc` の参照診断（`-a "$USER"` 落とし穴の検出含む） |
 | `akc guide` | AI エージェント向け使い方ガイド表示 |


### PR DESCRIPTION
## 概要
Closes #94

`akc set` / MCP `set_secret` のシークレット値が `security add-generic-password -w <value>` の argv 経由で同一ユーザーのプロセス一覧に露出していた問題（PR #93 セルフレビューの重要度: 高 指摘）を根本解決。

## 変更内容

`security -i`（stdin からコマンドを読むインタラクティブモード）+ `-X`（hex 値指定）に切り替え。**値はどのプロセスの argv にも載らない**。hex 化によりクォート/エスケープ問題も同時に消滅。

| ファイル | 変更内容 |
|---------|---------|
| `cli/src/keychain.js` | `setKey()` を `spawn('security', ['-i'])` + stdin 方式に変更。キー名検証・制御文字拒否・保存後 read-back 検証を追加 |
| `cli/test/cli.test.js` | スタブが argv 経由の `add-generic-password` を exit 99 で拒否（リグレッション防止）。検証 2 テスト追加（21 件、全 PASS） |
| `cli/src/usage-guide.js` / `cli/README.md` / `docs/guide/cli-mcp.md` | 「argv 露出あり」の旧制約記述を撤回し stdin 方式を明記 |
| `cli/package.json` | 0.1.0 → 0.2.0 |

## 実測エビデンス（ps 監視・ポジティブコントロール付き）

新旧両方式に同一の 300ms 観測窓を与えて `ps -axo args` をポーリング:

```
=== Positive control: OLD method (security ... -w <value>) ===
    | /usr/bin/security add-generic-password -U -s akc94-control -a akc94-control -w AKC94OLDSENTINEL...
argv sightings: 2   ← 監視は旧方式を確実に捕捉できる

=== Fix under test: akc set (security -i, stdin + -X hex) ===
argv sightings: 0   ← 新方式は同一条件で露出ゼロ

=== Round-trip check (special chars via real keychain) ===
special-char round-trip: OK (25 chars)   ← `"` `\` `$` スペース含む値が正確に往復

VERDICT: PASS
```

## テスト計画
- [x] `npm test` 21/21 PASS
- [x] 実 Keychain ラウンドトリップ（特殊文字含む）
- [x] ps 監視による argv 非露出の実測（上記）
- [ ] マージ後: Secret Reference / Proxy 両モードの結合試験（issue #94 に結果を報告予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
