### PR TITLE
chore(cli): npm publish-readiness（macOS 専用宣言 + publish 前テスト）

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -15,8 +15,12 @@
   "engines": {
     "node": ">=18"
   },
+  "os": [
+    "darwin"
+  ],
   "scripts": {
-    "test": "node --test 'test/*.test.js'"
+    "test": "node --test 'test/*.test.js'",
+    "prepublishOnly": "npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 概要
`aikeychain` CLI を npm 公開できる状態に仕上げる小改善。

## 変更内容
- `"os": ["darwin"]` を追加 — CLI は macOS の `security` コマンドに依存するため、非 macOS への誤インストールを防ぐ
- `prepublishOnly: "npm test"` — 公開前に必ずテストを通す

## 検証
- `npm test` 24/24 PASS
- `npm publish --dry-run`: パッケージ内容を検証（8 files、`bin/akc.js` + `src/*` + README、11.8kB）

## 補足（公開の前提）
実際の `npm publish` は **npm 認証が必要**（現状 `ENEEDAUTH`）。マージ後、npm にログイン済みの環境で `cd cli && npm publish` を実行すると `npx aikeychain` / `claude mcp add aikeychain -- npx -y aikeychain mcp` が利用可能になる。パッケージ名 `aikeychain` は未取得（取得可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
