### PR TITLE
fix(editor): キー登録の Service 必須をやめ任意プリセット化（#102）

### DIFF
--- a/AIkeychain/Models/CustomKeyStore.swift
+++ b/AIkeychain/Models/CustomKeyStore.swift
@@ -55,7 +55,12 @@ final class CustomKeyStore {
     /// プリセットキーのカテゴリ上書き（envVarName → カテゴリ識別子）
     var categoryOverrides: [String: String] = [:]
 
-    private init() {
+    private let defaults: UserDefaults
+
+    /// テストでは独立した `UserDefaults(suiteName:)` を注入して、実環境の
+    /// 設定を汚さずに永続化挙動を検証できる。
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
         load()
     }
 
@@ -137,32 +142,32 @@ final class CustomKeyStore {
     // MARK: - Persistence
 
     private func load() {
-        if let data = UserDefaults.standard.data(forKey: Self.categoriesKey),
+        if let data = defaults.data(forKey: Self.categoriesKey),
            let decoded = try? JSONDecoder().decode([CustomCategory].self, from: data) {
             categories = decoded
         }
-        if let data = UserDefaults.standard.data(forKey: Self.keysKey),
+        if let data = defaults.data(forKey: Self.keysKey),
            let decoded = try? JSONDecoder().decode([CustomKey].self, from: data) {
             keys = decoded
         }
-        if let dict = UserDefaults.standard.dictionary(forKey: Self.overridesKey) as? [String: String] {
+        if let dict = defaults.dictionary(forKey: Self.overridesKey) as? [String: String] {
             categoryOverrides = dict
         }
     }
 
     private func saveCategories() {
         if let data = try? JSONEncoder().encode(categories) {
-            UserDefaults.standard.set(data, forKey: Self.categoriesKey)
+            defaults.set(data, forKey: Self.categoriesKey)
         }
     }
 
     private func saveKeys() {
         if let data = try? JSONEncoder().encode(keys) {
-            UserDefaults.standard.set(data, forKey: Self.keysKey)
+            defaults.set(data, forKey: Self.keysKey)
         }
     }
 
     private func saveOverrides() {
-        UserDefaults.standard.set(categoryOverrides, forKey: Self.overridesKey)
+        defaults.set(categoryOverrides, forKey: Self.overridesKey)
     }
 }

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -38,9 +38,10 @@ final class KeyEditorViewModel {
         return trimmed.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil
     }
 
+    /// 保存可能条件。Service は任意のプリセット（クイック補完）に過ぎないため
+    /// 必須ではない。必須は「カテゴリ + 妥当な環境変数名 + 値」。
     var canSave: Bool {
-        selectedService != nil
-        && selectedCategorySelection != nil
+        selectedCategorySelection != nil
         && !tokenValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         && isValidEnvVarName
     }

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -93,21 +93,10 @@ final class KeyEditorViewModel {
 
             if let key = editingKey {
                 // 既存キーの編集
-                if key.service != nil {
-                    let defaultCategory = key.service!.category
-                    let overrideValue: String? = {
-                        switch selectedCategorySelection {
-                        case .builtin(let cat) where cat == defaultCategory:
-                            return nil  // デフォルトに戻す → 上書き削除
-                        case .builtin(let cat):
-                            return "builtin:\(cat.rawValue)"
-                        case .custom(let id):
-                            return "custom:\(id.uuidString)"
-                        case .all, .activity, .none:
-                            return nil
-                        }
-                    }()
-                    customStore.setCategoryOverride(envVarName: trimmedEnvVar, value: overrideValue)
+                if let service = key.service {
+                    customStore.setCategoryOverride(
+                        envVarName: trimmedEnvVar,
+                        value: categoryOverrideValue(defaultCategory: service.category))
                 } else if let customKey = key.customKey {
                     // カスタムキーのカテゴリ変更
                     var updated = customKey
@@ -115,9 +104,15 @@ final class KeyEditorViewModel {
                     customStore.updateKey(updated)
                 }
             } else {
-                // 新規キー: envVarName がプリセットに一致しない場合は CustomKey として保存
-                let matchesPreset = ServiceType.allCases.contains { $0.envVarName == trimmedEnvVar }
-                if !matchesPreset {
+                // 新規キー
+                if let preset = ServiceType.allCases.first(where: { $0.envVarName == trimmedEnvVar }) {
+                    // envVarName がプリセットに一致 → プリセットキーとして一覧表示される。
+                    // 選択カテゴリがプリセット既定と異なる場合のみカテゴリ上書きを保存する
+                    // （Service 未選択でカテゴリだけ変えたケースを取りこぼさない / #102）。
+                    customStore.setCategoryOverride(
+                        envVarName: trimmedEnvVar,
+                        value: categoryOverrideValue(defaultCategory: preset.category))
+                } else {
                     let customKey = CustomKey(
                         envVarName: trimmedEnvVar,
                         displayName: selectedService?.displayName ?? trimmedEnvVar,
@@ -145,6 +140,21 @@ final class KeyEditorViewModel {
     }
 
     // MARK: - Private
+
+    /// 選択カテゴリをプリセット上書き文字列に変換する。
+    /// プリセット既定と同じなら nil（= 上書きを保存しない/削除）。
+    private func categoryOverrideValue(defaultCategory: KeyCategory) -> String? {
+        switch selectedCategorySelection {
+        case .builtin(let cat) where cat == defaultCategory:
+            return nil
+        case .builtin(let cat):
+            return "builtin:\(cat.rawValue)"
+        case .custom(let id):
+            return "custom:\(id.uuidString)"
+        case .all, .activity, .none:
+            return nil
+        }
+    }
 
     private func resolveCategoryId() -> UUID {
         switch selectedCategorySelection {

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -30,19 +30,27 @@ struct KeyEditorView: View {
 
             // Form
             Form {
-                // Service picker
+                // Optional quick-preset: picking a known service auto-fills the
+                // env var name + category below. Not required — a category and
+                // environment variable name are enough.
                 if !viewModel.isEditing {
-                    Picker("Service", selection: $viewModel.selectedService) {
-                        Text("Select a service...")
-                            .foregroundStyle(.secondary)
-                            .tag(ServiceType?.none)
-                        ForEach(ServiceType.allCases) { service in
-                            Label(service.displayName, systemImage: service.systemImage)
-                                .tag(ServiceType?.some(service))
+                    Section {
+                        Picker("Quick preset", selection: $viewModel.selectedService) {
+                            Text("None (custom key)")
+                                .foregroundStyle(.secondary)
+                                .tag(ServiceType?.none)
+                            ForEach(ServiceType.allCases) { service in
+                                Label(service.displayName, systemImage: service.systemImage)
+                                    .tag(ServiceType?.some(service))
+                            }
                         }
-                    }
-                    .onChange(of: viewModel.selectedService) {
-                        viewModel.onServiceChange()
+                        .onChange(of: viewModel.selectedService) {
+                            viewModel.onServiceChange()
+                        }
+                    } footer: {
+                        Text("Optional. Pick a known service to auto-fill the fields below, or just set a category and variable name.")
+                            .font(AppFonts.caption)
+                            .foregroundStyle(.secondary)
                     }
                 } else if let service = viewModel.selectedService {
                     LabeledContent("Service") {
@@ -54,7 +62,7 @@ struct KeyEditorView: View {
                     }
                 }
 
-                // Category
+                // Category (required)
                 Picker("Category", selection: $viewModel.selectedCategorySelection) {
                     Text("Select a category...")
                         .foregroundStyle(.secondary)
@@ -72,7 +80,7 @@ struct KeyEditorView: View {
                     }
                 }
 
-                // Env var name
+                // Env var name (required)
                 TextField("Environment Variable", text: $viewModel.envVarName)
                     .font(AppFonts.code)
 

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import AIkeychain
 
@@ -184,5 +185,71 @@ struct KeyEditorViewModelTests {
         let vm = KeyEditorViewModel(editingKey: key, keychainService: mock)
         #expect(vm.tokenValue == "existing-value")
         #expect(vm.isEditing == true)
+    }
+
+    /// Build a CustomKeyStore backed by an isolated UserDefaults suite so tests
+    /// never touch the real app state.
+    private func isolatedStore() -> (CustomKeyStore, UserDefaults, String) {
+        let suite = "test-keyeditor-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        return (CustomKeyStore(defaults: defaults), defaults, suite)
+    }
+
+    @Test("Save with NO service + custom env var creates a CustomKey with the chosen category (#102)")
+    func saveNoServiceCreatesCustomKey() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mock = MockKeychainService()
+        let vm = KeyEditorViewModel(keychainService: mock, customStore: store)
+        vm.selectedService = nil
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.envVarName = "MY_CUSTOM_KEY"
+        vm.tokenValue = "secret-1"
+        try vm.save()
+
+        #expect(mock.store["MY_CUSTOM_KEY"] == "secret-1")
+        let created = store.keys.first { $0.envVarName == "MY_CUSTOM_KEY" }
+        #expect(created != nil)
+        #expect(created?.categoryId == KeyCategory.devTools.stableId)
+        #expect(created?.displayName == "MY_CUSTOM_KEY")
+    }
+
+    @Test("Save with NO service but a preset-named env var preserves the chosen category via override (#102)")
+    func saveNoServicePresetNamePreservesCategory() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mock = MockKeychainService()
+        let vm = KeyEditorViewModel(keychainService: mock, customStore: store)
+        vm.selectedService = nil
+        // GITHUB_TOKEN is a preset (default category Code & Git) but the user
+        // deliberately files it under Developer Tools without picking a service.
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.envVarName = "GITHUB_TOKEN"
+        vm.tokenValue = "ghp_test"
+        try vm.save()
+
+        #expect(mock.store["GITHUB_TOKEN"] == "ghp_test")
+        // The chosen category must be persisted as an override, not silently lost.
+        #expect(store.overriddenCategory(for: "GITHUB_TOKEN") == .builtin(.devTools))
+        // It is a preset, so no CustomKey is created.
+        #expect(store.keys.contains { $0.envVarName == "GITHUB_TOKEN" } == false)
+    }
+
+    @Test("Save with NO service + preset env var + matching default category writes no override")
+    func saveNoServicePresetDefaultCategoryNoOverride() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mock = MockKeychainService()
+        let vm = KeyEditorViewModel(keychainService: mock, customStore: store)
+        vm.selectedService = nil
+        vm.selectedCategorySelection = .builtin(.codeAndGit) // GitHub's default
+        vm.envVarName = "GITHUB_TOKEN"
+        vm.tokenValue = "ghp_test"
+        try vm.save()
+
+        #expect(store.overriddenCategory(for: "GITHUB_TOKEN") == nil)
     }
 }

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -115,11 +115,22 @@ struct KeyEditorViewModelTests {
         #expect(vm.prefixWarning == nil)
     }
 
-    @Test("Cannot save without service selection")
-    func cannotSaveNoService() {
+    @Test("Can save WITHOUT a service when category + env var + value are set (issue #102)")
+    func canSaveNoService() {
         let vm = KeyEditorViewModel(keychainService: MockKeychainService())
+        vm.selectedService = nil // Service is an optional preset, not required
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.envVarName = "MY_CUSTOM_KEY"
         vm.tokenValue = "test"
-        vm.envVarName = "TEST_KEY"
+        #expect(vm.canSave == true)
+    }
+
+    @Test("Cannot save with an invalid env var name even with a category")
+    func cannotSaveInvalidEnvVar() {
+        let vm = KeyEditorViewModel(keychainService: MockKeychainService())
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.envVarName = "bad name!" // not a valid shell identifier
+        vm.tokenValue = "test"
         #expect(vm.canSave == false)
     }
 


### PR DESCRIPTION
## 概要
Closes #102

キー登録で **Service と Category の二重入力**を解消。Service を必須から**任意のクイック・プリセット**に格下げし、必須項目を「カテゴリ + 環境変数名 + 値」にする。

## なぜ
- `Category` は `ServiceType.category` で **Service から自動導出**されるのに、編集画面は両方を別々に選ばせていた
- `KeyEditorViewModel.canSave` が `selectedService != nil` を要求 → **新規キーは Service を選ばないと保存不可**。カスタムキー登録も「適当な Service を選んでから書き換える」回りくどい導線だった
- CLI(`akc`)・Proxy・Keychain ルックアップはいずれも **envVarName（= Keychain の account）でのみ動作**し、UI の Service には非依存（`ProxyRoute` は host→envVarName、`security` は `-s com.aieo.aikeychain -a <envVar>`）

## 変更内容
| ファイル | 変更 |
|---|---|
| `KeyEditorViewModel.swift` | `canSave` から `selectedService != nil` を削除。必須は category + 妥当な envVarName + 値 |
| `KeyEditorView.swift` | Service ピッカーを「Quick preset（任意）」に。既定を "None (custom key)"、補足文を追加。選択時の envVarName/カテゴリ自動補完は維持 |
| `ModelTests.swift` | 「Service 無しでも保存可」「不正な envVarName は不可」を追加、旧「Service 必須」テストを置換 |

## テスト計画
- [x] `swift test` **84/84 PASS**
- [x] `canSave`: Service 無し + カテゴリ + envVarName + 値 → true / カテゴリ無し → false / 不正 envVarName → false / 空値 → false
- [x] 既存の preset 保存・編集・prefix 警告は不変
- [ ] **GUI 手動確認**（Add Key シート）: Service を選ばずカテゴリ + 変数名 + 値だけで保存できること、Service を選べば従来どおり自動補完されること

## 非対象
- `ServiceType` プリセット自体の削除（既知プロバイダのワンタップ補完は残す）
- Keychain の `kSecAttrService`（固定値 `com.aieo.aikeychain`・CLI/Proxy が依存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
