### PR TITLE
docs: Apple 商標配慮（非提携の明記 + Apple ロゴバッジ撤去）#108

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/platform-macOS%2014+-blue?style=flat-square&logo=apple" />
+  <img src="https://img.shields.io/badge/platform-macOS%2014+-blue?style=flat-square" />
   <img src="https://img.shields.io/badge/Swift-5.9+-orange?style=flat-square&logo=swift" />
   <img src="https://img.shields.io/badge/SwiftUI-Native-purple?style=flat-square" />
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" />
@@ -170,6 +170,10 @@ The author assumes no responsibility for any damages resulting from the use of t
 
 **Use entirely at your own risk.**
 
+### Trademarks
+
+This is an independent project and is **not affiliated with, endorsed by, or sponsored by Apple Inc.** "Apple", "macOS", and "Keychain" are trademarks of Apple Inc., used here for descriptive and identification purposes only.
+
 ---
 
 <a id="日本語"></a>
@@ -301,3 +305,7 @@ MIT License
 作者は本アプリの使用によって生じたいかなる損害（APIキー漏洩、請求発生、データ損失など）についても一切の責任を負いません。
 
 **すべて自己責任**でご利用ください。
+
+### 商標について
+
+本プロジェクトは独立したプロジェクトであり、**Apple Inc. とは一切提携しておらず、Apple による承認・後援も受けていません**。「Apple」「macOS」「Keychain」は Apple Inc. の商標であり、本書では説明・識別の目的でのみ使用しています。

--- a/cli/README.md
+++ b/cli/README.md
@@ -87,6 +87,10 @@ claude mcp add aikeychain -- npx -y aikeychain mcp
 
 **There is intentionally no tool that returns a secret value.** Agents obtain a `keychain://` reference and execute workloads through `akc run`, so values stay out of the model context entirely.
 
+## Trademarks
+
+This is an independent project and is **not affiliated with, endorsed by, or sponsored by Apple Inc.** "Apple", "macOS", and "Keychain" are trademarks of Apple Inc., used here for descriptive and identification purposes only.
+
 ## License
 
 MIT


### PR DESCRIPTION
## 概要
Closes #108

npm 公開（`aikeychain`）前の Apple 商標配慮。

## 変更
- README の platform バッジから `&logo=apple` を除去（Apple 公認の示唆を回避）
- README（EN/JA）の Disclaimer に **Trademarks / 商標について**（非提携・帰属）注記を追加:
  > This is an independent project and is **not affiliated with, endorsed by, or sponsored by Apple Inc.** "Apple", "macOS", and "Keychain" are trademarks of Apple Inc., used here for descriptive and identification purposes only.
- `cli/README.md`（npm 公開ページ）にも同注記

## 非対象
- 名称（`aikeychain`）・ライセンスは維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)