### PR TITLE
feat(cli): akc doctor に重複エントリ検出を追加 (#91)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -35,7 +35,8 @@ akc set GITHUB_TOKEN      # hidden prompt (or pipe via stdin); the value never
                           # via stdin as hex. Overwrites in place, no duplicates
 akc delete GITHUB_TOKEN
 
-# Diagnose your setup (env + ~/.zshrc), including the -a "$USER" pitfall
+# Diagnose your setup (env + ~/.zshrc), the -a "$USER" pitfall, and
+# ambiguous duplicate keychain entries (same service name, multiple accounts)
 akc doctor
 
 # Print the usage guide for AI agents

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aikeychain",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI KeyChain CLI & MCP server — resolve keychain:// secret references from macOS Keychain and let AI agents use them safely",
   "type": "module",
   "bin": {

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -5,7 +5,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { collectRefs, resolveRefs } from './run.js';
-import { listKeys, resolveKey, KeychainError } from './keychain.js';
+import { listKeys, resolveKey, listAmbiguousDuplicates, KeychainError } from './keychain.js';
 
 /** Extract keychain://KEY and `security find-generic-password -s "KEY"` keys from shell config text. */
 export function scanShellConfig(text) {
@@ -57,6 +57,30 @@ export async function runDoctor({ env = process.env, zshrcPath } = {}) {
     } else {
       throw err;
     }
+  }
+
+  // Ambiguous duplicate entries (issue #91): same service name, multiple accts.
+  try {
+    const dups = await listAmbiguousDuplicates();
+    if (dups.length === 0) {
+      check('duplicate entries', true, 'no ambiguous duplicate keychain entries');
+    } else {
+      check(
+        'duplicate entries',
+        false,
+        `${dups.length} service(s) have duplicate entries — \`security -s NAME -w\` is ambiguous:\n` +
+          dups
+            .map(
+              (d) =>
+                `       - ${d.service}: acct=[${d.accounts.map((a) => `"${a}"`).join(', ')}]` +
+                ` → remove the stale one: security delete-generic-password -s "${d.service}" -a "<acct>"`
+            )
+            .join('\n')
+      );
+    }
+  } catch (err) {
+    if (!(err instanceof KeychainError)) throw err;
+    // keychain access already reported above; skip duplicate scan on failure
   }
 
   // Environment keychain:// references

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -179,6 +179,40 @@ export async function listKeys() {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Detect ambiguous duplicate entries: env-var-shaped service names that have
+ * more than one generic-password item with distinct `acct` values. For such a
+ * service, `security find-generic-password -s NAME -w` returns an unspecified
+ * one of them — the root cause of issue #91 ("registered but invalid token").
+ *
+ * Secret values are never read; only the `acct` attribute (from dump-keychain)
+ * is reported so the user can identify and remove the stale entry.
+ *
+ * Returns [{ service, accounts: [...] }] sorted by service, accounts sorted.
+ */
+export function findAmbiguousDuplicates(records) {
+  const byService = new Map();
+  for (const { service, account } of records) {
+    if (!service || service === GUI_SERVICE) continue;
+    if (!MANUAL_NAME_PATTERN.test(service)) continue;
+    if (!byService.has(service)) byService.set(service, new Set());
+    byService.get(service).add(account ?? '');
+  }
+  return [...byService.entries()]
+    .filter(([, accts]) => accts.size > 1)
+    .map(([service, accts]) => ({ service, accounts: [...accts].sort() }))
+    .sort((a, b) => a.service.localeCompare(b.service));
+}
+
+/** Convenience wrapper around the live keychain dump (names/accts only). */
+export async function listAmbiguousDuplicates() {
+  const r = await security(['dump-keychain']);
+  if (!r.ok) {
+    throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
+  }
+  return findAmbiguousDuplicates(parseDump(r.stdout));
+}
+
 export function maskValue(value) {
   return `****** (${value.length} chars)`;
 }

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseDump, maskValue, MANUAL_NAME_PATTERN, GUI_SERVICE } from '../src/keychain.js';
+import {
+  parseDump,
+  maskValue,
+  findAmbiguousDuplicates,
+  MANUAL_NAME_PATTERN,
+  GUI_SERVICE,
+} from '../src/keychain.js';
 import { collectRefs } from '../src/run.js';
 import { scanShellConfig } from '../src/doctor.js';
 
@@ -47,6 +53,32 @@ test('MANUAL_NAME_PATTERN accepts env-var names and rejects bundle ids', () => {
 
 test('maskValue never includes the value', () => {
   assert.equal(maskValue('super-secret'), '****** (12 chars)');
+});
+
+test('findAmbiguousDuplicates flags same-service multi-acct entries (issue #91)', () => {
+  // The exact #91 scenario: CLOUDFLARE_API_TOKEN exists twice with different accts.
+  const records = [
+    { service: 'CLOUDFLARE_API_TOKEN', account: 'takehiro' },
+    { service: 'CLOUDFLARE_API_TOKEN', account: 'CLOUDFLARE_API_TOKEN' },
+    { service: 'GITHUB_TOKEN', account: 'GITHUB_TOKEN' }, // single → fine
+    { service: GUI_SERVICE, account: 'ANTHROPIC_API_KEY' }, // GUI store → ignored
+    { service: GUI_SERVICE, account: 'OPENAI_API_KEY' },
+    { service: 'com.apple.foo', account: 'a' }, // non-env-var service → ignored
+    { service: 'com.apple.foo', account: 'b' },
+  ];
+  const dups = findAmbiguousDuplicates(records);
+  assert.equal(dups.length, 1);
+  assert.equal(dups[0].service, 'CLOUDFLARE_API_TOKEN');
+  assert.deepEqual(dups[0].accounts, ['CLOUDFLARE_API_TOKEN', 'takehiro']);
+});
+
+test('findAmbiguousDuplicates returns empty when every service is unique', () => {
+  const records = [
+    { service: 'GITHUB_TOKEN', account: 'GITHUB_TOKEN' },
+    { service: 'QIITA_TOKEN', account: 'takehiro' },
+    { service: GUI_SERVICE, account: 'GITHUB_TOKEN' }, // app+manual for same key is not a same-service dup
+  ];
+  assert.deepEqual(findAmbiguousDuplicates(records), []);
 });
 
 test('collectRefs picks only keychain:// values', () => {

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -22,7 +22,7 @@ npx aikeychain <command>
 | `akc get <KEY>` | `keychain://<KEY>` 参照を出力（`--reveal` で生値） |
 | `akc set <KEY>` | キー登録・更新（隠し入力 or stdin。値は `security -i` に stdin + hex で渡すため**どのプロセスの argv にも露出しない**。`-U` 相当の上書きで重複防止） |
 | `akc delete <KEY>` | キー削除 |
-| `akc doctor` | env / `~/.zshrc` の参照診断（`-a "$USER"` 落とし穴の検出含む） |
+| `akc doctor` | env / `~/.zshrc` の参照診断（`-a "$USER"` 落とし穴 + 同一サービス名の**重複エントリ検出**を含む。値は読まない） |
 | `akc guide` | AI エージェント向け使い方ガイド表示 |
 | `akc mcp` | MCP サーバー起動（stdio） |
 


### PR DESCRIPTION
## 概要
Refs #91

#91（同一サービス名で acct 違いの重複エントリにより `security -s NAME -w` が無効値を引く）の最後のピースとして、**重複エントリを非破壊的に検出**する機能を `akc doctor` に追加。

## #91 の解決状況（本 PR で完了）

| 対策（#91 の提案） | 状態 |
|---|---|
| 取得を `acct` 非依存に（サービス名のみ） | ✅ 済み: `akc` / `scripts/akc` の 2 段ルックアップ、各 `CLAUDE.md` の取得例 |
| 保存 `acct` をサービス名に統一 | ✅ 済み: GUI `KeychainService.save` は `acct = キー名`で一貫保存 |
| `-a "$USER"` 落とし穴の検出 | ✅ 済み: `akc doctor` が `.zshrc` を走査して警告 |
| **重複エントリの検出** | ✅ **本 PR**: `akc doctor` が同一サービス名の複数 acct を検出・報告 |
| 重複の自動削除/マイグレーション | 意図的に非対応（破壊的なため。検出 + 手動削除コマンドの提示に留める） |

## 変更内容
| ファイル | 変更 |
|---|---|
| `cli/src/keychain.js` | `findAmbiguousDuplicates` / `listAmbiguousDuplicates` を追加。dump-keychain から env-var 形式サービス名で acct 複数のものを列挙（**値は読まない**、acct 属性のみ） |
| `cli/src/doctor.js` | doctor に「duplicate entries」チェックを追加。検出時は acct 一覧と削除コマンド例を提示 |
| `cli/test/unit.test.js` | #91 再現シナリオの検出 + ユニーク時空の単体テスト |
| `cli/package.json` | 0.2.0 → 0.3.0 |
| docs | doctor の説明に重複検出を追記 |

## テスト計画
- [x] `npm test` **24/24 PASS**
- [x] 実 keychain で `akc doctor` 実行 → 「no ambiguous duplicate keychain entries」（現環境は #91 暫定対処で既にクリーン）。`-a "$USER"` 警告は従来どおり検出
- [x] 検出ロジックは #91 の実シナリオ（`CLOUDFLARE_API_TOKEN` × acct 2 種）を単体テストで検証

## 設計方針
- **非破壊的**: 自動削除はしない。`security delete-generic-password -s "NAME" -a "<acct>"` の例を示し、ユーザーが acct を確認して手動で削除
- シークレット値は一切読まない（acct 属性のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
