### PR TITLE
feat(cli): akc init をデフォルトでマシン全体反映に (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The [`aikeychain`](cli/) npm package provides a standalone CLI (`akc`) and an MC
 
 ```bash
 npm install -g aikeychain    # or: npx aikeychain
-akc init                     # set up AI-agent discovery (CLAUDE.md/AGENTS.md + MCP)
+akc init                     # set up AI-agent discovery machine-wide (Claude + Codex)
 
 # Secret Reference workflow
 export OPENAI_API_KEY=keychain://OPENAI_API_KEY
@@ -120,10 +120,10 @@ akc set GITHUB_TOKEN         # hidden prompt, overwrites in place
 akc doctor                   # diagnose env + ~/.zshrc references
 ```
 
-Let AI agents (Claude Code, Codex, ...) use AI KeyChain correctly — run **`akc init`** once and every future session discovers it via the MCP tools and the instructions block written into `CLAUDE.md`/`AGENTS.md`. To register the MCP server manually instead:
+Let AI agents (Claude Code, Codex, ...) use AI KeyChain correctly — run **`akc init`** once and every future session on the machine discovers it via the MCP tools and the instructions block written into `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md`. To register the Claude MCP server manually instead:
 
 ```bash
-claude mcp add aikeychain -- akc mcp
+claude mcp add --scope user aikeychain -- akc mcp
 ```
 
 The MCP tools (`usage_guide`, `list_keys`, `check_key`, `get_secret_reference`, `set_secret`, `delete_secret`, `doctor`) **never return raw secret values to the model** — agents get `keychain://` references and run workloads through `akc run`. See [cli/README.md](cli/README.md) for details.

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,13 +11,15 @@ akc init                    # teach the AI agents on this machine to use it
 
 ## For AI agents (Claude, Codex, …)
 
-Run **`akc init`** once. It:
+Run **`akc init`** once. It sets up **every AI session on this machine** (AI KeyChain is not a per-project tool):
 
-1. Writes a managed instructions block into `CLAUDE.md` and `AGENTS.md` (idempotent) so agents in this project learn the rules.
-2. Registers the MCP server with Claude Code (`claude mcp add aikeychain -- akc mcp`).
-3. Prints the Codex config snippet and next steps.
+1. Writes a managed instructions block into `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md` (idempotent) so agents learn the rules.
+2. Registers the MCP server with Claude Code at **user scope** (`claude mcp add --scope user aikeychain -- akc mcp`) — every project/session sees it.
+3. Adds the MCP server to `~/.codex/config.toml` for Codex.
 
-After that, every new AI session discovers AI KeyChain via the MCP tools (`usage_guide`, `list_keys`, `get_secret_reference`, …) and the instructions block — no per-session setup. `akc init --print` previews everything without writing; `--no-register` skips MCP registration; `--global` targets `~/.claude/CLAUDE.md`.
+After that, every new Claude/Codex session discovers AI KeyChain via the MCP tools (`usage_guide`, `list_keys`, `get_secret_reference`, …) and the instructions block — no per-session setup. (Already-running sessions need a restart.)
+
+Flags: `--print` previews without writing, `--no-register` skips MCP registration, `--local` scopes everything to the current project (`./CLAUDE.md` + `./AGENTS.md` + a local-scope Claude MCP) instead of machine-wide.
 
 ## Why
 

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -23,7 +23,7 @@ const { version } = require('../package.json');
 const USAGE = `akc — AI KeyChain CLI (secret references, key management, MCP server)
 
 Usage:
-  akc init [--print] [--no-register] [--global]
+  akc init [--print] [--no-register] [--local]
   akc run [--dry-run] -- <command> [args...]
   akc list
   akc check <KEY>
@@ -37,9 +37,10 @@ Usage:
   akc help
 
 Commands:
-  init     Set up agent discoverability: write CLAUDE.md/AGENTS.md instructions
-           and register the MCP server (--print previews, --no-register skips it,
-           --global targets ~/.claude/CLAUDE.md)
+  init     Set up agent discoverability machine-wide: write ~/.claude/CLAUDE.md
+           + ~/.codex/AGENTS.md instructions, register the MCP server (Claude user
+           scope + ~/.codex/config.toml). --local scopes it to the current project,
+           --print previews, --no-register skips MCP registration.
   run      Resolve keychain:// env references and execute a command
   list     List known key names (never prints values)
   check    Check whether a key exists and in which store
@@ -51,7 +52,7 @@ Commands:
   mcp      Start the MCP server on stdio (for Claude Code / Codex etc.)
 
 Examples:
-  akc init                        # teach AI agents on this machine to use akc
+  akc init                        # set up every AI session on this machine (Claude + Codex)
   export OPENAI_API_KEY=keychain://OPENAI_API_KEY
   akc run -- claude
   akc set GITHUB_TOKEN            # prompts for the value (hidden)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aikeychain",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI KeyChain CLI & MCP server — resolve keychain:// secret references from macOS Keychain and let AI agents (Claude, Codex) use them safely. Run `akc init` to set up discovery.",
   "type": "module",
   "bin": {

--- a/cli/src/agent-setup.js
+++ b/cli/src/agent-setup.js
@@ -113,6 +113,12 @@ export function upsertCodexBlock(content) {
   if (existing.includes(CODEX_BLOCK_BEGIN)) {
     return { content: existing, action: 'unchanged' };
   }
+  // A hand-written [mcp_servers.aikeychain] table (without our markers) would
+  // become a duplicate table key — invalid TOML — if we appended ours. Refuse
+  // and let the caller tell the user to merge manually.
+  if (/^\s*\[mcp_servers\.aikeychain\]\s*$/m.test(existing)) {
+    return { content: existing, action: 'conflict' };
+  }
   const sep = existing.length === 0 ? '' : existing.endsWith('\n') ? '\n' : '\n\n';
   return { content: `${existing}${sep}${renderCodexBlock()}\n`, action: 'created' };
 }

--- a/cli/src/agent-setup.js
+++ b/cli/src/agent-setup.js
@@ -46,48 +46,73 @@ function countOccurrences(haystack, needle) {
   return count;
 }
 
-/** Remove every complete BEGIN..END block (assumes balanced, non-overlapping markers). */
-function removeCompleteBlocks(content) {
+/** Remove every complete begin..end block (assumes balanced, non-overlapping markers). */
+function removeCompleteBlocks(content, begin, end) {
   let result = content;
-  let beginIdx = result.indexOf(BLOCK_BEGIN);
+  let beginIdx = result.indexOf(begin);
   while (beginIdx !== -1) {
-    const endIdx = result.indexOf(BLOCK_END, beginIdx);
+    const endIdx = result.indexOf(end, beginIdx);
     if (endIdx === -1) break; // shouldn't happen when markers are balanced
-    result = result.slice(0, beginIdx) + result.slice(endIdx + BLOCK_END.length);
-    beginIdx = result.indexOf(BLOCK_BEGIN);
+    result = result.slice(0, beginIdx) + result.slice(endIdx + end.length);
+    beginIdx = result.indexOf(begin);
   }
   return result;
 }
 
 /**
- * Insert or replace the managed block in `content`. Idempotent and
+ * Insert or replace a marker-delimited block in `content`. Idempotent and
  * non-destructive:
- *  - no block         → append one
+ *  - no block          → append one
  *  - one+ complete blocks → canonicalize to exactly one (dedupes duplicates)
- *  - unbalanced markers (dangling BEGIN/END from hand-editing) → refuse to edit
- *    so no user content is ever truncated.
+ *  - unbalanced markers (dangling begin/end) → refuse to edit (no truncation)
  * Returns { content, action: 'created' | 'updated' | 'unchanged' | 'malformed' }.
  */
-export function upsertManagedBlock(content) {
-  const block = renderManagedBlock();
+export function upsertDelimitedBlock(content, begin, end, fullBlock) {
   const existing = content ?? '';
-
-  const begins = countOccurrences(existing, BLOCK_BEGIN);
-  const ends = countOccurrences(existing, BLOCK_END);
+  const begins = countOccurrences(existing, begin);
+  const ends = countOccurrences(existing, end);
 
   if (begins !== ends) {
-    // Malformed (e.g. a dangling BEGIN with no END). Do not guess where the
-    // block ends — leave the file untouched and let the caller warn.
     return { content: existing, action: 'malformed' };
   }
 
   if (begins === 0) {
     const sep = existing.length === 0 ? '' : existing.endsWith('\n') ? '\n' : '\n\n';
-    return { content: `${existing}${sep}${block}\n`, action: 'created' };
+    return { content: `${existing}${sep}${fullBlock}\n`, action: 'created' };
   }
 
-  // Remove all existing blocks, tidy whitespace, then append exactly one.
-  const stripped = removeCompleteBlocks(existing).replace(/\n{3,}/g, '\n\n').replace(/\s+$/, '');
-  const next = stripped.length === 0 ? `${block}\n` : `${stripped}\n\n${block}\n`;
+  const stripped = removeCompleteBlocks(existing, begin, end)
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\s+$/, '');
+  const next = stripped.length === 0 ? `${fullBlock}\n` : `${stripped}\n\n${fullBlock}\n`;
   return { content: next, action: next === existing ? 'unchanged' : 'updated' };
+}
+
+/** Upsert the markdown instructions block (CLAUDE.md / AGENTS.md). */
+export function upsertManagedBlock(content) {
+  return upsertDelimitedBlock(content, BLOCK_BEGIN, BLOCK_END, renderManagedBlock());
+}
+
+// --- Codex MCP server block (~/.codex/config.toml) ---
+// Markers are TOML comments so the block is valid TOML.
+export const CODEX_BLOCK_BEGIN = '# BEGIN aikeychain (managed by `akc init`)';
+export const CODEX_BLOCK_END = '# END aikeychain (managed by `akc init`)';
+
+export function renderCodexBlock() {
+  return `${CODEX_BLOCK_BEGIN}\n[mcp_servers.aikeychain]\ncommand = "akc"\nargs = ["mcp"]\n${CODEX_BLOCK_END}`;
+}
+
+/**
+ * Ensure the Codex MCP block is present in a config.toml. Append-only and
+ * idempotent: if the marker is already there it leaves the file completely
+ * untouched (never reformats the user's hand-written TOML).
+ * Returns { content, action: 'created' | 'unchanged' }.
+ */
+export function upsertCodexBlock(content) {
+  const existing = content ?? '';
+  if (existing.includes(CODEX_BLOCK_BEGIN)) {
+    return { content: existing, action: 'unchanged' };
+  }
+  const sep = existing.length === 0 ? '' : existing.endsWith('\n') ? '\n' : '\n\n';
+  return { content: `${existing}${sep}${renderCodexBlock()}\n`, action: 'created' };
 }

--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -1,111 +1,140 @@
 // `akc init` — one-command discoverability setup so AI agents (and humans) learn
-// how to use AI KeyChain:
-//   1. Write a managed instructions block into CLAUDE.md and AGENTS.md (idempotent).
-//   2. Register the MCP server with Claude Code (`claude mcp add`) when available.
-//   3. Print the Codex config snippet and next steps.
+// how to use AI KeyChain. Machine-wide by default (this tool is not meant to be
+// scoped per project):
+//   - Claude: write ~/.claude/CLAUDE.md + register the MCP server at user scope
+//   - Codex:  write ~/.codex/AGENTS.md + add the MCP server to ~/.codex/config.toml
+// Use --local for the old project-scoped behavior (./CLAUDE.md + ./AGENTS.md and a
+// local-scope Claude MCP registration).
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { renderManagedBlock, upsertManagedBlock } from './agent-setup.js';
+import {
+  renderManagedBlock,
+  renderCodexBlock,
+  upsertManagedBlock,
+  upsertCodexBlock,
+} from './agent-setup.js';
 
 const pExecFile = promisify(execFile);
 
-const CODEX_SNIPPET = `[mcp_servers.aikeychain]
-command = "akc"
-args = ["mcp"]`;
-
-async function writeBlock(path) {
-  let existing = '';
+async function readFileOrEmpty(path) {
   try {
-    existing = await readFile(path, 'utf8');
+    return await readFile(path, 'utf8');
   } catch (err) {
-    // Only "file does not exist" means start fresh; surface other read errors
-    // (e.g. permissions) instead of silently overwriting as empty.
-    if (err.code !== 'ENOENT') throw err;
+    // Only "missing" means start fresh; surface other errors (e.g. permissions).
+    if (err.code === 'ENOENT') return '';
+    throw err;
   }
-  const { content, action } = upsertManagedBlock(existing);
-  if (action === 'malformed') {
-    return { path, action };
-  }
-  if (action !== 'unchanged') {
+}
+
+/** Apply an upsert result to a file, creating parent dirs as needed. */
+async function applyUpsert(path, upsert) {
+  const existing = await readFileOrEmpty(path);
+  const { content, action } = upsert(existing);
+  if (action !== 'unchanged' && action !== 'malformed') {
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, content);
   }
-  return { path, action };
+  return action;
 }
 
-async function registerClaudeMcp() {
-  // Add first; only if that fails (usually "already exists") do we replace, so a
-  // working registration is never removed unless the re-add is about to run.
+async function registerClaudeMcp(scope) {
+  const addArgs = ['mcp', 'add', '--scope', scope, 'aikeychain', '--', 'akc', 'mcp'];
+  // Add first; only replace (remove+add) if the add fails (usually "exists"),
+  // so a working registration is never deleted unless we are re-adding it.
   try {
-    await pExecFile('claude', ['mcp', 'add', 'aikeychain', '--', 'akc', 'mcp'], { timeout: 15000 });
+    await pExecFile('claude', addArgs, { timeout: 15000 });
     return;
   } catch {
-    // likely already registered, or another transient failure
+    // already registered or transient failure
   }
-  await pExecFile('claude', ['mcp', 'remove', 'aikeychain'], { timeout: 15000 });
-  await pExecFile('claude', ['mcp', 'add', 'aikeychain', '--', 'akc', 'mcp'], { timeout: 15000 });
+  try {
+    await pExecFile('claude', ['mcp', 'remove', '--scope', scope, 'aikeychain'], { timeout: 15000 });
+  } catch {
+    try {
+      await pExecFile('claude', ['mcp', 'remove', 'aikeychain'], { timeout: 15000 });
+    } catch {
+      // ignore — the add below will surface a real failure
+    }
+  }
+  await pExecFile('claude', addArgs, { timeout: 15000 });
+}
+
+function reportAction(out, path, action) {
+  if (action === 'malformed') {
+    out.write(`  ⚠️  ${path} has unbalanced aikeychain markers — left untouched. Fix it manually, then re-run.\n`);
+    return true; // failure
+  }
+  const verb = { created: 'wrote', updated: 'updated', unchanged: 'already current' }[action];
+  out.write(`  ✅ ${verb}: ${path}\n`);
+  return false;
 }
 
 export async function cmdInit(argv) {
   const printOnly = argv.includes('--print');
   const noRegister = argv.includes('--no-register');
-  const global = argv.includes('--global');
-
+  const local = argv.includes('--local');
   const out = process.stdout;
 
   if (printOnly) {
-    out.write('# Managed block that `akc init` writes to CLAUDE.md / AGENTS.md:\n\n');
+    out.write('# Instructions block written to CLAUDE.md / AGENTS.md:\n\n');
     out.write(`${renderManagedBlock()}\n\n`);
-    out.write('# Claude Code MCP registration:\n');
-    out.write('  claude mcp add aikeychain -- akc mcp\n\n');
-    out.write('# Codex (~/.codex/config.toml):\n');
-    out.write(`${CODEX_SNIPPET}\n`);
+    out.write('# Claude Code MCP registration (machine-wide):\n');
+    out.write('  claude mcp add --scope user aikeychain -- akc mcp\n\n');
+    out.write('# Codex block appended to ~/.codex/config.toml:\n');
+    out.write(`${renderCodexBlock()}\n`);
     return 0;
   }
 
-  // 1. Instructions files
-  const targets = global
-    ? [join(homedir(), '.claude', 'CLAUDE.md')]
-    : [join(process.cwd(), 'CLAUDE.md'), join(process.cwd(), 'AGENTS.md')];
+  let failed = false;
+  const home = homedir();
 
-  let writeFailed = false;
-  for (const path of targets) {
-    try {
-      const { action } = await writeBlock(path);
-      if (action === 'malformed') {
-        writeFailed = true;
-        out.write(`  ⚠️  ${path} has unbalanced aikeychain markers — left untouched. Fix it manually, then re-run.\n`);
-        continue;
+  if (local) {
+    // Project-scoped (legacy): files in cwd, Claude MCP at local scope.
+    for (const path of [join(process.cwd(), 'CLAUDE.md'), join(process.cwd(), 'AGENTS.md')]) {
+      try {
+        failed = reportAction(out, path, await applyUpsert(path, upsertManagedBlock)) || failed;
+      } catch (err) {
+        failed = true;
+        out.write(`  ⚠️  could not write ${path}: ${err.message}\n`);
       }
-      const verb = { created: 'wrote', updated: 'updated', unchanged: 'already current' }[action];
-      out.write(`  ✅ ${verb}: ${path}\n`);
-    } catch (err) {
-      writeFailed = true;
-      out.write(`  ⚠️  could not write ${path}: ${err.message}\n`);
     }
-  }
-
-  // 2. Claude Code MCP registration
-  if (noRegister) {
-    out.write('  ⏭️  skipped MCP registration (--no-register)\n');
+    if (!noRegister) await registerClaude(out, 'local');
   } else {
-    try {
-      await registerClaudeMcp();
-      out.write('  ✅ registered MCP server with Claude Code (aikeychain)\n');
-    } catch {
-      out.write('  ⏭️  Claude Code CLI not found — register manually:\n');
-      out.write('       claude mcp add aikeychain -- akc mcp\n');
+    // Machine-wide (default).
+    const targets = [
+      { path: join(home, '.claude', 'CLAUDE.md'), upsert: upsertManagedBlock },
+      { path: join(home, '.codex', 'AGENTS.md'), upsert: upsertManagedBlock },
+      { path: join(home, '.codex', 'config.toml'), upsert: upsertCodexBlock },
+    ];
+    for (const { path, upsert } of targets) {
+      try {
+        failed = reportAction(out, path, await applyUpsert(path, upsert)) || failed;
+      } catch (err) {
+        failed = true;
+        out.write(`  ⚠️  could not write ${path}: ${err.message}\n`);
+      }
     }
+    if (!noRegister) await registerClaude(out, 'user');
   }
 
-  // 3. Codex + next steps
-  out.write('\nFor Codex, add to ~/.codex/config.toml:\n');
-  out.write(`${CODEX_SNIPPET.split('\n').map((l) => `  ${l}`).join('\n')}\n`);
-  out.write('\nDone. New AI sessions will discover AI KeyChain via the MCP tools and the\n');
+  out.write('\nDone. New AI sessions discover AI KeyChain via the MCP tools and the\n');
   out.write('instructions block. Run `akc guide` anytime for the full usage guide.\n');
-  return writeFailed ? 1 : 0;
+  if (!local) {
+    out.write('(Already-running sessions need a restart to pick this up.)\n');
+  }
+  return failed ? 1 : 0;
+}
+
+async function registerClaude(out, scope) {
+  try {
+    await registerClaudeMcp(scope);
+    out.write(`  ✅ registered MCP server with Claude Code (aikeychain, ${scope} scope)\n`);
+  } catch {
+    out.write('  ⏭️  Claude Code CLI not found — register manually:\n');
+    out.write(`       claude mcp add --scope ${scope} aikeychain -- akc mcp\n`);
+  }
 }

--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -34,38 +34,46 @@ async function readFileOrEmpty(path) {
 async function applyUpsert(path, upsert) {
   const existing = await readFileOrEmpty(path);
   const { content, action } = upsert(existing);
-  if (action !== 'unchanged' && action !== 'malformed') {
+  if (action === 'created' || action === 'updated') {
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, content);
   }
   return action;
 }
 
-async function registerClaudeMcp(scope) {
-  const addArgs = ['mcp', 'add', '--scope', scope, 'aikeychain', '--', 'akc', 'mcp'];
-  // Add first; only replace (remove+add) if the add fails (usually "exists"),
-  // so a working registration is never deleted unless we are re-adding it.
+/** Is the aikeychain MCP server already registered with Claude Code? */
+async function claudeMcpRegistered() {
   try {
-    await pExecFile('claude', addArgs, { timeout: 15000 });
+    const { stdout } = await pExecFile('claude', ['mcp', 'list'], { timeout: 15000 });
+    return /(^|\n)\s*aikeychain[:\s]/.test(stdout);
+  } catch {
+    return false;
+  }
+}
+
+async function registerClaudeMcp(scope) {
+  // Add first. If that fails, it is almost always "already registered" — verify
+  // and leave the existing one in place. Never remove a working registration
+  // (a transient re-add failure must not leave the user with nothing).
+  try {
+    await pExecFile('claude', ['mcp', 'add', '--scope', scope, 'aikeychain', '--', 'akc', 'mcp'], {
+      timeout: 15000,
+    });
     return;
   } catch {
-    // already registered or transient failure
+    // fall through to verification
   }
-  try {
-    await pExecFile('claude', ['mcp', 'remove', '--scope', scope, 'aikeychain'], { timeout: 15000 });
-  } catch {
-    try {
-      await pExecFile('claude', ['mcp', 'remove', 'aikeychain'], { timeout: 15000 });
-    } catch {
-      // ignore — the add below will surface a real failure
-    }
-  }
-  await pExecFile('claude', addArgs, { timeout: 15000 });
+  if (await claudeMcpRegistered()) return; // already there — keep it
+  throw new Error('claude mcp add failed and aikeychain is not registered');
 }
 
 function reportAction(out, path, action) {
   if (action === 'malformed') {
     out.write(`  ⚠️  ${path} has unbalanced aikeychain markers — left untouched. Fix it manually, then re-run.\n`);
+    return true; // failure
+  }
+  if (action === 'conflict') {
+    out.write(`  ⚠️  ${path} already has an [mcp_servers.aikeychain] table without our markers — left untouched. Merge it manually.\n`);
     return true; // failure
   }
   const verb = { created: 'wrote', updated: 'updated', unchanged: 'already current' }[action];

--- a/cli/test/init.test.js
+++ b/cli/test/init.test.js
@@ -108,6 +108,16 @@ test('upsertCodexBlock appends once and is idempotent (never reformats existing 
   assert.equal(second.content, first.content);
 });
 
+test('upsertCodexBlock refuses to append when a marker-less aikeychain table already exists', () => {
+  // The exact hazard: user hand-wrote the table without our markers.
+  const existing = `[mcp_servers.node_repl]\ncommand = "node"\n\n[mcp_servers.aikeychain]\ncommand = "akc"\nargs = ["mcp"]\n`;
+  const { content, action } = upsertCodexBlock(existing);
+  assert.equal(action, 'conflict');
+  assert.equal(content, existing); // untouched — never produces duplicate table
+  // and it must NOT have appended a second table
+  assert.equal((content.match(/\[mcp_servers\.aikeychain\]/g) || []).length, 1);
+});
+
 test('akc init --print previews machine-wide setup without writing', async () => {
   const r = await runAkc(['init', '--print']);
   assert.equal(r.code, 0);

--- a/cli/test/init.test.js
+++ b/cli/test/init.test.js
@@ -8,9 +8,11 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   upsertManagedBlock,
+  upsertCodexBlock,
   renderManagedBlock,
   BLOCK_BEGIN,
   BLOCK_END,
+  CODEX_BLOCK_BEGIN,
   AGENT_INSTRUCTIONS,
 } from '../src/agent-setup.js';
 
@@ -93,35 +95,61 @@ function runAkc(args, opts = {}) {
   );
 }
 
-test('akc init --print previews without writing files', async () => {
+test('upsertCodexBlock appends once and is idempotent (never reformats existing TOML)', () => {
+  const existing = `[mcp_servers.node_repl]\ncommand = "node"\n`;
+  const first = upsertCodexBlock(existing);
+  assert.equal(first.action, 'created');
+  assert.ok(first.content.startsWith(existing)); // existing config untouched
+  assert.ok(first.content.includes(CODEX_BLOCK_BEGIN));
+  assert.ok(first.content.includes('[mcp_servers.aikeychain]'));
+  // re-run leaves it completely unchanged
+  const second = upsertCodexBlock(first.content);
+  assert.equal(second.action, 'unchanged');
+  assert.equal(second.content, first.content);
+});
+
+test('akc init --print previews machine-wide setup without writing', async () => {
   const r = await runAkc(['init', '--print']);
   assert.equal(r.code, 0);
   assert.match(r.stdout, new RegExp(BLOCK_BEGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-  assert.match(r.stdout, /claude mcp add aikeychain -- akc mcp/);
+  assert.match(r.stdout, /claude mcp add --scope user aikeychain -- akc mcp/);
   assert.match(r.stdout, /\[mcp_servers\.aikeychain\]/);
 });
 
-test('akc init writes CLAUDE.md + AGENTS.md and is idempotent', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'akc-init-'));
-  // --no-register so the test never touches the real Claude config.
-  const first = await runAkc(['init', '--no-register'], { cwd: dir });
+test('akc init (default machine-wide) writes ~/.claude + ~/.codex under HOME, idempotently', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'akc-home-'));
+  const env = { ...process.env, HOME: home };
+  const first = await runAkc(['init', '--no-register'], { env });
   assert.equal(first.code, 0);
-  const claudeMd = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
-  const agentsMd = await readFile(join(dir, 'AGENTS.md'), 'utf8');
-  assert.ok(claudeMd.includes(BLOCK_BEGIN));
-  assert.ok(agentsMd.includes(BLOCK_BEGIN));
-  assert.match(first.stdout, /skipped MCP registration/);
 
-  // Pre-existing content is preserved, block appended once.
+  const claudeMd = await readFile(join(home, '.claude', 'CLAUDE.md'), 'utf8');
+  const codexAgents = await readFile(join(home, '.codex', 'AGENTS.md'), 'utf8');
+  const codexToml = await readFile(join(home, '.codex', 'config.toml'), 'utf8');
+  assert.ok(claudeMd.includes(BLOCK_BEGIN));
+  assert.ok(codexAgents.includes(BLOCK_BEGIN));
+  assert.ok(codexToml.includes('[mcp_servers.aikeychain]'));
+
+  // Re-run is idempotent: still exactly one block in each.
+  await runAkc(['init', '--no-register'], { env });
+  const claudeMd2 = await readFile(join(home, '.claude', 'CLAUDE.md'), 'utf8');
+  const codexToml2 = await readFile(join(home, '.codex', 'config.toml'), 'utf8');
+  assert.equal(claudeMd2.split(BLOCK_BEGIN).length - 1, 1);
+  assert.equal(codexToml2.split(CODEX_BLOCK_BEGIN).length - 1, 1);
+});
+
+test('akc init --local writes cwd CLAUDE.md + AGENTS.md, preserving existing content', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'akc-init-'));
+  const first = await runAkc(['init', '--local', '--no-register'], { cwd: dir });
+  assert.equal(first.code, 0);
+  assert.ok((await readFile(join(dir, 'CLAUDE.md'), 'utf8')).includes(BLOCK_BEGIN));
+  assert.ok((await readFile(join(dir, 'AGENTS.md'), 'utf8')).includes(BLOCK_BEGIN));
+
+  // Pre-existing content is preserved, block appended once, then stable.
   await writeFile(join(dir, 'CLAUDE.md'), `# Existing\n\nrules here\n`);
-  await runAkc(['init', '--no-register'], { cwd: dir });
+  await runAkc(['init', '--local', '--no-register'], { cwd: dir });
   const updated = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
   assert.ok(updated.startsWith('# Existing'));
   assert.equal(updated.split(BLOCK_BEGIN).length - 1, 1);
-
-  // Third run: unchanged, still exactly one block.
-  await runAkc(['init', '--no-register'], { cwd: dir });
-  const third = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
-  assert.equal(third.split(BLOCK_BEGIN).length - 1, 1);
-  assert.equal(third, updated);
+  await runAkc(['init', '--local', '--no-register'], { cwd: dir });
+  assert.equal(await readFile(join(dir, 'CLAUDE.md'), 'utf8'), updated);
 });

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -16,7 +16,7 @@ npx aikeychain <command>
 
 | コマンド | 機能 |
 |---|---|
-| `akc init` | AI エージェント向けセットアップ。`CLAUDE.md`/`AGENTS.md` に作法スニペットを追記（冪等）+ MCP サーバー登録。`--print` プレビュー / `--no-register` / `--global` |
+| `akc init` | **マシン全体**のセットアップ: `~/.claude/CLAUDE.md` + `~/.codex/AGENTS.md` にスニペット、Claude MCP を user スコープ登録、`~/.codex/config.toml` に Codex MCP 追記（冪等）。`--print` プレビュー / `--no-register` / `--local`（プロジェクト単位） |
 | `akc run [--dry-run] -- <cmd>` | env の `keychain://` 参照を解決してコマンド実行（値は子プロセスのみに注入） |
 | `akc list` | キー名一覧（値は一切表示しない） |
 | `akc check <KEY>` | キーの存在・格納先（app / manual）確認 |


### PR DESCRIPTION
## 概要
Closes #106

AI KeyChain は**プロジェクト単位で使う想定ではない**（マシン全体で1つのキーチェーンを共有）。`akc init` 一発で Claude/Codex の**全セッション**に反映するようデフォルトを変更。

## 変更内容
`akc init`（デフォルト = マシン全体）が以下を実施:

| 対象 | 反映先 |
|---|---|
| Claude グローバル指示 | `~/.claude/CLAUDE.md` に作法スニペット（冪等な管理ブロック） |
| Claude MCP | **user スコープ**で登録（`claude mcp add --scope user`、全プロジェクト/セッション） |
| Codex グローバル指示 | `~/.codex/AGENTS.md` に作法スニペット |
| Codex MCP | `~/.codex/config.toml` に `[mcp_servers.aikeychain]` を**追記のみ**（既存 TOML は再整形しない） |

| ファイル | 変更 |
|---|---|
| `cli/src/agent-setup.js` | 汎用 `upsertDelimitedBlock` に整理。Codex 用 `upsertCodexBlock`（append-only・既存設定非破壊） |
| `cli/src/init.js` | 既定マシン全体 / `--local` で旧プロジェクト挙動。`registerClaudeMcp(scope)`、`~/.codex`・`~/.claude` を mkdir -p、malformed/失敗で exit 1 |
| `cli/bin/akc.js` / README / docs | usage・説明更新 |
| `cli/package.json` | 0.4.0 → 0.5.0 |

### フラグ
- 既定: マシン全体（Claude user スコープ + Codex）
- `--local`: cwd の CLAUDE.md/AGENTS.md + Claude MCP local スコープ
- `--print`: プレビュー（副作用なし）/ `--no-register`: MCP 登録抑止

## テスト計画
- [x] `npm test` **36/36 PASS**
- [x] machine-wide: temp HOME で `~/.claude/CLAUDE.md` + `~/.codex/AGENTS.md` + `~/.codex/config.toml` 生成・冪等
- [x] `upsertCodexBlock`: 既存 TOML を保持して追記、再実行で unchanged
- [x] `--local`: cwd 書込・既存内容保持・冪等
- [x] `--print`: `--scope user` 表示・副作用なし
- [ ] 実機 `akc init`（MCP 登録あり）はマージ後に実施（テストは `--no-register` で実設定非汚染）

## 安全性
- 既存設定ファイルはマーカー付きブロック / TOML 追記のみで非破壊。malformed は無変更 + exit 1
- `~/.codex`/`~/.claude` が無くても mkdir -p
- `--print` 完全に副作用なし、`claude` 未導入でも手順表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)
