### PR TITLE
feat(editor): キー個別アイコン（Service→アイコン化）+ AddKey 日本語化 (#110)

### DIFF
--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		7D946F2DB9B9D085052EDB87 /* AppFonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56404BDE58192F0E86AD8B7E /* AppFonts.swift */; };
 		997092F4B071916A707F052B /* AppColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AF158D6FB20753F89DF323 /* AppColors.swift */; };
 		A2F1064807E933FE345F8063 /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DC4BEF20A119E940433F3A /* KeychainServiceTests.swift */; };
+		A333DEEBD8AD828CC031413A /* IconPickerGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE82389E8C1EDD586872750A /* IconPickerGrid.swift */; };
 		A5417351BB72385534D8B9B7 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E7404C25ED51694C3DF766 /* SidebarView.swift */; };
 		AB911324067521B34322D8A9 /* KeyListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86254B995FB20769DA53656A /* KeyListViewModel.swift */; };
 		AF1D41DA4AC29AEE58B49FDF /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF474BC29A1530637DA89AB /* MenuBarView.swift */; };
@@ -121,6 +122,7 @@
 		F2A3438BA6DB0A665C0E3D08 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		F69D54AA42B1FDEBB2AD036B /* ViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelTests.swift; sourceTree = "<group>"; };
 		FCD863D9D3D25902544E5FFC /* ShareKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareKeysView.swift; sourceTree = "<group>"; };
+		FE82389E8C1EDD586872750A /* IconPickerGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerGrid.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -160,6 +162,14 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		3583B31A559FCC2A23E29BC3 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				FE82389E8C1EDD586872750A /* IconPickerGrid.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		59E705C3BF8EAB243BA4E46E /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -172,6 +182,7 @@
 				2939F10EF6CE9C4D059904DC /* ModeSelectView.swift */,
 				4A96E32BD83312A5116D44E7 /* RecoveryView.swift */,
 				FCD863D9D3D25902544E5FFC /* ShareKeysView.swift */,
+				3583B31A559FCC2A23E29BC3 /* Components */,
 				C166B224999EEA1A66870FC9 /* Editor */,
 				A9A45D381E261DC40D05F3B2 /* Export */,
 				EAD00F96FE54FBD31C7BED93 /* Main */,
@@ -404,6 +415,7 @@
 				17E984B7629D8CE3316EA863 /* ExportView.swift in Sources */,
 				25101CE19322B14D1988F7ED /* HTTPRequestParser.swift in Sources */,
 				DB35D6EB592E09D00C582035 /* HelpView.swift in Sources */,
+				A333DEEBD8AD828CC031413A /* IconPickerGrid.swift in Sources */,
 				C8354CC8F169967E2C4F8058 /* KeyCategory.swift in Sources */,
 				163DDFF8E8B54D9552084AC4 /* KeyEditorView.swift in Sources */,
 				057C67CA77C34F8753AC4E1B /* KeyEditorViewModel.swift in Sources */,

--- a/AIkeychain/Components/ServiceIcon.swift
+++ b/AIkeychain/Components/ServiceIcon.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 struct ServiceIcon: View {
     let service: ServiceType
+    /// 表示記号の上書き（キー個別アイコン等）。未指定はサービス既定。
+    var symbol: String? = nil
     var size: CGFloat = 32
 
     var body: some View {
-        Image(systemName: service.systemImage)
+        Image(systemName: symbol ?? service.systemImage)
             .font(.system(size: size * 0.45))
             .foregroundStyle(.white)
             .frame(width: size, height: size)

--- a/AIkeychain/Components/StatusBadge.swift
+++ b/AIkeychain/Components/StatusBadge.swift
@@ -7,7 +7,7 @@ struct StatusBadge: View {
         HStack(spacing: 4) {
             Image(systemName: isConfigured ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                 .font(.system(size: 10))
-            Text(isConfigured ? "Configured" : "Pending")
+            Text(isConfigured ? L10n.s(ja: "設定済み", en: "Configured") : L10n.s(ja: "未設定", en: "Pending"))
                 .font(AppFonts.badge)
         }
         .foregroundStyle(isConfigured ? AppColors.configured : AppColors.pending)

--- a/AIkeychain/Models/APIKey.swift
+++ b/AIkeychain/Models/APIKey.swift
@@ -36,10 +36,21 @@ struct APIKey: Identifiable, Equatable, Hashable {
     }
 
     var systemImage: String {
+        // 1. ユーザーがこのキーに設定した個別アイコンを最優先
+        if let customKey, let icon = customKey.icon, !icon.isEmpty {
+            return icon
+        }
+        if let override = CustomKeyStore.shared.overriddenIcon(for: envVarName), !override.isEmpty {
+            return override
+        }
+        // 2. プリセット由来のアイコン
         if let service { return service.systemImage }
+        // 3. カスタムキーが属するカテゴリのアイコン
         if let customKey, let cat = CustomKeyStore.shared.category(for: customKey.categoryId) {
             return cat.systemImage
         }
+        // 4. ビルトインカテゴリのアイコン（プリセット名キーのフォールバック）
+        if let builtin = builtinCategory { return builtin.systemImage }
         return "key"
     }
 

--- a/AIkeychain/Models/APIKey.swift
+++ b/AIkeychain/Models/APIKey.swift
@@ -43,15 +43,30 @@ struct APIKey: Identifiable, Equatable, Hashable {
         if let override = CustomKeyStore.shared.overriddenIcon(for: envVarName), !override.isEmpty {
             return override
         }
-        // 2. プリセット由来のアイコン
+        // 2. プリセット名キーを別カテゴリへ移している場合は、その実効カテゴリのアイコン
+        //    （エディタの既定選択と一致させ「nil はカテゴリ追従」を成立させる）
+        if let sel = CustomKeyStore.shared.overriddenCategory(for: envVarName),
+           let icon = Self.categoryIcon(for: sel), !icon.isEmpty {
+            return icon
+        }
+        // 3. プリセット由来のアイコン（既定配置のプリセット名キー）
         if let service { return service.systemImage }
-        // 3. カスタムキーが属するカテゴリのアイコン
-        if let customKey, let cat = CustomKeyStore.shared.category(for: customKey.categoryId) {
+        // 4. カスタムキーが属するカテゴリのアイコン
+        if let customKey, let cat = CustomKeyStore.shared.category(for: customKey.categoryId),
+           !cat.systemImage.isEmpty {
             return cat.systemImage
         }
-        // 4. ビルトインカテゴリのアイコン（プリセット名キーのフォールバック）
-        if let builtin = builtinCategory { return builtin.systemImage }
+        // 5. ビルトインカテゴリのアイコン（プリセット名キーのフォールバック）
+        if let builtin = builtinCategory, !builtin.systemImage.isEmpty { return builtin.systemImage }
         return "key"
+    }
+
+    private static func categoryIcon(for selection: CategorySelection) -> String? {
+        switch selection {
+        case .builtin(let cat): return cat.systemImage
+        case .custom(let id): return CustomKeyStore.shared.category(for: id)?.systemImage
+        case .all, .activity: return nil
+        }
     }
 
     var categoryColor: Color {

--- a/AIkeychain/Models/CustomKeyStore.swift
+++ b/AIkeychain/Models/CustomKeyStore.swift
@@ -26,18 +26,22 @@ struct CustomKey: Identifiable, Codable, Hashable {
     var categoryId: UUID  // CustomCategory.id or built-in category ID
     var tokenPrefix: String?
     var setupURLString: String?
+    /// ユーザーが選んだ表示アイコン（SF Symbol 名）。未設定はカテゴリのアイコンに従う。
+    /// Optional なので旧データ（icon フィールド無し）は nil で復号され非破壊。
+    var icon: String?
 
     var setupURL: URL? {
         setupURLString.flatMap { URL(string: $0) }
     }
 
-    init(id: UUID = UUID(), envVarName: String, displayName: String, categoryId: UUID, tokenPrefix: String? = nil, setupURLString: String? = nil) {
+    init(id: UUID = UUID(), envVarName: String, displayName: String, categoryId: UUID, tokenPrefix: String? = nil, setupURLString: String? = nil, icon: String? = nil) {
         self.id = id
         self.envVarName = envVarName
         self.displayName = displayName
         self.categoryId = categoryId
         self.tokenPrefix = tokenPrefix
         self.setupURLString = setupURLString
+        self.icon = icon
     }
 }
 
@@ -49,11 +53,14 @@ final class CustomKeyStore {
     private static let categoriesKey = "custom_categories"
     private static let keysKey = "custom_keys"
     private static let overridesKey = "category_overrides"
+    private static let iconOverridesKey = "icon_overrides"
 
     var categories: [CustomCategory] = []
     var keys: [CustomKey] = []
     /// プリセットキーのカテゴリ上書き（envVarName → カテゴリ識別子）
     var categoryOverrides: [String: String] = [:]
+    /// プリセット名キーのアイコン上書き（envVarName → SF Symbol 名）
+    var iconOverrides: [String: String] = [:]
 
     private let defaults: UserDefaults
 
@@ -139,6 +146,23 @@ final class CustomKeyStore {
         return nil
     }
 
+    // MARK: - Icon Overrides (for preset-named keys)
+
+    /// プリセット名キー（CustomKey でないキー）の表示アイコンを上書き。
+    func setIconOverride(envVarName: String, icon: String?) {
+        if let icon, !icon.isEmpty {
+            iconOverrides[envVarName] = icon
+        } else {
+            iconOverrides.removeValue(forKey: envVarName)
+        }
+        saveIconOverrides()
+    }
+
+    /// プリセット名キーの上書きアイコンを取得（無ければ nil）。
+    func overriddenIcon(for envVarName: String) -> String? {
+        iconOverrides[envVarName]
+    }
+
     // MARK: - Persistence
 
     private func load() {
@@ -152,6 +176,9 @@ final class CustomKeyStore {
         }
         if let dict = defaults.dictionary(forKey: Self.overridesKey) as? [String: String] {
             categoryOverrides = dict
+        }
+        if let dict = defaults.dictionary(forKey: Self.iconOverridesKey) as? [String: String] {
+            iconOverrides = dict
         }
     }
 
@@ -169,5 +196,9 @@ final class CustomKeyStore {
 
     private func saveOverrides() {
         defaults.set(categoryOverrides, forKey: Self.overridesKey)
+    }
+
+    private func saveIconOverrides() {
+        defaults.set(iconOverrides, forKey: Self.iconOverridesKey)
     }
 }

--- a/AIkeychain/Models/KeyCategory.swift
+++ b/AIkeychain/Models/KeyCategory.swift
@@ -10,6 +10,18 @@ enum KeyCategory: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// UI 表示用のローカライズ名（`rawValue` は永続化キーなので英語のまま維持）。
+    var displayName: String {
+        switch self {
+        case .ai: L10n.s(ja: "AI API", en: "AI API")
+        case .webAuth: L10n.s(ja: "AI Web 認証", en: "AI Web")
+        case .codeAndGit: L10n.s(ja: "コード & Git", en: "Code & Git")
+        case .cloud: L10n.s(ja: "クラウド & インフラ", en: "Cloud & Infra")
+        case .communication: L10n.s(ja: "コミュニケーション", en: "Communication")
+        case .devTools: L10n.s(ja: "開発ツール", en: "Developer Tools")
+        }
+    }
+
     var color: Color {
         switch self {
         case .ai: Color(hex: 0x7C3AED)

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -92,9 +92,16 @@ final class KeyEditorViewModel {
                 selectedCategorySelection = .custom(customId)
             }
 
-            // 現在の表示アイコンを初期値にし、編集中は維持（カテゴリ追従させない）
-            selectedIcon = key.systemImage
-            iconManuallySet = true
+            // 明示的に保存されたアイコンがあればそれを初期値に（保存時に維持）。
+            // 無ければ現在の表示アイコンを初期値にし、未指定扱い（カテゴリ追従可）。
+            let explicitIcon = key.customKey?.icon ?? customStore.overriddenIcon(for: key.envVarName)
+            if let explicitIcon, !explicitIcon.isEmpty {
+                selectedIcon = explicitIcon
+                iconManuallySet = true
+            } else {
+                selectedIcon = key.systemImage
+                iconManuallySet = false
+            }
 
             tokenValue = (try? keychainService.retrieve(for: key.envVarName)) ?? ""
         } else {
@@ -188,11 +195,12 @@ final class KeyEditorViewModel {
         }
     }
 
-    /// 保存するアイコン。カテゴリ既定と同じなら nil（= カテゴリに追従させ、保存しない）。
+    /// 保存するアイコン。ユーザーが明示的に選んでいなければ nil（= カテゴリ/プリセットに
+    /// 追従させ、上書きを保存しない）。明示選択時のみその値を保存する。
     private func iconToPersist() -> String? {
+        guard iconManuallySet else { return nil }
         let trimmed = selectedIcon.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty || trimmed == categoryDefaultIcon { return nil }
-        return trimmed
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func resolveCategoryId() -> UUID {

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -3,6 +3,8 @@ import Observation
 
 @Observable
 final class KeyEditorViewModel {
+    /// 既存プリセットキーの編集時のみ参照（プレフィックス検証 / 発行 URL 表示用）。
+    /// エディタにサービス選択 UI は無い。
     var selectedService: ServiceType?
     var envVarName: String = ""
     var tokenValue: String = ""
@@ -12,6 +14,10 @@ final class KeyEditorViewModel {
     var showDeleteConfirm: Bool = false
     var errorMessage: String?
     var selectedCategorySelection: CategorySelection?
+    /// このキーに表示するアイコン（SF Symbol 名）。
+    var selectedIcon: String = "key"
+    /// ユーザーが明示的にアイコンを選んだか（カテゴリ変更で自動追従させるか判定）。
+    var iconManuallySet: Bool = false
 
     let editingKey: APIKey?
     private let keychainService: KeychainServiceProtocol
@@ -20,7 +26,29 @@ final class KeyEditorViewModel {
     var isEditing: Bool { editingKey != nil }
 
     var title: String {
-        isEditing ? "Edit Key" : "Add Key"
+        isEditing ? L10n.s(ja: "キーを編集", en: "Edit Key") : L10n.s(ja: "キーを追加", en: "Add Key")
+    }
+
+    /// 選択中カテゴリの既定アイコン。
+    var categoryDefaultIcon: String {
+        switch selectedCategorySelection {
+        case .builtin(let cat): return cat.systemImage
+        case .custom(let id): return customStore.category(for: id)?.systemImage ?? "folder"
+        case .all, .activity, .none: return "key"
+        }
+    }
+
+    /// カテゴリ選択が変わったとき、ユーザー未指定なら既定アイコンに追従させる。
+    func categoryDidChange() {
+        if !iconManuallySet {
+            selectedIcon = categoryDefaultIcon
+        }
+    }
+
+    /// ユーザーがアイコンを選んだ。
+    func pickIcon(_ icon: String) {
+        selectedIcon = icon
+        iconManuallySet = true
     }
 
     var prefixWarning: String? {
@@ -29,7 +57,7 @@ final class KeyEditorViewModel {
               !tokenValue.hasPrefix(prefix) else {
             return nil
         }
-        return "Expected prefix: \(prefix)"
+        return L10n.s(ja: "想定プレフィックス: \(prefix)", en: "Expected prefix: \(prefix)")
     }
 
     /// envVarName が安全なシェル変数名パターンに一致するか
@@ -54,7 +82,7 @@ final class KeyEditorViewModel {
         self.customStore = customStore
 
         if let key = editingKey {
-            selectedService = key.service ?? .anthropic
+            selectedService = key.service
             envVarName = key.envVarName
 
             // Resolve current category
@@ -64,19 +92,18 @@ final class KeyEditorViewModel {
                 selectedCategorySelection = .custom(customId)
             }
 
+            // 現在の表示アイコンを初期値にし、編集中は維持（カテゴリ追従させない）
+            selectedIcon = key.systemImage
+            iconManuallySet = true
+
             tokenValue = (try? keychainService.retrieve(for: key.envVarName)) ?? ""
         } else {
             // 新規: 未選択状態で開始
             selectedService = nil
             envVarName = ""
             selectedCategorySelection = nil
-        }
-    }
-
-    func onServiceChange() {
-        if !isEditing, let service = selectedService {
-            envVarName = service.envVarName
-            selectedCategorySelection = .builtin(service.category)
+            selectedIcon = "key"
+            iconManuallySet = false
         }
     }
 
@@ -91,34 +118,38 @@ final class KeyEditorViewModel {
         do {
             try keychainService.save(value: trimmedValue, for: trimmedEnvVar)
 
+            let iconToStore = iconToPersist()
+
             if let key = editingKey {
                 // 既存キーの編集
                 if let service = key.service {
                     customStore.setCategoryOverride(
                         envVarName: trimmedEnvVar,
                         value: categoryOverrideValue(defaultCategory: service.category))
+                    customStore.setIconOverride(envVarName: trimmedEnvVar, icon: iconToStore)
                 } else if let customKey = key.customKey {
-                    // カスタムキーのカテゴリ変更
+                    // カスタムキーのカテゴリ/アイコン変更
                     var updated = customKey
                     updated.categoryId = resolveCategoryId()
+                    updated.icon = iconToStore
                     customStore.updateKey(updated)
                 }
             } else {
                 // 新規キー
                 if let preset = ServiceType.allCases.first(where: { $0.envVarName == trimmedEnvVar }) {
                     // envVarName がプリセットに一致 → プリセットキーとして一覧表示される。
-                    // 選択カテゴリがプリセット既定と異なる場合のみカテゴリ上書きを保存する
-                    // （Service 未選択でカテゴリだけ変えたケースを取りこぼさない / #102）。
+                    // 選択カテゴリ/アイコンがプリセット既定と異なる場合のみ上書きを保存
+                    // （Service 未選択でカテゴリ・アイコンだけ変えたケースを取りこぼさない）。
                     customStore.setCategoryOverride(
                         envVarName: trimmedEnvVar,
                         value: categoryOverrideValue(defaultCategory: preset.category))
+                    customStore.setIconOverride(envVarName: trimmedEnvVar, icon: iconToStore)
                 } else {
                     let customKey = CustomKey(
                         envVarName: trimmedEnvVar,
-                        displayName: selectedService?.displayName ?? trimmedEnvVar,
+                        displayName: trimmedEnvVar,
                         categoryId: resolveCategoryId(),
-                        tokenPrefix: selectedService?.tokenPrefix,
-                        setupURLString: selectedService?.setupURL?.absoluteString
+                        icon: iconToStore
                     )
                     customStore.addKey(customKey)
                 }
@@ -135,8 +166,9 @@ final class KeyEditorViewModel {
     func deleteKey() throws {
         guard let key = editingKey else { return }
         try keychainService.delete(for: key.envVarName)
-        // カテゴリ上書きも削除
+        // カテゴリ/アイコン上書きも削除
         customStore.setCategoryOverride(envVarName: key.envVarName, value: nil)
+        customStore.setIconOverride(envVarName: key.envVarName, icon: nil)
     }
 
     // MARK: - Private
@@ -154,6 +186,13 @@ final class KeyEditorViewModel {
         case .all, .activity, .none:
             return nil
         }
+    }
+
+    /// 保存するアイコン。カテゴリ既定と同じなら nil（= カテゴリに追従させ、保存しない）。
+    private func iconToPersist() -> String? {
+        let trimmed = selectedIcon.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty || trimmed == categoryDefaultIcon { return nil }
+        return trimmed
     }
 
     private func resolveCategoryId() -> UUID {

--- a/AIkeychain/Views/Components/IconPickerGrid.swift
+++ b/AIkeychain/Views/Components/IconPickerGrid.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// キー/カテゴリの表示アイコンを選ぶ共通グリッド。
+/// 選択中アイコンを `selection` にバインドし、`tint` で強調色を指定する。
+struct IconPickerGrid: View {
+    @Binding var selection: String
+    var tint: Color = AppColors.aiPurple
+    var columns: Int = 8
+
+    /// 選択肢。カテゴリ用の汎用アイコン + サービスを想起させるアイコンを含む。
+    static let options: [String] = [
+        // カテゴリ汎用
+        "folder", "tray.full", "cpu", "server.rack", "globe",
+        "doc.text", "hammer", "paintbrush", "chart.bar", "lock.shield",
+        "creditcard", "cart", "envelope", "antenna.radiowaves.left.and.right",
+        "gamecontroller", "camera", "music.note", "photo", "video",
+        "wand.and.stars", "testtube.2", "leaf", "bolt", "flame",
+        // サービス想起
+        "key", "brain", "sparkles", "bolt.fill", "waveform",
+        "chevron.left.forwardslash.chevron.right", "cloud.fill", "network",
+        "message.fill", "number", "bubble.left.and.bubble.right.fill",
+        "brain.head.profile", "wrench.and.screwdriver.fill", "face.smiling",
+        "star.fill", "tag.fill", "shippingbox.fill", "terminal.fill",
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.fixed(32)), count: columns), spacing: 6) {
+            ForEach(Self.options, id: \.self) { icon in
+                Button {
+                    selection = icon
+                } label: {
+                    Image(systemName: icon)
+                        .font(.system(size: 14))
+                        .frame(width: 28, height: 28)
+                        .background(
+                            selection == icon ? tint.opacity(0.2) : Color.clear,
+                            in: RoundedRectangle(cornerRadius: 6)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(selection == icon ? tint : Color.clear, lineWidth: 1.5)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help(icon)
+            }
+        }
+    }
+}

--- a/AIkeychain/Views/Components/IconPickerGrid.swift
+++ b/AIkeychain/Views/Components/IconPickerGrid.swift
@@ -23,9 +23,18 @@ struct IconPickerGrid: View {
         "star.fill", "tag.fill", "shippingbox.fill", "terminal.fill",
     ]
 
+    /// 現在の選択が選択肢に無い場合（既存キーのサービスアイコン等）でも
+    /// 選択状態が見えるよう、先頭に補う。
+    private var displayedOptions: [String] {
+        if !selection.isEmpty && !Self.options.contains(selection) {
+            return [selection] + Self.options
+        }
+        return Self.options
+    }
+
     var body: some View {
         LazyVGrid(columns: Array(repeating: GridItem(.fixed(32)), count: columns), spacing: 6) {
-            ForEach(Self.options, id: \.self) { icon in
+            ForEach(displayedOptions, id: \.self) { icon in
                 Button {
                     selection = icon
                 } label: {

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -36,7 +36,7 @@ struct KeyEditorView: View {
                         .foregroundStyle(.secondary)
                         .tag(CategorySelection?.none)
                     ForEach(KeyCategory.allCases) { cat in
-                        Label(cat.rawValue, systemImage: cat.systemImage)
+                        Label(cat.displayName, systemImage: cat.systemImage)
                             .tag(CategorySelection?.some(.builtin(cat)))
                     }
                     if !CustomKeyStore.shared.categories.isEmpty {

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -30,41 +30,9 @@ struct KeyEditorView: View {
 
             // Form
             Form {
-                // Optional quick-preset: picking a known service auto-fills the
-                // env var name + category below. Not required — a category and
-                // environment variable name are enough.
-                if !viewModel.isEditing {
-                    Section {
-                        Picker("Quick preset", selection: $viewModel.selectedService) {
-                            Text("None (custom key)")
-                                .foregroundStyle(.secondary)
-                                .tag(ServiceType?.none)
-                            ForEach(ServiceType.allCases) { service in
-                                Label(service.displayName, systemImage: service.systemImage)
-                                    .tag(ServiceType?.some(service))
-                            }
-                        }
-                        .onChange(of: viewModel.selectedService) {
-                            viewModel.onServiceChange()
-                        }
-                    } footer: {
-                        Text("Optional. Pick a known service to auto-fill the fields below, or just set a category and variable name.")
-                            .font(AppFonts.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                } else if let service = viewModel.selectedService {
-                    LabeledContent("Service") {
-                        HStack(spacing: 8) {
-                            Image(systemName: service.systemImage)
-                                .foregroundStyle(service.category.color)
-                            Text(service.displayName)
-                        }
-                    }
-                }
-
                 // Category (required)
-                Picker("Category", selection: $viewModel.selectedCategorySelection) {
-                    Text("Select a category...")
+                Picker(L10n.s(ja: "カテゴリ", en: "Category"), selection: $viewModel.selectedCategorySelection) {
+                    Text(L10n.s(ja: "カテゴリを選択...", en: "Select a category..."))
                         .foregroundStyle(.secondary)
                         .tag(CategorySelection?.none)
                     ForEach(KeyCategory.allCases) { cat in
@@ -79,19 +47,40 @@ struct KeyEditorView: View {
                         }
                     }
                 }
+                .onChange(of: viewModel.selectedCategorySelection) {
+                    viewModel.categoryDidChange()
+                }
 
                 // Env var name (required)
-                TextField("Environment Variable", text: $viewModel.envVarName)
+                TextField(L10n.s(ja: "環境変数名", en: "Environment Variable"), text: $viewModel.envVarName)
                     .font(AppFonts.code)
+
+                // Icon picker — pick the symbol shown for this key in its category.
+                Section {
+                    IconPickerGrid(
+                        selection: Binding(
+                            get: { viewModel.selectedIcon },
+                            set: { viewModel.pickIcon($0) }
+                        ),
+                        tint: categoryColor(viewModel.selectedCategorySelection)
+                    )
+                } header: {
+                    Text(L10n.s(ja: "アイコン", en: "Icon"))
+                } footer: {
+                    Text(L10n.s(ja: "一覧でこのキーに表示するアイコンを選びます。",
+                                en: "Choose the icon shown for this key in the list."))
+                        .font(AppFonts.caption)
+                        .foregroundStyle(.secondary)
+                }
 
                 // Token value
                 Section {
                     HStack {
                         if viewModel.showToken {
-                            TextField("Token Value", text: $viewModel.tokenValue)
+                            TextField(L10n.s(ja: "トークンの値", en: "Token Value"), text: $viewModel.tokenValue)
                                 .font(AppFonts.code)
                         } else {
-                            SecureField("Token Value", text: $viewModel.tokenValue)
+                            SecureField(L10n.s(ja: "トークンの値", en: "Token Value"), text: $viewModel.tokenValue)
                                 .font(AppFonts.code)
                         }
                         Button {
@@ -109,11 +98,11 @@ struct KeyEditorView: View {
                     }
                 }
 
-                // Setup URL
+                // Setup URL (existing preset keys only)
                 if let url = viewModel.selectedService?.setupURL {
                     Section {
                         Link(destination: url) {
-                            Label("Get Token", systemImage: "arrow.up.right.square")
+                            Label(L10n.s(ja: "トークンを取得", en: "Get Token"), systemImage: "arrow.up.right.square")
                         }
                     }
                 }
@@ -133,17 +122,19 @@ struct KeyEditorView: View {
             // Actions
             HStack {
                 if viewModel.isEditing {
-                    Button("Delete", role: .destructive) {
+                    Button(L10n.s(ja: "削除", en: "Delete"), role: .destructive) {
                         viewModel.showDeleteConfirm = true
                     }
                 }
 
                 Spacer()
 
-                Button("Cancel") { dismiss() }
+                Button(L10n.s(ja: "キャンセル", en: "Cancel")) { dismiss() }
                     .keyboardShortcut(.cancelAction)
 
-                Button(viewModel.showSaveSuccess ? "Saved!" : "Save to Keychain") {
+                Button(viewModel.showSaveSuccess
+                       ? L10n.s(ja: "保存しました", en: "Saved!")
+                       : L10n.s(ja: "Keychain に保存", en: "Save to Keychain")) {
                     do {
                         try viewModel.save()
                         onSave()
@@ -159,10 +150,10 @@ struct KeyEditorView: View {
             }
             .padding()
         }
-        .frame(width: 520, height: 460)
-        .alert("Delete Key?", isPresented: $viewModel.showDeleteConfirm) {
-            Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
+        .frame(width: 520, height: 480)
+        .alert(L10n.s(ja: "キーを削除しますか？", en: "Delete Key?"), isPresented: $viewModel.showDeleteConfirm) {
+            Button(L10n.s(ja: "キャンセル", en: "Cancel"), role: .cancel) {}
+            Button(L10n.s(ja: "削除", en: "Delete"), role: .destructive) {
                 do {
                     try viewModel.deleteKey()
                     onSave()
@@ -172,7 +163,17 @@ struct KeyEditorView: View {
                 }
             }
         } message: {
-            Text("This will remove the key from Keychain. This action cannot be undone.")
+            Text(L10n.s(ja: "このキーを Keychain から削除します。この操作は取り消せません。",
+                        en: "This will remove the key from Keychain. This action cannot be undone."))
+        }
+    }
+
+    /// 選択中カテゴリの強調色（アイコンピッカーの tint）。
+    private func categoryColor(_ sel: CategorySelection?) -> Color {
+        switch sel {
+        case .builtin(let cat): return cat.color
+        case .custom(let id): return CustomKeyStore.shared.category(for: id)?.color ?? AppColors.aiPurple
+        default: return AppColors.aiPurple
         }
     }
 }

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -55,25 +55,7 @@ struct KeyEditorView: View {
                 TextField(L10n.s(ja: "環境変数名", en: "Environment Variable"), text: $viewModel.envVarName)
                     .font(AppFonts.code)
 
-                // Icon picker — pick the symbol shown for this key in its category.
-                Section {
-                    IconPickerGrid(
-                        selection: Binding(
-                            get: { viewModel.selectedIcon },
-                            set: { viewModel.pickIcon($0) }
-                        ),
-                        tint: categoryColor(viewModel.selectedCategorySelection)
-                    )
-                } header: {
-                    Text(L10n.s(ja: "アイコン", en: "Icon"))
-                } footer: {
-                    Text(L10n.s(ja: "一覧でこのキーに表示するアイコンを選びます。",
-                                en: "Choose the icon shown for this key in the list."))
-                        .font(AppFonts.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                // Token value
+                // Token value (required) — primary input, kept above the optional icon picker.
                 Section {
                     HStack {
                         if viewModel.showToken {
@@ -96,6 +78,30 @@ struct KeyEditorView: View {
                             .font(AppFonts.caption)
                             .foregroundStyle(AppColors.pending)
                     }
+                } header: {
+                    Text(L10n.s(ja: "トークンの値", en: "Token Value"))
+                }
+
+                // Icon picker (optional) — compact, scrollable so it never hides the fields above.
+                Section {
+                    ScrollView {
+                        IconPickerGrid(
+                            selection: Binding(
+                                get: { viewModel.selectedIcon },
+                                set: { viewModel.pickIcon($0) }
+                            ),
+                            tint: categoryColor(viewModel.selectedCategorySelection)
+                        )
+                        .padding(.vertical, 2)
+                    }
+                    .frame(height: 96)
+                } header: {
+                    Text(L10n.s(ja: "アイコン（任意）", en: "Icon (optional)"))
+                } footer: {
+                    Text(L10n.s(ja: "一覧でこのキーに表示するアイコンを選びます。",
+                                en: "Choose the icon shown for this key in the list."))
+                        .font(AppFonts.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 // Setup URL (existing preset keys only)
@@ -150,7 +156,7 @@ struct KeyEditorView: View {
             }
             .padding()
         }
-        .frame(width: 520, height: 480)
+        .frame(width: 520, height: 540)
         .alert(L10n.s(ja: "キーを削除しますか？", en: "Delete Key?"), isPresented: $viewModel.showDeleteConfirm) {
             Button(L10n.s(ja: "キャンセル", en: "Cancel"), role: .cancel) {}
             Button(L10n.s(ja: "削除", en: "Delete"), role: .destructive) {

--- a/AIkeychain/Views/Main/KeyListView.swift
+++ b/AIkeychain/Views/Main/KeyListView.swift
@@ -11,7 +11,7 @@ struct KeyListView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(selectedCategoryName)
                         .font(AppFonts.sectionTitle)
-                    Text("\(viewModel.filteredKeys.count) keys")
+                    Text(L10n.s(ja: "\(viewModel.filteredKeys.count) 件のキー", en: "\(viewModel.filteredKeys.count) keys"))
                         .font(AppFonts.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -21,13 +21,13 @@ struct KeyListView: View {
                 Button {
                     showingImport = true
                 } label: {
-                    Label("Import", systemImage: "square.and.arrow.down")
+                    Label(L10n.s(ja: "インポート", en: "Import"), systemImage: "square.and.arrow.down")
                 }
 
                 Button {
                     viewModel.addNewKey()
                 } label: {
-                    Label("Add Key", systemImage: "plus")
+                    Label(L10n.s(ja: "キーを追加", en: "Add Key"), systemImage: "plus")
                 }
             }
             .padding()
@@ -46,10 +46,10 @@ struct KeyListView: View {
                     Image(systemName: "key.slash")
                         .font(.system(size: 32))
                         .foregroundStyle(.tertiary)
-                    Text("No Keys Found")
+                    Text(L10n.s(ja: "キーがありません", en: "No Keys Found"))
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.secondary)
-                    Text("Add Key or Import to get started.")
+                    Text(L10n.s(ja: "「キーを追加」またはインポートで始めましょう。", en: "Add Key or Import to get started."))
                         .font(.system(size: 12))
                         .foregroundStyle(.tertiary)
                 }
@@ -59,13 +59,13 @@ struct KeyListView: View {
                     KeyRowView(key: key)
                         .tag(key)
                         .contextMenu {
-                            Button("Edit") { viewModel.editKey(key) }
-                            Button("Copy Env Name") {
+                            Button(L10n.s(ja: "編集", en: "Edit")) { viewModel.editKey(key) }
+                            Button(L10n.s(ja: "変数名をコピー", en: "Copy Env Name")) {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(key.envVarName, forType: .string)
                             }
                             if key.isConfigured {
-                                Button("Copy Value") {
+                                Button(L10n.s(ja: "値をコピー", en: "Copy Value")) {
                                     if let value = viewModel.retrieveValue(for: key) {
                                         NSPasteboard.general.clearContents()
                                         NSPasteboard.general.setString(value, forType: .string)
@@ -78,7 +78,7 @@ struct KeyListView: View {
                             }
                             Divider()
                             if let url = key.setupURL {
-                                Button("Open Setup Page") {
+                                Button(L10n.s(ja: "取得ページを開く", en: "Open Setup Page")) {
                                     NSWorkspace.shared.open(url)
                                 }
                             }
@@ -93,14 +93,14 @@ struct KeyListView: View {
     }
 
     private var selectedCategoryName: String {
-        guard let sel = viewModel.selectedCategory else { return "All Keys" }
+        guard let sel = viewModel.selectedCategory else { return L10n.s(ja: "すべてのキー", en: "All Keys") }
         switch sel {
-        case .all: return "All Keys"
-        case .builtin(let cat): return cat.rawValue
+        case .all: return L10n.s(ja: "すべてのキー", en: "All Keys")
+        case .builtin(let cat): return cat.displayName
         case .custom(let id):
-            return CustomKeyStore.shared.category(for: id)?.name ?? "Custom"
+            return CustomKeyStore.shared.category(for: id)?.name ?? L10n.s(ja: "カスタム", en: "Custom")
         case .activity:
-            return "Activity"
+            return L10n.s(ja: "アクティビティ", en: "Activity")
         }
     }
 }

--- a/AIkeychain/Views/Main/KeyRowView.swift
+++ b/AIkeychain/Views/Main/KeyRowView.swift
@@ -6,7 +6,7 @@ struct KeyRowView: View {
     var body: some View {
         HStack(spacing: 12) {
             if let service = key.service {
-                ServiceIcon(service: service)
+                ServiceIcon(service: service, symbol: key.systemImage)
             } else {
                 Image(systemName: key.systemImage)
                     .font(.system(size: 16))

--- a/AIkeychain/Views/Main/SidebarView.swift
+++ b/AIkeychain/Views/Main/SidebarView.swift
@@ -15,7 +15,7 @@ struct SidebarView: View {
                 NavigationLink(value: CategorySelection.all) {
                     Label {
                         HStack {
-                            Text("All Keys")
+                            Text(L10n.s(ja: "すべてのキー", en: "All Keys"))
                             Spacer()
                             Text("\(viewModel.configuredCount)/\(viewModel.keys.count)")
                                 .font(AppFonts.badge)
@@ -30,7 +30,7 @@ struct SidebarView: View {
                 NavigationLink(value: CategorySelection.activity) {
                     Label {
                         HStack {
-                            Text("Activity")
+                            Text(L10n.s(ja: "アクティビティ", en: "Activity"))
                             Spacer()
                             if appState.isProxyMode && logStore.todayCount > 0 {
                                 Text("\(logStore.todayCount)")
@@ -45,12 +45,12 @@ struct SidebarView: View {
                 }
             }
 
-            Section("Categories") {
+            Section(L10n.s(ja: "カテゴリ", en: "Categories")) {
                 ForEach(KeyCategory.allCases) { category in
                     NavigationLink(value: CategorySelection.builtin(category)) {
                         Label {
                             HStack {
-                                Text(category.rawValue)
+                                Text(category.displayName)
                                 Spacer()
                                 Text("\(viewModel.builtinCategoryConfiguredCount(for: category))/\(viewModel.builtinCategoryCount(for: category))")
                                     .font(AppFonts.badge)
@@ -64,7 +64,7 @@ struct SidebarView: View {
             }
 
             if !customStore.categories.isEmpty {
-                Section("Custom") {
+                Section(L10n.s(ja: "カスタム", en: "Custom")) {
                     ForEach(customStore.categories) { category in
                         NavigationLink(value: CategorySelection.custom(category.id)) {
                             Label {
@@ -94,16 +94,16 @@ struct SidebarView: View {
                 Button {
                     showingCategoryEditor = true
                 } label: {
-                    Label("Manage Categories", systemImage: "folder.badge.gearshape")
+                    Label(L10n.s(ja: "カテゴリを管理", en: "Manage Categories"), systemImage: "folder.badge.gearshape")
                         .font(.system(size: 11))
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
 
                 HStack(spacing: 12) {
-                    Label("\(viewModel.configuredCount) configured", systemImage: "checkmark.circle.fill")
+                    Label(L10n.s(ja: "\(viewModel.configuredCount) 設定済み", en: "\(viewModel.configuredCount) configured"), systemImage: "checkmark.circle.fill")
                         .foregroundStyle(AppColors.configured)
-                    Label("\(viewModel.pendingCount) pending", systemImage: "exclamationmark.triangle.fill")
+                    Label(L10n.s(ja: "\(viewModel.pendingCount) 未設定", en: "\(viewModel.pendingCount) pending"), systemImage: "exclamationmark.triangle.fill")
                         .foregroundStyle(AppColors.pending)
                 }
                 .font(AppFonts.badge)

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -281,6 +281,14 @@ struct KeyEditorViewModelTests {
         #expect(store.overriddenIcon(for: "GITHUB_TOKEN") == "star.fill")
     }
 
+    @Test("APIKey.systemImage prefers a custom key's explicit icon (#110)")
+    func apiKeyExplicitIcon() {
+        let key = APIKey(customKey: CustomKey(
+            envVarName: "X_CUSTOM", displayName: "X",
+            categoryId: KeyCategory.devTools.stableId, icon: "flame"))
+        #expect(key.systemImage == "flame")
+    }
+
     @Test("Old CustomKey JSON without an icon field decodes safely (migration, #110)")
     func oldCustomKeyJsonDecodes() throws {
         // A record persisted by a version before the `icon` field existed.

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -84,13 +84,29 @@ struct KeyEditorViewModelTests {
         #expect(vm.selectedCategorySelection == nil)
     }
 
-    @Test("Service change updates env var name")
-    func serviceChange() {
+    @Test("Icon follows the category default until the user picks one")
+    func iconFollowsCategory() {
         let vm = KeyEditorViewModel(keychainService: MockKeychainService())
-        vm.selectedService = .github
-        vm.onServiceChange()
-        #expect(vm.envVarName == "GITHUB_TOKEN")
-        #expect(vm.selectedCategorySelection == .builtin(.codeAndGit))
+        vm.selectedCategorySelection = .builtin(.cloud)
+        vm.categoryDidChange()
+        #expect(vm.selectedIcon == KeyCategory.cloud.systemImage)
+
+        // Switching category updates the icon (not manually set yet)
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.categoryDidChange()
+        #expect(vm.selectedIcon == KeyCategory.devTools.systemImage)
+    }
+
+    @Test("Once the user picks an icon, category changes no longer override it")
+    func pickedIconSticks() {
+        let vm = KeyEditorViewModel(keychainService: MockKeychainService())
+        vm.selectedCategorySelection = .builtin(.cloud)
+        vm.categoryDidChange()
+        vm.pickIcon("flame")
+        #expect(vm.selectedIcon == "flame")
+        vm.selectedCategorySelection = .builtin(.ai)
+        vm.categoryDidChange()
+        #expect(vm.selectedIcon == "flame") // sticks
     }
 
     @Test("Prefix warning shows for wrong prefix")
@@ -213,6 +229,69 @@ struct KeyEditorViewModelTests {
         #expect(created != nil)
         #expect(created?.categoryId == KeyCategory.devTools.stableId)
         #expect(created?.displayName == "MY_CUSTOM_KEY")
+    }
+
+    @Test("Save stores a user-picked icon on a custom key (#110)")
+    func saveCustomKeyWithIcon() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mock = MockKeychainService()
+        let vm = KeyEditorViewModel(keychainService: mock, customStore: store)
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.envVarName = "MY_CUSTOM_KEY"
+        vm.tokenValue = "x"
+        vm.pickIcon("flame")
+        try vm.save()
+
+        let created = store.keys.first { $0.envVarName == "MY_CUSTOM_KEY" }
+        #expect(created?.icon == "flame")
+    }
+
+    @Test("Custom key icon equal to category default is not persisted (follows category)")
+    func saveCustomKeyIconMatchingCategoryNotStored() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mock = MockKeychainService()
+        let vm = KeyEditorViewModel(keychainService: mock, customStore: store)
+        vm.selectedCategorySelection = .builtin(.devTools)
+        vm.categoryDidChange() // icon = devTools default
+        vm.envVarName = "MY_CUSTOM_KEY"
+        vm.tokenValue = "x"
+        try vm.save()
+
+        let created = store.keys.first { $0.envVarName == "MY_CUSTOM_KEY" }
+        #expect(created?.icon == nil) // nil → follows category icon
+    }
+
+    @Test("Save stores an icon override for a preset-named key (#110)")
+    func saveIconOverrideForPresetName() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mock = MockKeychainService()
+        let vm = KeyEditorViewModel(keychainService: mock, customStore: store)
+        vm.selectedCategorySelection = .builtin(.codeAndGit)
+        vm.envVarName = "GITHUB_TOKEN"
+        vm.tokenValue = "ghp_x"
+        vm.pickIcon("star.fill")
+        try vm.save()
+
+        #expect(store.overriddenIcon(for: "GITHUB_TOKEN") == "star.fill")
+    }
+
+    @Test("Old CustomKey JSON without an icon field decodes safely (migration, #110)")
+    func oldCustomKeyJsonDecodes() throws {
+        // A record persisted by a version before the `icon` field existed.
+        let json = """
+        [{"id":"\(UUID().uuidString)","envVarName":"LEGACY_KEY","displayName":"Legacy",
+          "categoryId":"\(KeyCategory.ai.stableId.uuidString)"}]
+        """
+        let decoded = try JSONDecoder().decode([CustomKey].self, from: Data(json.utf8))
+        #expect(decoded.count == 1)
+        #expect(decoded[0].envVarName == "LEGACY_KEY")
+        #expect(decoded[0].icon == nil) // missing field → nil, no crash
     }
 
     @Test("Save with NO service but a preset-named env var preserves the chosen category via override (#102)")


### PR DESCRIPTION
## 概要
Closes #110

v1.6.0 実機テストのフィードバック対応:
1. AddKey / キー編集画面を**日本語化**
2. 「Service」項目を撤去し、**カテゴリ内表示用のアイコンを選ぶだけの項目**に
3. キーごとに好きな SF Symbol アイコンをセットして見やすく
4. 既存データを壊さない後方互換マイグレーション

## 変更内容
| 領域 | 変更 |
|---|---|
| モデル | `CustomKey` に optional `icon`（旧 JSON は nil 復号・非破壊）/ `CustomKeyStore.iconOverrides`（プリセット名キー用・新 UserDefaults キー）/ `APIKey.systemImage` を「個別アイコン → プリセット/カテゴリ」フォールバックに |
| UI | 共通 `IconPickerGrid` 追加 / `KeyEditorView` の Service ピッカーを撤去しアイコンピッカーに置換 / `L10n.s` で全面日本語化 |
| 挙動 | アイコンはカテゴリ既定に追従し、ユーザーが選ぶと固定。既定と同じなら保存しない（カテゴリ追従を維持） |

## マイグレーション（破壊なし）
追加項目は全て**任意**で後方互換:
- 旧 `CustomKey` JSON（icon フィールド無し）→ `icon = nil` で復号（テストで検証）
- `iconOverrides` は新規 UserDefaults キー → 旧環境に無くても空
- 既存キー/カスタムキー/カテゴリ上書きは従来どおり表示

## テスト計画
- [x] `swift test` **92/92 PASS**
- [x] アイコンがカテゴリ既定に追従 / ユーザー選択で固定
- [x] custom キーへの icon 保存 / 既定と同じなら nil / プリセット名キーは iconOverride 保存
- [x] 旧 JSON（icon 無し）の復号（マイグレーション）
- [ ] GUI 実機での日本語表示・アイコン選択は手動確認（ロジックは単体テスト済み）

## 非対象
- `ServiceType` 型は後方互換で残置（一覧表示・env インポート・ProxyRoute が使用）
- カテゴリ管理機能・初期カテゴリは不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)
