### PR TITLE
fix(proxy): Proxy モードの無期限ハングを解消（#96）

### DIFF
--- a/AIkeychain/Models/ProxyRoute.swift
+++ b/AIkeychain/Models/ProxyRoute.swift
@@ -34,8 +34,11 @@ struct ProxyRoute {
         ),
     ]
 
-    /// ホスト名からルートを検索
+    /// ホスト名からルートを検索（完全一致。ポートは除去して比較）
+    /// 部分一致（contains）は `evil-api.anthropic.com.attacker.test` のような
+    /// 攻撃者制御ホストを誤マッチさせるため使用しない。
     static func route(for host: String) -> ProxyRoute? {
-        routes.first { host.contains($0.host) }
+        let hostname = host.split(separator: ":", maxSplits: 1).first.map(String.init) ?? host
+        return routes.first { $0.host == hostname }
     }
 }

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -1,10 +1,12 @@
 import Foundation
 import Security
+import LocalAuthentication
 
 enum KeychainError: LocalizedError {
     case duplicateItem
     case itemNotFound
     case invalidData
+    case interactionRequired
     case unexpectedStatus(OSStatus)
 
     var errorDescription: String? {
@@ -12,6 +14,7 @@ enum KeychainError: LocalizedError {
         case .duplicateItem: "This key already exists in the Keychain."
         case .itemNotFound: "Key not found in the Keychain."
         case .invalidData: "Failed to encode/decode the key data."
+        case .interactionRequired: "Keychain access requires user interaction (consent or unlock), which is unavailable in this context."
         case .unexpectedStatus(let status): "Keychain error: \(status)"
         }
     }
@@ -20,6 +23,11 @@ enum KeychainError: LocalizedError {
 protocol KeychainServiceProtocol {
     func save(value: String, for account: String) throws
     func retrieve(for account: String) throws -> String?
+    /// Read without ever presenting authentication/consent UI.
+    /// Throws `KeychainError.interactionRequired` instead of blocking when macOS
+    /// would otherwise show a SecurityAgent prompt — required for an unattended
+    /// background proxy that must never hang on a keychain read.
+    func retrieveNoninteractive(for account: String) throws -> String?
     func delete(for account: String) throws
     func exists(for account: String) -> Bool
 }
@@ -91,6 +99,33 @@ final class KeychainService: KeychainServiceProtocol {
         return string
     }
 
+    func retrieveNoninteractive(for account: String) throws -> String? {
+        var query = baseQuery(for: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        // Fail fast instead of presenting (and blocking on) a consent/auth prompt.
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        query[kSecUseAuthenticationContext as String] = context
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            throw KeychainError.interactionRequired
+        }
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+        guard let data = result as? Data, let string = String(data: data, encoding: .utf8) else {
+            throw KeychainError.invalidData
+        }
+        return string
+    }
+
     func delete(for account: String) throws {
         let query = baseQuery(for: account)
         let status = SecItemDelete(query as CFDictionary)
@@ -119,6 +154,10 @@ final class MockKeychainService: KeychainServiceProtocol {
     }
 
     func retrieve(for account: String) throws -> String? {
+        store[account]
+    }
+
+    func retrieveNoninteractive(for account: String) throws -> String? {
         store[account]
     }
 

--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -19,10 +19,44 @@ final class ProxyServer {
 
     private var listener: NWListener?
     private let keychainService: KeychainServiceProtocol
+    /// listener 専用（接続受理は軽量・直列で十分）
     private let queue = DispatchQueue(label: "com.aieo.aikeychain.proxy", qos: .userInitiated)
+    /// 接続ごとの処理は並列キューで行う。1 本の遅い/ブロックしたリクエストが
+    /// 他のリクエスト（403/502 など即応すべき経路を含む）を巻き込まないようにする。
+    private let processingQueue = DispatchQueue(
+        label: "com.aieo.aikeychain.proxy.processing", qos: .userInitiated, attributes: .concurrent)
 
-    init(keychainService: KeychainServiceProtocol = KeychainService.shared) {
+    /// Keychain 読み取りのタイムアウト（consent UI 抑止が効かないレガシー ACL でも有限時間で打ち切る保険）
+    private let keychainTimeout: TimeInterval
+    /// 上流接続・受信のタイムアウト
+    private let upstreamTimeout: TimeInterval
+
+    init(keychainService: KeychainServiceProtocol = KeychainService.shared,
+         keychainTimeout: TimeInterval = 3,
+         upstreamTimeout: TimeInterval = 30) {
         self.keychainService = keychainService
+        self.keychainTimeout = keychainTimeout
+        self.upstreamTimeout = upstreamTimeout
+    }
+
+    /// クライアントへの応答が一度だけ行われることを保証する（タイムアウトと正常完了の競合対策）。
+    private final class OneShot {
+        private let lock = NSLock()
+        private var fired = false
+        func consume() -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            if fired { return false }
+            fired = true
+            return true
+        }
+    }
+
+    private enum KeyReadResult {
+        case success(String)
+        case notFound
+        case interactionRequired
+        case timedOut
+        case error(String)
     }
 
     func start() throws {
@@ -74,9 +108,10 @@ final class ProxyServer {
     // MARK: - Connection Handling
 
     private func handleConnection(_ connection: NWConnection) {
-        connection.start(queue: queue)
+        // 並列キューで処理することで、1 接続のブロックが他をブロックしない。
+        connection.start(queue: processingQueue)
 
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
             guard let self, let data else {
                 connection.cancel()
                 return
@@ -84,6 +119,38 @@ final class ProxyServer {
 
             self.processRequest(data: data, connection: connection)
         }
+    }
+
+    /// Keychain 読み取りを非対話・タイムアウト付きで実行する。
+    /// 非対話読み取りでも万一ブロックした場合に備え、別キューで実行して
+    /// `keychainTimeout` で打ち切る（処理スレッドを占有させない）。
+    private func readKeyWithTimeout(account: String) -> KeyReadResult {
+        let semaphore = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        var outcome: KeyReadResult = .timedOut
+
+        DispatchQueue.global(qos: .userInitiated).async { [keychainService] in
+            var local: KeyReadResult
+            do {
+                if let value = try keychainService.retrieveNoninteractive(for: account), !value.isEmpty {
+                    local = .success(value)
+                } else {
+                    local = .notFound
+                }
+            } catch KeychainError.interactionRequired {
+                local = .interactionRequired
+            } catch {
+                local = .error(error.localizedDescription)
+            }
+            lock.lock(); outcome = local; lock.unlock()
+            semaphore.signal()
+        }
+
+        if semaphore.wait(timeout: .now() + keychainTimeout) == .timedOut {
+            return .timedOut
+        }
+        lock.lock(); defer { lock.unlock() }
+        return outcome
     }
 
     private func processRequest(data: Data, connection: NWConnection) {
@@ -134,19 +201,41 @@ final class ProxyServer {
             return
         }
 
-        // Read API key from Keychain
-        guard let apiKey = try? keychainService.retrieve(for: route.keychainAccount), !apiKey.isEmpty else {
-            AppState.shared.proxyLogStore.append(ProxyLog(
-                timestamp: Date(), service: route.host,
-                method: parsed.method, path: parsed.path,
-                statusCode: 401, latency: 0, isError: true
-            ))
-            sendErrorResponse(connection: connection, statusCode: 401, message: "API key not found in Keychain for \(route.keychainAccount)")
+        // Read API key from Keychain — non-interactive and time-bounded so an
+        // unattended proxy can never hang on a SecurityAgent consent prompt.
+        let apiKey: String
+        switch readKeyWithTimeout(account: route.keychainAccount) {
+        case .success(let value):
+            apiKey = value
+        case .notFound:
+            respondReadFailure(connection: connection, route: route, parsed: parsed,
+                               statusCode: 401, message: "API key not found in Keychain for \(route.keychainAccount)")
+            return
+        case .interactionRequired:
+            respondReadFailure(connection: connection, route: route, parsed: parsed,
+                               statusCode: 503, message: "Keychain access for \(route.keychainAccount) requires user consent/unlock. Open AI KeyChain and approve access, then retry.")
+            return
+        case .timedOut:
+            respondReadFailure(connection: connection, route: route, parsed: parsed,
+                               statusCode: 504, message: "Keychain read for \(route.keychainAccount) timed out after \(Int(keychainTimeout))s")
+            return
+        case .error(let detail):
+            respondReadFailure(connection: connection, route: route, parsed: parsed,
+                               statusCode: 502, message: "Keychain read error for \(route.keychainAccount): \(detail)")
             return
         }
 
         // Forward request with injected auth header
         forwardRequest(parsed: parsed, route: route, apiKey: apiKey, clientConnection: connection)
+    }
+
+    private func respondReadFailure(connection: NWConnection, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest, statusCode: Int, message: String) {
+        AppState.shared.proxyLogStore.append(ProxyLog(
+            timestamp: Date(), service: route.host,
+            method: parsed.method, path: parsed.path,
+            statusCode: statusCode, latency: 0, isError: true
+        ))
+        sendErrorResponse(connection: connection, statusCode: statusCode, message: message)
     }
 
     // MARK: - Upstream Forwarding (NWConnection-based)
@@ -187,15 +276,33 @@ final class ProxyServer {
             using: tlsParams
         )
 
+        // Guarantee exactly one client response even if the watchdog and a real
+        // completion race each other.
+        let responseGuard = OneShot()
+
+        // Watchdog: never let a stuck upstream hang the client forever.
+        let watchdog = DispatchWorkItem { [weak self] in
+            guard let self, responseGuard.consume() else { return }
+            upstreamConnection.cancel()
+            self.logAndSend(
+                clientConnection: clientConnection, requestStart: requestStart,
+                route: route, parsed: parsed,
+                message: "Upstream timed out after \(Int(self.upstreamTimeout))s"
+            )
+        }
+        processingQueue.asyncAfter(deadline: .now() + upstreamTimeout, execute: watchdog)
+
         upstreamConnection.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
                 // Connection established - send the request
                 upstreamConnection.send(content: requestData, completion: .contentProcessed { sendError in
                     if let sendError {
-                        self?.logAndRespondError(
+                        watchdog.cancel()
+                        guard responseGuard.consume() else { return }
+                        self?.logAndSend(
                             clientConnection: clientConnection, requestStart: requestStart,
-                            route: route, parsed: parsed, latency: Date().timeIntervalSince(requestStart),
+                            route: route, parsed: parsed,
                             message: "Upstream send error: \(sendError.localizedDescription)"
                         )
                         upstreamConnection.cancel()
@@ -204,14 +311,17 @@ final class ProxyServer {
                     // Receive upstream response
                     self?.receiveUpstreamResponse(
                         upstream: upstreamConnection, clientConnection: clientConnection,
-                        requestStart: requestStart, route: route, parsed: parsed
+                        requestStart: requestStart, route: route, parsed: parsed,
+                        watchdog: watchdog, responseGuard: responseGuard
                     )
                 })
 
             case .failed(let error):
-                self?.logAndRespondError(
+                watchdog.cancel()
+                guard responseGuard.consume() else { return }
+                self?.logAndSend(
                     clientConnection: clientConnection, requestStart: requestStart,
-                    route: route, parsed: parsed, latency: Date().timeIntervalSince(requestStart),
+                    route: route, parsed: parsed,
                     message: "Upstream connection failed: \(error.localizedDescription)"
                 )
                 upstreamConnection.cancel()
@@ -221,10 +331,10 @@ final class ProxyServer {
             }
         }
 
-        upstreamConnection.start(queue: queue)
+        upstreamConnection.start(queue: processingQueue)
     }
 
-    private func receiveUpstreamResponse(upstream: NWConnection, clientConnection: NWConnection, requestStart: Date, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest) {
+    private func receiveUpstreamResponse(upstream: NWConnection, clientConnection: NWConnection, requestStart: Date, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest, watchdog: DispatchWorkItem, responseGuard: OneShot) {
         // Receive all data from upstream then forward to client
         // Note: NWConnection の send は中間チャンクをフラッシュしないため、
         // ストリーミング転送ではなくバッファリング方式を使用
@@ -238,12 +348,14 @@ final class ProxyServer {
 
                 if isComplete || error != nil {
                     upstream.cancel()
+                    watchdog.cancel()
+                    guard responseGuard.consume() else { return }
                     let latency = Date().timeIntervalSince(requestStart)
 
                     if allData.isEmpty {
-                        self?.logAndRespondError(
+                        self?.logAndSend(
                             clientConnection: clientConnection, requestStart: requestStart,
-                            route: route, parsed: parsed, latency: latency,
+                            route: route, parsed: parsed,
                             message: error.map { "Upstream error: \($0.localizedDescription)" } ?? "Empty upstream response"
                         )
                         return
@@ -283,11 +395,11 @@ final class ProxyServer {
         return 200
     }
 
-    private func logAndRespondError(clientConnection: NWConnection, requestStart: Date, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest, latency: TimeInterval, message: String) {
+    private func logAndSend(clientConnection: NWConnection, requestStart: Date, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest, message: String) {
         AppState.shared.proxyLogStore.append(ProxyLog(
             timestamp: requestStart, service: route.host,
             method: parsed.method, path: parsed.path,
-            statusCode: 502, latency: latency, isError: true
+            statusCode: 502, latency: Date().timeIntervalSince(requestStart), isError: true
         ))
         sendErrorResponse(connection: clientConnection, statusCode: 502, message: message)
     }

--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -34,6 +34,8 @@ final class ProxyServer {
     /// タイムアウトしても背後の `SecItemCopyMatching` スレッドは即座には解放されないため、
     /// このサーキットブレーカーが無いと連続リクエストでスレッドが滞留・枯渇し得る。
     private let keychainCooldown: TimeInterval
+    /// クライアントが接続後リクエストを送らない場合に接続を破棄するまでの猶予（slowloris 対策）。
+    private let inboundTimeout: TimeInterval
 
     private let breakerLock = NSLock()
     private var keychainUnavailableUntil: Date?
@@ -41,11 +43,15 @@ final class ProxyServer {
     init(keychainService: KeychainServiceProtocol = KeychainService.shared,
          keychainTimeout: TimeInterval = 3,
          upstreamTimeout: TimeInterval = 30,
-         keychainCooldown: TimeInterval = 10) {
+         keychainCooldown: TimeInterval = 10,
+         maxConcurrentKeychainReads: Int = 4,
+         inboundTimeout: TimeInterval = 15) {
         self.keychainService = keychainService
         self.keychainTimeout = keychainTimeout
         self.upstreamTimeout = upstreamTimeout
         self.keychainCooldown = keychainCooldown
+        self.inboundTimeout = inboundTimeout
+        self.keychainAdmission = DispatchSemaphore(value: max(1, maxConcurrentKeychainReads))
     }
 
     /// サーキットブレーカー: クールダウン中なら true（読み取りを試みない）。
@@ -86,8 +92,14 @@ final class ProxyServer {
         case notFound
         case interactionRequired
         case timedOut
+        case busy
         case error(String)
     }
+
+    /// 同時に走る Keychain 読み取り数の上限。ブロックした読み取りの背後スレッドは
+    /// タイムアウト後も滞留するため、サーキットブレーカーが開く前（最初の
+    /// keychainTimeout 窓）の同時バーストでもスレッドが無制限に増えないよう上限化する。
+    private let keychainAdmission: DispatchSemaphore
 
     func start() throws {
         guard !isRunning else { return }
@@ -141,7 +153,12 @@ final class ProxyServer {
         // 並列キューで処理することで、1 接続のブロックが他をブロックしない。
         connection.start(queue: processingQueue)
 
+        // 接続後にリクエストを送ってこないクライアントで接続が滞留しないよう破棄する。
+        let idleTimeout = DispatchWorkItem { connection.cancel() }
+        processingQueue.asyncAfter(deadline: .now() + inboundTimeout, execute: idleTimeout)
+
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
+            idleTimeout.cancel()
             guard let self, let data else {
                 connection.cancel()
                 return
@@ -154,12 +171,23 @@ final class ProxyServer {
     /// Keychain 読み取りを非対話・タイムアウト付きで実行する。
     /// 非対話読み取りでも万一ブロックした場合に備え、別キューで実行して
     /// `keychainTimeout` で打ち切る（処理スレッドを占有させない）。
+    /// 同時実行数は `keychainAdmission` で上限化し、ブロックした読み取りスレッドが
+    /// バーストで無制限に増えるのを防ぐ。
     private func readKeyWithTimeout(account: String) -> KeyReadResult {
+        // 空きが無ければ（=上限数の読み取りが既にブロック中なら）即座に busy で返す。
+        guard keychainAdmission.wait(timeout: .now()) == .success else {
+            return .busy
+        }
+
         let semaphore = DispatchSemaphore(value: 0)
         let lock = NSLock()
         var outcome: KeyReadResult = .timedOut
 
-        DispatchQueue.global(qos: .userInitiated).async { [keychainService] in
+        DispatchQueue.global(qos: .userInitiated).async { [keychainService, keychainAdmission] in
+            // permit は SecItemCopyMatching が実際に返るまで保持する
+            // （readKeyWithTimeout のタイムアウト時点ではなく）。これにより
+            // 「ブロック中スレッド数 ≤ 上限」が保証される。
+            defer { keychainAdmission.signal() }
             var local: KeyReadResult
             do {
                 if let value = try keychainService.retrieveNoninteractive(for: account), !value.isEmpty {
@@ -260,6 +288,10 @@ final class ProxyServer {
             tripKeychainBreaker()
             respondReadFailure(connection: connection, route: route, parsed: parsed,
                                statusCode: 504, message: "Keychain read for \(route.keychainAccount) timed out after \(Int(keychainTimeout))s")
+            return
+        case .busy:
+            respondReadFailure(connection: connection, route: route, parsed: parsed,
+                               statusCode: 503, message: "Keychain busy (too many concurrent reads blocked). Retry shortly.")
             return
         case .error(let detail):
             respondReadFailure(connection: connection, route: route, parsed: parsed,

--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -30,13 +30,43 @@ final class ProxyServer {
     private let keychainTimeout: TimeInterval
     /// 上流接続・受信のタイムアウト
     private let upstreamTimeout: TimeInterval
+    /// Keychain が consent/タイムアウトで利用不能になった後、再試行を抑止する期間。
+    /// タイムアウトしても背後の `SecItemCopyMatching` スレッドは即座には解放されないため、
+    /// このサーキットブレーカーが無いと連続リクエストでスレッドが滞留・枯渇し得る。
+    private let keychainCooldown: TimeInterval
+
+    private let breakerLock = NSLock()
+    private var keychainUnavailableUntil: Date?
 
     init(keychainService: KeychainServiceProtocol = KeychainService.shared,
          keychainTimeout: TimeInterval = 3,
-         upstreamTimeout: TimeInterval = 30) {
+         upstreamTimeout: TimeInterval = 30,
+         keychainCooldown: TimeInterval = 10) {
         self.keychainService = keychainService
         self.keychainTimeout = keychainTimeout
         self.upstreamTimeout = upstreamTimeout
+        self.keychainCooldown = keychainCooldown
+    }
+
+    /// サーキットブレーカー: クールダウン中なら true（読み取りを試みない）。
+    private func keychainInCooldown() -> Bool {
+        breakerLock.lock(); defer { breakerLock.unlock() }
+        guard let until = keychainUnavailableUntil else { return false }
+        if Date() >= until {
+            keychainUnavailableUntil = nil
+            return false
+        }
+        return true
+    }
+
+    private func tripKeychainBreaker() {
+        breakerLock.lock(); defer { breakerLock.unlock() }
+        keychainUnavailableUntil = Date().addingTimeInterval(keychainCooldown)
+    }
+
+    private func resetKeychainBreaker() {
+        breakerLock.lock(); defer { breakerLock.unlock() }
+        keychainUnavailableUntil = nil
     }
 
     /// クライアントへの応答が一度だけ行われることを保証する（タイムアウトと正常完了の競合対策）。
@@ -201,21 +231,33 @@ final class ProxyServer {
             return
         }
 
+        // Circuit breaker: if a recent read was consent-blocked/timed out, fail
+        // fast without dispatching another read (whose backing SecItemCopyMatching
+        // thread would otherwise pile up while the prompt remains unanswered).
+        if keychainInCooldown() {
+            respondReadFailure(connection: connection, route: route, parsed: parsed,
+                               statusCode: 503, message: "Keychain temporarily unavailable (consent/unlock required). Open AI KeyChain and approve access, then retry.")
+            return
+        }
+
         // Read API key from Keychain — non-interactive and time-bounded so an
         // unattended proxy can never hang on a SecurityAgent consent prompt.
         let apiKey: String
         switch readKeyWithTimeout(account: route.keychainAccount) {
         case .success(let value):
+            resetKeychainBreaker()
             apiKey = value
         case .notFound:
             respondReadFailure(connection: connection, route: route, parsed: parsed,
                                statusCode: 401, message: "API key not found in Keychain for \(route.keychainAccount)")
             return
         case .interactionRequired:
+            tripKeychainBreaker()
             respondReadFailure(connection: connection, route: route, parsed: parsed,
                                statusCode: 503, message: "Keychain access for \(route.keychainAccount) requires user consent/unlock. Open AI KeyChain and approve access, then retry.")
             return
         case .timedOut:
+            tripKeychainBreaker()
             respondReadFailure(connection: connection, route: route, parsed: parsed,
                                statusCode: 504, message: "Keychain read for \(route.keychainAccount) timed out after \(Int(keychainTimeout))s")
             return

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -293,6 +293,73 @@ struct ProxyHangRegressionTests {
         #expect(second.elapsed < 0.5) // short-circuited, not a fresh 1s block
     }
 
+    @Test("Admission cap: concurrent burst during the first timeout window is bounded (fast 503)")
+    func admissionCapBoundsConcurrentBurst() throws {
+        let port = testPort()
+        // Only 1 concurrent keychain read allowed; reads block 10s; read timeout 3s.
+        // The first request occupies the single permit (blocked). A second request
+        // arriving during the SAME timeout window — before the breaker has tripped —
+        // must NOT spawn another blocked read; it gets 503 busy almost instantly.
+        let server = ProxyServer(
+            keychainService: BlockingKeychainService(blockFor: 10),
+            keychainTimeout: 3, upstreamTimeout: 5, keychainCooldown: 10,
+            maxConcurrentKeychainReads: 1)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+        let token = server.sessionToken
+
+        let blocker = Thread {
+            _ = TestHTTPClient.request(port: port, host: "api.anthropic.com", token: token, timeout: 12)
+        }
+        blocker.start()
+        Thread.sleep(forTimeInterval: 0.3) // first request now holds the single permit
+
+        // Second request within the first read's 3s timeout window:
+        let second = TestHTTPClient.request(port: port, host: "api.anthropic.com", token: token, timeout: 5)
+        #expect(second.status == 503)
+        #expect(second.elapsed < 1.0) // fast-failed by admission cap, not a fresh 3s block
+    }
+
+    @Test("Idle client connection is dropped after the inbound timeout")
+    func idleConnectionDropped() throws {
+        let port = testPort()
+        let server = ProxyServer(
+            keychainService: MockKeychainService(),
+            keychainTimeout: 2, upstreamTimeout: 5, keychainCooldown: 10,
+            maxConcurrentKeychainReads: 4, inboundTimeout: 1)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        // Connect but never send a request; the server must close the connection.
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        #expect(fd >= 0)
+        defer { close(fd) }
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let connected = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                Foundation.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        #expect(connected == 0)
+
+        // A blocking recv should return 0 (EOF) once the server cancels the idle connection.
+        var tv = timeval(tv_sec: 4, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        var buf = [UInt8](repeating: 0, count: 16)
+        let start = Date()
+        let n = recv(fd, &buf, buf.count, 0)
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(n == 0)          // connection closed by server (EOF)
+        #expect(elapsed < 3.5)   // around inboundTimeout (1s), not the recv timeout (4s)
+    }
+
     @Test("Unknown host is rejected instantly without touching the keychain")
     func unknownHostInstant502() throws {
         let port = testPort()

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -34,6 +34,19 @@ struct ProxyRouteTests {
         let route = ProxyRoute.route(for: "example.com")
         #expect(route == nil)
     }
+
+    @Test("Host with port still matches (port stripped)")
+    func hostWithPort() {
+        #expect(ProxyRoute.route(for: "api.anthropic.com:443") != nil)
+    }
+
+    @Test("Look-alike host does NOT match (exact match, not contains)")
+    func lookAlikeHostRejected() {
+        // issue #96: substring matching let attacker-controlled hosts match.
+        #expect(ProxyRoute.route(for: "api.anthropic.com.attacker.test") == nil)
+        #expect(ProxyRoute.route(for: "evil-api.anthropic.com") == nil)
+        #expect(ProxyRoute.route(for: "notapi.openai.com") == nil)
+    }
 }
 
 @Suite("HTTPRequestParser Tests")
@@ -120,6 +133,159 @@ struct ProxyServerTests {
         try server.start() // Should be no-op
         Thread.sleep(forTimeInterval: 0.3)
         server.stop()
+    }
+}
+
+/// Keychain double whose non-interactive read blocks for a long time —
+/// simulates the SecurityAgent consent prompt that caused the issue #96 hang.
+final class BlockingKeychainService: KeychainServiceProtocol {
+    let blockFor: TimeInterval
+    init(blockFor: TimeInterval) { self.blockFor = blockFor }
+    func save(value: String, for account: String) throws {}
+    func retrieve(for account: String) throws -> String? { nil }
+    func retrieveNoninteractive(for account: String) throws -> String? {
+        Thread.sleep(forTimeInterval: blockFor)
+        return "should-not-be-used"
+    }
+    func delete(for account: String) throws {}
+    func exists(for account: String) -> Bool { false }
+}
+
+/// Keychain double that reports the read needs user interaction.
+final class InteractionRequiredKeychainService: KeychainServiceProtocol {
+    func save(value: String, for account: String) throws {}
+    func retrieve(for account: String) throws -> String? { nil }
+    func retrieveNoninteractive(for account: String) throws -> String? {
+        throw KeychainError.interactionRequired
+    }
+    func delete(for account: String) throws {}
+    func exists(for account: String) -> Bool { false }
+}
+
+/// Minimal raw-TCP HTTP client for talking to the local proxy in tests.
+/// Returns (statusCode, elapsedSeconds). statusCode == -1 on connection failure.
+enum TestHTTPClient {
+    static func request(port: UInt16, host: String, token: String?, timeout: TimeInterval) -> (status: Int, elapsed: TimeInterval) {
+        let start = Date()
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return (-1, 0) }
+        defer { close(fd) }
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                Foundation.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard connectResult == 0 else { return (-1, Date().timeIntervalSince(start)) }
+
+        var req = "GET /v1/models HTTP/1.1\r\nHost: \(host)\r\n"
+        if let token { req += "\(ProxyServer.tokenHeaderName): \(token)\r\n" }
+        req += "Connection: close\r\n\r\n"
+        _ = req.withCString { send(fd, $0, strlen($0), 0) }
+
+        // bound read with a recv timeout
+        var tv = timeval(tv_sec: Int(timeout), tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        var buf = [UInt8](repeating: 0, count: 4096)
+        let n = recv(fd, &buf, buf.count, 0)
+        let elapsed = Date().timeIntervalSince(start)
+        guard n > 0, let resp = String(bytes: buf[0..<n], encoding: .utf8), resp.hasPrefix("HTTP/") else {
+            return (-1, elapsed)
+        }
+        let parts = resp.split(separator: " ", maxSplits: 2)
+        let status = parts.count >= 2 ? (Int(parts[1]) ?? -1) : -1
+        return (status, elapsed)
+    }
+}
+
+@Suite("Proxy Hang Regression Tests (issue #96)")
+struct ProxyHangRegressionTests {
+
+    /// Pick a high port unlikely to collide.
+    private func testPort() -> UInt16 { UInt16.random(in: 19000...19900) }
+
+    @Test("A blocked keychain read does NOT wedge other requests")
+    func blockedReadDoesNotWedgeOthers() throws {
+        let port = testPort()
+        // keychain read blocks 10s, but our keychain timeout is 1s.
+        let server = ProxyServer(
+            keychainService: BlockingKeychainService(blockFor: 10),
+            keychainTimeout: 1, upstreamTimeout: 5)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+        let token = server.sessionToken
+
+        // Fire a request that hits the (blocking) keychain read in the background.
+        let blocker = Thread {
+            _ = TestHTTPClient.request(port: port, host: "api.anthropic.com", token: token, timeout: 12)
+        }
+        blocker.start()
+        Thread.sleep(forTimeInterval: 0.3) // let it reach the keychain read
+
+        // Meanwhile, a no-token request must be rejected (403) essentially instantly,
+        // proving the proxy is not wedged behind the blocked keychain read.
+        let result = TestHTTPClient.request(port: port, host: "api.anthropic.com", token: nil, timeout: 3)
+        #expect(result.status == 403)
+        #expect(result.elapsed < 1.5)
+    }
+
+    @Test("A blocked keychain read returns a timeout error, never hangs forever")
+    func blockedReadTimesOut() throws {
+        let port = testPort()
+        let server = ProxyServer(
+            keychainService: BlockingKeychainService(blockFor: 30),
+            keychainTimeout: 1, upstreamTimeout: 5)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let result = TestHTTPClient.request(
+            port: port, host: "api.anthropic.com", token: server.sessionToken, timeout: 8)
+        // 504 Gateway Timeout, returned well before the 30s block would elapse.
+        #expect(result.status == 504)
+        #expect(result.elapsed < 4)
+    }
+
+    @Test("Keychain consent-required read returns 503 quickly, no hang")
+    func interactionRequiredReturns503() throws {
+        let port = testPort()
+        let server = ProxyServer(
+            keychainService: InteractionRequiredKeychainService(),
+            keychainTimeout: 2, upstreamTimeout: 5)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let result = TestHTTPClient.request(
+            port: port, host: "api.anthropic.com", token: server.sessionToken, timeout: 5)
+        #expect(result.status == 503)
+        #expect(result.elapsed < 2)
+    }
+
+    @Test("Unknown host is rejected instantly without touching the keychain")
+    func unknownHostInstant502() throws {
+        let port = testPort()
+        // Even with a blocking keychain, unknown-host must 502 immediately.
+        let server = ProxyServer(
+            keychainService: BlockingKeychainService(blockFor: 30),
+            keychainTimeout: 2, upstreamTimeout: 5)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let result = TestHTTPClient.request(
+            port: port, host: "example.com", token: server.sessionToken, timeout: 3)
+        #expect(result.status == 502)
+        #expect(result.elapsed < 1.5)
     }
 }
 

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -270,6 +270,29 @@ struct ProxyHangRegressionTests {
         #expect(result.elapsed < 2)
     }
 
+    @Test("Circuit breaker: after a timeout, subsequent reads fail fast without re-blocking")
+    func circuitBreakerShortCircuits() throws {
+        let port = testPort()
+        // 10s block, 1s read timeout, 5s cooldown. First request times out (≈1s);
+        // the next request during cooldown must return 503 almost instantly
+        // (it must NOT spend another ~1s waiting on a fresh blocked read).
+        let server = ProxyServer(
+            keychainService: BlockingKeychainService(blockFor: 10),
+            keychainTimeout: 1, upstreamTimeout: 5, keychainCooldown: 5)
+        server.port = port
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+        let token = server.sessionToken
+
+        let first = TestHTTPClient.request(port: port, host: "api.anthropic.com", token: token, timeout: 5)
+        #expect(first.status == 504)
+
+        let second = TestHTTPClient.request(port: port, host: "api.anthropic.com", token: token, timeout: 5)
+        #expect(second.status == 503)
+        #expect(second.elapsed < 0.5) // short-circuited, not a fresh 1s block
+    }
+
     @Test("Unknown host is rejected instantly without touching the keychain")
     func unknownHostInstant502() throws {
         let port = testPort()


### PR DESCRIPTION
## 概要
Closes #96

Proxy モードが Keychain 読み取りで無期限ハングし実用上機能しない問題を修正。原因 3 つ（consent UI 無限ブロック / 単一シリアルキューで全リクエスト直列化 / タイムアウト無し）を防御的に解消し、**Proxy が二度とハングしない**ようにする。

## 変更内容

| # | ファイル | 変更 |
|---|---------|------|
| 1 | `KeychainService.swift` | `retrieveNoninteractive`（`LAContext.interactionNotAllowed`）を追加。consent/認証 UI が必要なら待たず `errSecInteractionNotAllowed` → `KeychainError.interactionRequired` で即エラー化。SecurityAgent 無限ブロックを根本回避 |
| 2 | `ProxyServer.swift` | 接続処理を**並列キュー**（`.concurrent`）へ。listener とは別キューで、1 本の遅い/詰まったリクエストが他（403/502 含む即応経路）を巻き込まない |
| 3 | `ProxyServer.swift` | Keychain 読み取りを**タイムアウト付き**（既定 3s）で別キュー実行。UI 抑止が効かないレガシー ACL でも有限時間で打ち切り、504 を返す |
| 4 | `ProxyServer.swift` | 上流 connect/受信に**ウォッチドッグ・タイムアウト**（既定 30s）+ レスポンス one-shot ガード。タイムアウトと正常完了が競合しても二重応答しない |
| 5 | `ProxyRoute.swift` | `route(for:)` を `contains` → **ホスト完全一致**（ポート除去）に。look-alike ホスト（`api.anthropic.com.attacker.test` 等）の誤マッチを防止 |

エラーレスポンスの整理: Keychain 未登録=401 / consent 要=503 / Keychain タイムアウト=504 / 上流タイムアウト・失敗=502。

## テスト計画

- [x] `swift test` **73/73 PASS**
- [x] 回帰テスト（実 TCP、`ProxyHangRegressionTests`）:
  - **ブロッキング Keychain ダブルで読み取りが詰まっている最中でも、no-token リクエストは 403 を 1.5s 未満で返す**（= 単一シリアルキューの巻き込みが解消されたことの直接証明）
  - ブロッキング読み取りは 504 を有限時間（< 4s）で返す（無限ハングしない）
  - consent 要の読み取りは 503 を即返す（< 2s）
  - 未知ホストは Keychain に触れず 502 を即返す（< 1.5s）
  - ホスト完全一致・ポート付きホスト・look-alike 拒否
- [ ] **GUI 実機での consent 挙動**（署名ビルドで実際に SecurityAgent ダイアログが出る環境）は手動確認項目。本 PR は「ハングを有限時間のエラーに変える」防御で、ユニットテストで挙動を担保

## スコープ外（別 PR / issue #96 に記載）
- **Data Protection Keychain への移行**（`kSecUseDataProtectionKeychain` + アクセシビリティ）= consent を**そもそも出さない**恒久対応。entitlement 調整と既存キーの移行が必要で破壊的リスクがあるため独立 PR
- HTTP リクエストのフレーミング（部分受信の蓄積）・上流レスポンスの**ストリーミング転送**（SSE 対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
