### PR TITLE
fix(proxy): 上流レスポンスのストリーミング転送とリクエストフレーミング (#98)

### DIFF
--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -106,7 +106,9 @@ final class ProxyServer {
     private final class InactivityTimer {
         private let queue: DispatchQueue
         private let interval: TimeInterval
-        private let onFire: () -> Void
+        // onFire は timer 自身を捕捉するため、stop() で nil にして
+        // timer → onFire → timer の循環参照（リクエスト単位のリーク）を断つ。
+        private var onFire: (() -> Void)?
         private let lock = NSLock()
         private var stopped = false
         private var didFire = false
@@ -135,14 +137,17 @@ final class ProxyServer {
             lock.lock()
             if stopped || didFire || gen != generation { lock.unlock(); return }
             didFire = true
+            let callback = onFire
+            onFire = nil
             lock.unlock()
-            onFire()
+            callback?()
         }
 
         func stop() {
             lock.lock(); defer { lock.unlock() }
             stopped = true
             generation += 1 // 予約済みの fire を無効化
+            onFire = nil     // 循環参照を断つ
         }
     }
 
@@ -378,6 +383,18 @@ final class ProxyServer {
                 statusCode: 400, latency: 0, isError: true
             ))
             sendErrorResponse(connection: connection, statusCode: 400, message: "Failed to parse HTTP request")
+            return
+        }
+
+        // Transfer-Encoding は未対応（フレーミングは Content-Length のみ）。
+        // chunked を素通しするとリクエストスマグリングの余地になるため拒否する。
+        if parsed.headers.contains(where: { $0.name.lowercased() == "transfer-encoding" }) {
+            AppState.shared.proxyLogStore.append(ProxyLog(
+                timestamp: Date(), service: parsed.host,
+                method: parsed.method, path: parsed.path,
+                statusCode: 400, latency: 0, isError: true
+            ))
+            sendErrorResponse(connection: connection, statusCode: 400, message: "Transfer-Encoding is not supported")
             return
         }
 

--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -36,6 +36,9 @@ final class ProxyServer {
     private let keychainCooldown: TimeInterval
     /// クライアントが接続後リクエストを送らない場合に接続を破棄するまでの猶予（slowloris 対策）。
     private let inboundTimeout: TimeInterval
+    /// 受信リクエスト全体（ヘッダ + ボディ）の最大サイズ。超過は 413 で拒否し、
+    /// 巨大ボディによるメモリ膨張を防ぐ。
+    private let maxRequestBytes: Int
 
     private let breakerLock = NSLock()
     private var keychainUnavailableUntil: Date?
@@ -50,12 +53,14 @@ final class ProxyServer {
          keychainCooldown: TimeInterval = 10,
          maxConcurrentKeychainReads: Int = 4,
          inboundTimeout: TimeInterval = 15,
+         maxRequestBytes: Int = 10 * 1024 * 1024,
          makeUpstream: ((_ host: String) -> NWConnection)? = nil) {
         self.keychainService = keychainService
         self.keychainTimeout = keychainTimeout
         self.upstreamTimeout = upstreamTimeout
         self.keychainCooldown = keychainCooldown
         self.inboundTimeout = inboundTimeout
+        self.maxRequestBytes = max(8 * 1024, maxRequestBytes)
         self.keychainAdmission = DispatchSemaphore(value: max(1, maxConcurrentKeychainReads))
         self.makeUpstream = makeUpstream ?? { host in
             NWConnection(host: NWEndpoint.Host(host), port: .https, using: NWParameters.tls)
@@ -103,9 +108,13 @@ final class ProxyServer {
         private let interval: TimeInterval
         private let onFire: () -> Void
         private let lock = NSLock()
-        private var item: DispatchWorkItem?
         private var stopped = false
         private var didFire = false
+        /// 世代トークン。reschedule のたびに増やし、fire は自分の世代が最新の
+        /// ときだけ発火する。既にキューから取り出され実行に入った古い work item が
+        /// 「キャンセルされたはず」のまま発火してアクティブなストリームを誤って
+        /// 閉じる事故を防ぐ。
+        private var generation = 0
 
         init(queue: DispatchQueue, interval: TimeInterval, onFire: @escaping () -> Void) {
             self.queue = queue
@@ -116,15 +125,15 @@ final class ProxyServer {
         func reschedule() {
             lock.lock(); defer { lock.unlock() }
             if stopped || didFire { return }
-            item?.cancel()
-            let work = DispatchWorkItem { [weak self] in self?.fire() }
-            item = work
+            generation += 1
+            let gen = generation
+            let work = DispatchWorkItem { [weak self] in self?.fire(gen) }
             queue.asyncAfter(deadline: .now() + interval, execute: work)
         }
 
-        private func fire() {
+        private func fire(_ gen: Int) {
             lock.lock()
-            if stopped || didFire { lock.unlock(); return }
+            if stopped || didFire || gen != generation { lock.unlock(); return }
             didFire = true
             lock.unlock()
             onFire()
@@ -133,8 +142,7 @@ final class ProxyServer {
         func stop() {
             lock.lock(); defer { lock.unlock() }
             stopped = true
-            item?.cancel()
-            item = nil
+            generation += 1 // 予約済みの fire を無効化
         }
     }
 
@@ -227,15 +235,29 @@ final class ProxyServer {
                 return
             }
 
+            // リクエストが大きすぎる → 413 で拒否（メモリ膨張防止）。
+            if buffer.count > self.maxRequestBytes {
+                idleTimeout.cancel()
+                self.sendErrorResponse(connection: connection, statusCode: 413, message: "Request too large")
+                return
+            }
+
             // ヘッダが揃ったか？
             if let headerEnd = buffer.firstRange(of: Data("\r\n\r\n".utf8)) {
                 let headerData = buffer[buffer.startIndex..<headerEnd.lowerBound]
-                let contentLength = Self.parseContentLength(from: headerData)
-                let bodyReceived = buffer.distance(from: headerEnd.upperBound, to: buffer.endIndex)
-                if bodyReceived >= contentLength {
+                switch Self.contentLengthField(from: headerData) {
+                case .invalid:
                     idleTimeout.cancel()
-                    self.processRequest(data: buffer, connection: connection)
+                    self.sendErrorResponse(connection: connection, statusCode: 400, message: "Invalid or conflicting Content-Length")
                     return
+                case .absent, .present:
+                    let contentLength = Self.contentLengthValue(from: headerData)
+                    let bodyReceived = buffer.distance(from: headerEnd.upperBound, to: buffer.endIndex)
+                    if bodyReceived >= contentLength {
+                        idleTimeout.cancel()
+                        self.processRequest(data: buffer, connection: connection)
+                        return
+                    }
                 }
             }
 
@@ -255,8 +277,27 @@ final class ProxyServer {
         }
     }
 
-    /// ヘッダバイト列から Content-Length を取り出す（無ければ 0）。
-    static func parseContentLength(from headerData: Data) -> Int {
+    enum ContentLengthField { case absent; case present; case invalid }
+
+    /// Content-Length ヘッダを厳密に検証する。非数値・負値・値の異なる重複
+    /// （リクエストスマグリング対策）は invalid。
+    static func contentLengthField(from headerData: Data) -> ContentLengthField {
+        guard let text = String(data: headerData, encoding: .utf8) else { return .invalid }
+        var found: Int?
+        for line in text.components(separatedBy: "\r\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" else { continue }
+            let raw = parts[1].trimmingCharacters(in: .whitespaces)
+            guard let n = Int(raw), n >= 0 else { return .invalid }
+            if let prev = found, prev != n { return .invalid }
+            found = n
+        }
+        return found == nil ? .absent : .present
+    }
+
+    /// 検証済み前提で Content-Length の数値を返す（無ければ 0）。
+    static func contentLengthValue(from headerData: Data) -> Int {
         guard let text = String(data: headerData, encoding: .utf8) else { return 0 }
         for line in text.components(separatedBy: "\r\n") {
             let parts = line.split(separator: ":", maxSplits: 1)
@@ -265,6 +306,11 @@ final class ProxyServer {
             }
         }
         return 0
+    }
+
+    /// ヘッダバイト列から Content-Length を取り出す（無ければ 0）。テスト/上流補助用。
+    static func parseContentLength(from headerData: Data) -> Int {
+        contentLengthValue(from: headerData)
     }
 
     /// Keychain 読み取りを非対話・タイムアウト付きで実行する。
@@ -507,14 +553,18 @@ final class ProxyServer {
     /// （バックプレッシャー）。`upstreamTimeout` の**非活動**タイムアウトで、
     /// 上流の沈黙やクライアント停止による滞留を防ぐ（長時間ストリーム自体は許容）。
     private func receiveUpstreamResponse(upstream: NWConnection, clientConnection: NWConnection, requestStart: Date, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest, watchdog: DispatchWorkItem, responseGuard: OneShot) {
+        // 応答の所有権モデル:
+        //  - `responseGuard`（呼び出し元と共有）: 「最初に確定した結末」を 1 つだけ許す。
+        //    = ストリーミング開始 か、ストリーム前のエラー/タイムアウト 502 のどちらか。
+        //  - `finish`: ストリーム開始後の終端処理（正常完了/切断/非活動）を 1 回だけ。
         var firstByte = true
         let statusLock = NSLock()
         var status = 200
-        // ストリーム終了処理（正常完了・切断・非活動）の一度きりガード。
         let finish = OneShot()
         var timer: InactivityTimer!
 
-        func logAndCloseClient(truncated: Bool) {
+        // ストリーム開始後の終端: クライアント接続を閉じる（502 は返せない）。
+        func closeAfterStream(truncated: Bool) {
             guard finish.consume() else { return }
             timer.stop()
             upstream.cancel()
@@ -528,9 +578,31 @@ final class ProxyServer {
             clientConnection.cancel()
         }
 
+        // ストリーム開始前の終端: まだヘッダ未送信なので 502 を返せる。
+        func failBeforeStream(_ message: String) {
+            guard responseGuard.consume() else { return }
+            timer.stop()
+            watchdog.cancel()
+            upstream.cancel()
+            self.logAndSend(
+                clientConnection: clientConnection, requestStart: requestStart,
+                route: route, parsed: parsed, message: message
+            )
+        }
+
         timer = InactivityTimer(queue: processingQueue, interval: upstreamTimeout) {
-            // 上流の沈黙 or クライアント停止 → 接続を破棄（ヘッダ送信後なので 502 は返せない）。
-            logAndCloseClient(truncated: true)
+            // ストリーム開始前なら 502、開始後なら接続クローズ。responseGuard で判定。
+            if responseGuard.consume() {
+                timer.stop()
+                watchdog.cancel()
+                upstream.cancel()
+                self.logAndSend(
+                    clientConnection: clientConnection, requestStart: requestStart,
+                    route: route, parsed: parsed, message: "Upstream timed out (inactivity)"
+                )
+            } else {
+                closeAfterStream(truncated: true)
+            }
         }
 
         func readMore() {
@@ -541,18 +613,21 @@ final class ProxyServer {
                     if firstByte {
                         firstByte = false
                         watchdog.cancel()
-                        // 最初のバイトでストリーミング開始 = この応答の所有権を確定。
-                        // 以降 connect ウォッチドッグ等は 502 を返せない。
-                        _ = responseGuard.consume()
+                        // 最初のバイトでストリーミング所有権を確定。取れなければ
+                        // 既に別経路（タイムアウト等）が 502 を確定済み → 中断。
+                        guard responseGuard.consume() else {
+                            timer.stop(); upstream.cancel(); clientConnection.cancel()
+                            return
+                        }
                         statusLock.lock(); status = self.parseStatusCode(from: data); statusLock.unlock()
                     }
                     clientConnection.send(content: data, completion: .contentProcessed { sendError in
                         if sendError != nil {
-                            logAndCloseClient(truncated: true)
+                            closeAfterStream(truncated: true)
                             return
                         }
                         if isComplete || error != nil {
-                            logAndCloseClient(truncated: error != nil)
+                            closeAfterStream(truncated: error != nil)
                             return
                         }
                         timer.reschedule() // 送信完了＝進捗あり → 期限を延長
@@ -565,18 +640,9 @@ final class ProxyServer {
                 if isComplete || error != nil {
                     if firstByte {
                         // 1 バイトも受信せず終了 → エラー応答（まだヘッダ未送信）。
-                        watchdog.cancel()
-                        timer.stop()
-                        upstream.cancel()
-                        if responseGuard.consume() {
-                            self.logAndSend(
-                                clientConnection: clientConnection, requestStart: requestStart,
-                                route: route, parsed: parsed,
-                                message: error.map { "Upstream error: \($0.localizedDescription)" } ?? "Empty upstream response"
-                            )
-                        }
+                        failBeforeStream(error.map { "Upstream error: \($0.localizedDescription)" } ?? "Empty upstream response")
                     } else {
-                        logAndCloseClient(truncated: error != nil)
+                        closeAfterStream(truncated: error != nil)
                     }
                     return
                 }

--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -40,18 +40,26 @@ final class ProxyServer {
     private let breakerLock = NSLock()
     private var keychainUnavailableUntil: Date?
 
+    /// 上流接続の生成（既定は TLS:443）。テストではローカルの平文サーバーへ
+    /// 差し替えてストリーミング/フレーミングを検証できるようにする。
+    private let makeUpstream: (_ host: String) -> NWConnection
+
     init(keychainService: KeychainServiceProtocol = KeychainService.shared,
          keychainTimeout: TimeInterval = 3,
          upstreamTimeout: TimeInterval = 30,
          keychainCooldown: TimeInterval = 10,
          maxConcurrentKeychainReads: Int = 4,
-         inboundTimeout: TimeInterval = 15) {
+         inboundTimeout: TimeInterval = 15,
+         makeUpstream: ((_ host: String) -> NWConnection)? = nil) {
         self.keychainService = keychainService
         self.keychainTimeout = keychainTimeout
         self.upstreamTimeout = upstreamTimeout
         self.keychainCooldown = keychainCooldown
         self.inboundTimeout = inboundTimeout
         self.keychainAdmission = DispatchSemaphore(value: max(1, maxConcurrentKeychainReads))
+        self.makeUpstream = makeUpstream ?? { host in
+            NWConnection(host: NWEndpoint.Host(host), port: .https, using: NWParameters.tls)
+        }
     }
 
     /// サーキットブレーカー: クールダウン中なら true（読み取りを試みない）。
@@ -84,6 +92,49 @@ final class ProxyServer {
             if fired { return false }
             fired = true
             return true
+        }
+    }
+
+    /// 非活動タイムアウト。`reschedule()` のたびに期限を延ばし、無通信が `interval`
+    /// 続いたら一度だけ `onFire` を呼ぶ。ストリーミング応答（SSE 等の長時間接続）を
+    /// 許容しつつ、上流の沈黙やクライアント停止で永久に滞留しないようにする。
+    private final class InactivityTimer {
+        private let queue: DispatchQueue
+        private let interval: TimeInterval
+        private let onFire: () -> Void
+        private let lock = NSLock()
+        private var item: DispatchWorkItem?
+        private var stopped = false
+        private var didFire = false
+
+        init(queue: DispatchQueue, interval: TimeInterval, onFire: @escaping () -> Void) {
+            self.queue = queue
+            self.interval = interval
+            self.onFire = onFire
+        }
+
+        func reschedule() {
+            lock.lock(); defer { lock.unlock() }
+            if stopped || didFire { return }
+            item?.cancel()
+            let work = DispatchWorkItem { [weak self] in self?.fire() }
+            item = work
+            queue.asyncAfter(deadline: .now() + interval, execute: work)
+        }
+
+        private func fire() {
+            lock.lock()
+            if stopped || didFire { lock.unlock(); return }
+            didFire = true
+            lock.unlock()
+            onFire()
+        }
+
+        func stop() {
+            lock.lock(); defer { lock.unlock() }
+            stopped = true
+            item?.cancel()
+            item = nil
         }
     }
 
@@ -157,15 +208,63 @@ final class ProxyServer {
         let idleTimeout = DispatchWorkItem { connection.cancel() }
         processingQueue.asyncAfter(deadline: .now() + inboundTimeout, execute: idleTimeout)
 
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
-            idleTimeout.cancel()
-            guard let self, let data else {
+        receiveRequest(connection: connection, buffer: Data(), idleTimeout: idleTimeout)
+    }
+
+    /// リクエストを「ヘッダ終端（CRLFCRLF）＋ Content-Length 分のボディ」が
+    /// 揃うまで蓄積してから処理する。1 回の receive で全体が届く保証はないため
+    /// （大きい POST ボディや分割到着で取りこぼさないように）。
+    private func receiveRequest(connection: NWConnection, buffer: Data, idleTimeout: DispatchWorkItem) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self else { connection.cancel(); return }
+
+            var buffer = buffer
+            if let data { buffer.append(data) }
+
+            if error != nil {
+                idleTimeout.cancel()
                 connection.cancel()
                 return
             }
 
-            self.processRequest(data: data, connection: connection)
+            // ヘッダが揃ったか？
+            if let headerEnd = buffer.firstRange(of: Data("\r\n\r\n".utf8)) {
+                let headerData = buffer[buffer.startIndex..<headerEnd.lowerBound]
+                let contentLength = Self.parseContentLength(from: headerData)
+                let bodyReceived = buffer.distance(from: headerEnd.upperBound, to: buffer.endIndex)
+                if bodyReceived >= contentLength {
+                    idleTimeout.cancel()
+                    self.processRequest(data: buffer, connection: connection)
+                    return
+                }
+            }
+
+            if isComplete {
+                // 相手が送信を終えた（が枠が完結していない）—持っている分で処理を試みる。
+                idleTimeout.cancel()
+                if buffer.isEmpty {
+                    connection.cancel()
+                } else {
+                    self.processRequest(data: buffer, connection: connection)
+                }
+                return
+            }
+
+            // まだ足りない—受信を継続。
+            self.receiveRequest(connection: connection, buffer: buffer, idleTimeout: idleTimeout)
         }
+    }
+
+    /// ヘッダバイト列から Content-Length を取り出す（無ければ 0）。
+    static func parseContentLength(from headerData: Data) -> Int {
+        guard let text = String(data: headerData, encoding: .utf8) else { return 0 }
+        for line in text.components(separatedBy: "\r\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            if parts.count == 2, parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" {
+                return Int(parts[1].trimmingCharacters(in: .whitespaces)) ?? 0
+            }
+        }
+        return 0
     }
 
     /// Keychain 読み取りを非対話・タイムアウト付きで実行する。
@@ -342,13 +441,8 @@ final class ProxyServer {
             requestData.append(body)
         }
 
-        // Connect to upstream via NWConnection (TLS)
-        let tlsParams = NWParameters.tls
-        let upstreamConnection = NWConnection(
-            host: NWEndpoint.Host(route.host),
-            port: .https,
-            using: tlsParams
-        )
+        // Connect to upstream (TLS:443 by default; injectable for tests).
+        let upstreamConnection = makeUpstream(route.host)
 
         // Guarantee exactly one client response even if the watchdog and a real
         // completion race each other.
@@ -408,46 +502,82 @@ final class ProxyServer {
         upstreamConnection.start(queue: processingQueue)
     }
 
+    /// 上流レスポンスを**ストリーミング**でクライアントへ転送する（SSE 等に対応）。
+    /// 各チャンクを受信即送信し、クライアント送信完了後に次のチャンクを読む
+    /// （バックプレッシャー）。`upstreamTimeout` の**非活動**タイムアウトで、
+    /// 上流の沈黙やクライアント停止による滞留を防ぐ（長時間ストリーム自体は許容）。
     private func receiveUpstreamResponse(upstream: NWConnection, clientConnection: NWConnection, requestStart: Date, route: ProxyRoute, parsed: HTTPRequestParser.ParsedRequest, watchdog: DispatchWorkItem, responseGuard: OneShot) {
-        // Receive all data from upstream then forward to client
-        // Note: NWConnection の send は中間チャンクをフラッシュしないため、
-        // ストリーミング転送ではなくバッファリング方式を使用
-        var allData = Data()
+        var firstByte = true
+        let statusLock = NSLock()
+        var status = 200
+        // ストリーム終了処理（正常完了・切断・非活動）の一度きりガード。
+        let finish = OneShot()
+        var timer: InactivityTimer!
+
+        func logAndCloseClient(truncated: Bool) {
+            guard finish.consume() else { return }
+            timer.stop()
+            upstream.cancel()
+            statusLock.lock(); let code = status; statusLock.unlock()
+            AppState.shared.proxyLogStore.append(ProxyLog(
+                timestamp: requestStart, service: route.host,
+                method: parsed.method, path: parsed.path,
+                statusCode: code, latency: Date().timeIntervalSince(requestStart),
+                isError: truncated || code >= 400
+            ))
+            clientConnection.cancel()
+        }
+
+        timer = InactivityTimer(queue: processingQueue, interval: upstreamTimeout) {
+            // 上流の沈黙 or クライアント停止 → 接続を破棄（ヘッダ送信後なので 502 は返せない）。
+            logAndCloseClient(truncated: true)
+        }
 
         func readMore() {
             upstream.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
-                if let data {
-                    allData.append(data)
+                guard let self else { upstream.cancel(); return }
+
+                if let data, !data.isEmpty {
+                    if firstByte {
+                        firstByte = false
+                        watchdog.cancel()
+                        // 最初のバイトでストリーミング開始 = この応答の所有権を確定。
+                        // 以降 connect ウォッチドッグ等は 502 を返せない。
+                        _ = responseGuard.consume()
+                        statusLock.lock(); status = self.parseStatusCode(from: data); statusLock.unlock()
+                    }
+                    clientConnection.send(content: data, completion: .contentProcessed { sendError in
+                        if sendError != nil {
+                            logAndCloseClient(truncated: true)
+                            return
+                        }
+                        if isComplete || error != nil {
+                            logAndCloseClient(truncated: error != nil)
+                            return
+                        }
+                        timer.reschedule() // 送信完了＝進捗あり → 期限を延長
+                        readMore()
+                    })
+                    return
                 }
 
+                // データ無しのコールバック
                 if isComplete || error != nil {
-                    upstream.cancel()
-                    watchdog.cancel()
-                    guard responseGuard.consume() else { return }
-                    let latency = Date().timeIntervalSince(requestStart)
-
-                    if allData.isEmpty {
-                        self?.logAndSend(
-                            clientConnection: clientConnection, requestStart: requestStart,
-                            route: route, parsed: parsed,
-                            message: error.map { "Upstream error: \($0.localizedDescription)" } ?? "Empty upstream response"
-                        )
-                        return
+                    if firstByte {
+                        // 1 バイトも受信せず終了 → エラー応答（まだヘッダ未送信）。
+                        watchdog.cancel()
+                        timer.stop()
+                        upstream.cancel()
+                        if responseGuard.consume() {
+                            self.logAndSend(
+                                clientConnection: clientConnection, requestStart: requestStart,
+                                route: route, parsed: parsed,
+                                message: error.map { "Upstream error: \($0.localizedDescription)" } ?? "Empty upstream response"
+                            )
+                        }
+                    } else {
+                        logAndCloseClient(truncated: error != nil)
                     }
-
-                    let statusCode = self?.parseStatusCode(from: allData) ?? 200
-
-                    AppState.shared.proxyLogStore.append(ProxyLog(
-                        timestamp: requestStart, service: route.host,
-                        method: parsed.method, path: parsed.path,
-                        statusCode: statusCode, latency: latency,
-                        isError: statusCode >= 400
-                    ))
-                    // requestCount は processRequest で既にインクリメント済み
-
-                    clientConnection.send(content: allData, completion: .contentProcessed { _ in
-                        clientConnection.cancel()
-                    })
                     return
                 }
 
@@ -455,6 +585,7 @@ final class ProxyServer {
             }
         }
 
+        timer.reschedule()
         readMore()
     }
 

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import Testing
 @testable import AIkeychain
 
@@ -376,6 +377,180 @@ struct ProxyHangRegressionTests {
             port: port, host: "example.com", token: server.sessionToken, timeout: 3)
         #expect(result.status == 502)
         #expect(result.elapsed < 1.5)
+    }
+}
+
+/// A local plaintext TCP "upstream" the proxy can be pointed at (via the
+/// makeUpstream factory) so streaming/framing are testable without TLS or the network.
+final class FakeUpstream {
+    let port: UInt16
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "fake.upstream", attributes: .concurrent)
+
+    init(port: UInt16, responder: @escaping (NWConnection, DispatchQueue) -> Void) throws {
+        self.port = port
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: port)!)
+        listener = try NWListener(using: params)
+        listener.newConnectionHandler = { [queue] conn in
+            conn.start(queue: queue)
+            responder(conn, queue)
+        }
+        listener.start(queue: queue)
+    }
+
+    func factory() -> (String) -> NWConnection {
+        let p = port
+        return { _ in
+            NWConnection(host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: p)!, using: .tcp)
+        }
+    }
+
+    func stop() { listener.cancel() }
+}
+
+/// Raw-socket client with split-send and timed-recv, for streaming/framing tests.
+final class RawClient {
+    private let fd: Int32
+    init?(port: UInt16) {
+        fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let r = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { Foundation.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) }
+        }
+        if r != 0 { close(fd); return nil }
+    }
+    func send(_ s: String) { _ = s.withCString { Foundation.send(fd, $0, strlen($0), 0) } }
+    /// recv with a timeout; returns whatever bytes arrived (may be empty on timeout/EOF).
+    func recv(timeout: TimeInterval) -> Data {
+        var tv = timeval(tv_sec: Int(timeout), tv_usec: Int32((timeout - floor(timeout)) * 1_000_000))
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        var buf = [UInt8](repeating: 0, count: 8192)
+        let n = Foundation.recv(fd, &buf, buf.count, 0)
+        return n > 0 ? Data(buf[0..<n]) : Data()
+    }
+    func disconnect() { Foundation.close(fd) }
+}
+
+@Suite("Proxy HTTP Streaming & Framing Tests (issue #98)")
+struct ProxyStreamingTests {
+    private func port() -> UInt16 { UInt16.random(in: 20000...20900) }
+
+    @Test("Upstream response is streamed to the client, not buffered until completion")
+    func responseIsStreamed() throws {
+        let upstreamPort = port()
+        let proxyPort = port()
+        // Upstream sends headers + first SSE event immediately, then waits 1.5s
+        // before the second event and close. A buffering proxy would deliver
+        // nothing until ~1.5s; a streaming proxy delivers event 1 right away.
+        let upstream = try FakeUpstream(port: upstreamPort) { conn, queue in
+            conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { _, _, _, _ in
+                let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\ndata: 1\n\n"
+                conn.send(content: Data(head.utf8), completion: .contentProcessed { _ in
+                    queue.asyncAfter(deadline: .now() + 1.5) {
+                        conn.send(content: Data("data: 2\n\n".utf8), completion: .contentProcessed { _ in
+                            conn.cancel()
+                        })
+                    }
+                })
+            }
+        }
+        defer { upstream.stop() }
+
+        let mock = MockKeychainService()
+        try? mock.save(value: "test-key", for: "ANTHROPIC_API_KEY")
+        let server = ProxyServer(keychainService: mock, upstreamTimeout: 10, makeUpstream: upstream.factory())
+        server.port = proxyPort
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let client = try #require(RawClient(port: proxyPort))
+        defer { client.disconnect() }
+        client.send("GET /v1/models HTTP/1.1\r\nHost: api.anthropic.com\r\n\(ProxyServer.tokenHeaderName): \(server.sessionToken)\r\n\r\n")
+
+        // Within 0.8s (well before the upstream's 1.5s gap), we must already have
+        // the status line and the first event — proof of streaming.
+        let early = client.recv(timeout: 0.8)
+        let earlyStr = String(data: early, encoding: .utf8) ?? ""
+        #expect(earlyStr.contains("200"))
+        #expect(earlyStr.contains("data: 1"))
+        #expect(!earlyStr.contains("data: 2")) // second event hasn't been sent yet
+
+        // Drain the rest.
+        var rest = Data()
+        for _ in 0..<5 {
+            let chunk = client.recv(timeout: 2)
+            if chunk.isEmpty { break }
+            rest.append(chunk)
+        }
+        #expect((String(data: rest, encoding: .utf8) ?? "").contains("data: 2"))
+    }
+
+    @Test("Full request body is framed before forwarding (split header/body sends)")
+    func requestBodyIsFullyFramed() throws {
+        let upstreamPort = port()
+        let proxyPort = port()
+        let bodyLen = 5000 // larger than a typical single segment; sent in two writes
+        // Upstream accumulates the request and reports how many body bytes it got.
+        let upstream = try FakeUpstream(port: upstreamPort) { conn, _ in
+            var buf = Data()
+            func read() {
+                conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, isComplete, _ in
+                    if let data { buf.append(data) }
+                    if let r = buf.firstRange(of: Data("\r\n\r\n".utf8)) {
+                        let cl = ProxyServer.parseContentLength(from: buf[buf.startIndex..<r.lowerBound])
+                        let got = buf.distance(from: r.upperBound, to: buf.endIndex)
+                        if got >= cl {
+                            let resp = "HTTP/1.1 200 OK\r\nX-Body-Received: \(got)\r\nContent-Length: 0\r\n\r\n"
+                            conn.send(content: Data(resp.utf8), completion: .contentProcessed { _ in conn.cancel() })
+                            return
+                        }
+                    }
+                    if isComplete { conn.cancel(); return }
+                    read()
+                }
+            }
+            read()
+        }
+        defer { upstream.stop() }
+
+        let mock = MockKeychainService()
+        try? mock.save(value: "test-key", for: "ANTHROPIC_API_KEY")
+        let server = ProxyServer(keychainService: mock, upstreamTimeout: 10, inboundTimeout: 10, makeUpstream: upstream.factory())
+        server.port = proxyPort
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let client = try #require(RawClient(port: proxyPort))
+        defer { client.disconnect() }
+        // Send headers first, then the body after a delay — exercises framing.
+        client.send("POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\n\(ProxyServer.tokenHeaderName): \(server.sessionToken)\r\nContent-Length: \(bodyLen)\r\n\r\n")
+        Thread.sleep(forTimeInterval: 0.3)
+        client.send(String(repeating: "x", count: bodyLen))
+
+        var resp = Data()
+        for _ in 0..<5 {
+            let chunk = client.recv(timeout: 3)
+            if chunk.isEmpty { break }
+            resp.append(chunk)
+            if (String(data: resp, encoding: .utf8) ?? "").contains("\r\n\r\n") { break }
+        }
+        let respStr = String(data: resp, encoding: .utf8) ?? ""
+        #expect(respStr.contains("X-Body-Received: \(bodyLen)")) // proxy forwarded the FULL body
+    }
+
+    @Test("parseContentLength reads the header case-insensitively")
+    func parseContentLengthWorks() {
+        let h = "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 42\r\nAccept: */*"
+        #expect(ProxyServer.parseContentLength(from: Data(h.utf8)) == 42)
+        let h2 = "GET / HTTP/1.1\r\nhost: x"
+        #expect(ProxyServer.parseContentLength(from: Data(h2.utf8)) == 0)
     }
 }
 

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -600,6 +600,23 @@ struct ProxyStreamingTests {
         let resp = String(data: client.recv(timeout: 3), encoding: .utf8) ?? ""
         #expect(resp.contains("400"))
     }
+
+    @Test("Transfer-Encoding request is rejected with 400 (smuggling defense)")
+    func transferEncodingRejected() throws {
+        let proxyPort = port()
+        let server = ProxyServer(keychainService: MockKeychainService(), inboundTimeout: 10)
+        server.port = proxyPort
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let client = try #require(RawClient(port: proxyPort))
+        defer { client.disconnect() }
+        client.send("POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\n\(ProxyServer.tokenHeaderName): \(server.sessionToken)\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+        let resp = String(data: client.recv(timeout: 3), encoding: .utf8) ?? ""
+        #expect(resp.contains("400"))
+        #expect(resp.contains("Transfer-Encoding"))
+    }
 }
 
 @Suite("Header Injection Security Tests")

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -552,6 +552,54 @@ struct ProxyStreamingTests {
         let h2 = "GET / HTTP/1.1\r\nhost: x"
         #expect(ProxyServer.parseContentLength(from: Data(h2.utf8)) == 0)
     }
+
+    @Test("contentLengthField validates: absent/present/invalid (non-numeric, negative, conflicting)")
+    func contentLengthValidation() {
+        func field(_ s: String) -> ProxyServer.ContentLengthField {
+            ProxyServer.contentLengthField(from: Data(s.utf8))
+        }
+        #expect(field("GET / HTTP/1.1\r\nHost: x") == .absent)
+        #expect(field("POST / HTTP/1.1\r\nContent-Length: 10") == .present)
+        #expect(field("POST / HTTP/1.1\r\nContent-Length: abc") == .invalid)
+        #expect(field("POST / HTTP/1.1\r\nContent-Length: -5") == .invalid)
+        #expect(field("POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 20") == .invalid) // smuggling
+        #expect(field("POST / HTTP/1.1\r\nContent-Length: 10\r\nContent-Length: 10") == .present) // duplicate-equal OK
+    }
+
+    @Test("Oversized request is rejected with 413")
+    func oversizedRequestRejected() throws {
+        let proxyPort = port()
+        // 8KB cap (floor). Send a request larger than that.
+        let server = ProxyServer(keychainService: MockKeychainService(),
+                                 inboundTimeout: 10, maxRequestBytes: 8 * 1024)
+        server.port = proxyPort
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let client = try #require(RawClient(port: proxyPort))
+        defer { client.disconnect() }
+        let big = String(repeating: "y", count: 20_000)
+        client.send("POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\nContent-Length: 20000\r\n\r\n\(big)")
+        let resp = String(data: client.recv(timeout: 3), encoding: .utf8) ?? ""
+        #expect(resp.contains("413"))
+    }
+
+    @Test("Invalid (conflicting) Content-Length is rejected with 400")
+    func invalidContentLengthRejected() throws {
+        let proxyPort = port()
+        let server = ProxyServer(keychainService: MockKeychainService(), inboundTimeout: 10)
+        server.port = proxyPort
+        try server.start()
+        defer { server.stop() }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let client = try #require(RawClient(port: proxyPort))
+        defer { client.disconnect() }
+        client.send("POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\nContent-Length: 5\r\nContent-Length: 9\r\n\r\nhello")
+        let resp = String(data: client.recv(timeout: 3), encoding: .utf8) ?? ""
+        #expect(resp.contains("400"))
+    }
 }
 
 @Suite("Header Injection Security Tests")


### PR DESCRIPTION
## 概要
Closes #98

Proxy モードの HTTP correctness を改善。**DP Keychain 移行は CLI 連携（Standard / Secret Reference モードの `security` 読み取り）を壊すため、ユーザー判断で本 issue から除外**（#98 コメント参照）。本 PR は HTTP まわりの実装に絞る。

## 変更内容

| # | 変更 | 効果 |
|---|------|------|
| 1 | 上流レスポンスの**ストリーミング転送** | 全バッファ → チャンク毎に即クライアント転送。**Claude/OpenAI の SSE ストリーミング応答が流れる**ようになる（従来は完了までクライアントに何も届かなかった） |
| 2 | **非活動タイムアウト**（`InactivityTimer`） | 受信/送信の進捗ごとに期限をリセット。長時間ストリームを許容しつつ、上流の沈黙やクライアント停止での滞留を防ぐ |
| 3 | バックプレッシャー | クライアント送信完了後に次チャンクを読む。遅いクライアントでメモリが無制限に膨らまない。送信エラーでストリーム破棄（送信ウォッチドッグ相当） |
| 4 | リクエストの**フレーミング** | ヘッダ終端 + Content-Length 分のボディが揃うまで蓄積してから処理。大きい/分割到着の POST ボディを取りこぼさない |
| 5 | `makeUpstream` ファクトリ（既定 TLS:443）注入 | テスト容易化（ローカル平文 fake upstream で検証可能に） |

## テスト計画
- [x] `swift test` **79/79 PASS**
- [x] 回帰テスト（ローカル fake upstream を注入、実 TCP）:
  - **ストリーミング**: 上流がヘッダ + 1 イベント送信 → 1.5s 待機 → 2 イベント目。プロキシは待機中（0.8s 時点）に既に 1 イベント目を配信済み = バッファせずストリームしている直接証明
  - **フレーミング**: ヘッダと 5000B ボディを分割送信した POST で、上流が**全ボディを受信**（`X-Body-Received: 5000`）= プロキシが完全なリクエストを組み立ててから転送
  - `parseContentLength` の単体検証
- 既存の #96 ハング回帰テスト・全 Proxy テストも引き続きグリーン

## スコープ外
- DP Keychain 移行（CLI 連携と非両立のため中止）。consent 根治が将来必要なら CLI 連携を壊さない別アプローチ（署名済みアプリの ACL 信頼登録等）を別途検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)
