### PR TITLE
fix(security): プロキシ セッショントークンファイルを 0600 で作成 (#113)

### DIFF
--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -45,7 +45,25 @@ enum SetupManager {
         if !sessionToken.isEmpty {
             content += "\nexport AIKEYCHAIN_SESSION_TOKEN=\(sessionToken)"
         }
-        try content.write(toFile: proxyEnvPath, atomically: true, encoding: .utf8)
+        try writeProxyEnvFile(at: proxyEnvPath, content: content)
+    }
+
+    /// プロキシ設定ファイルを 0600 (rw-------) で書き込む
+    ///
+    /// このファイルには `AIKEYCHAIN_SESSION_TOKEN`（ループバックプロキシの唯一の
+    /// 認証情報。ユーザーの Keychain API キーで署名を行う）が含まれる。
+    /// umask 022 環境ではデフォルト 0644 (world-readable) になり、macOS では
+    /// 全ローカルアカウントが group `staff` に属するため、他アカウントから読み取れて
+    /// しまう。書き込み後に明示的に 0600 を適用してトークンの漏洩を防ぐ。
+    ///
+    /// `String.write(atomically:true)` は一時ファイルへ書いて rename するため、
+    /// mode がリセットされうる。したがって **書き込み後** に chmod する。
+    static func writeProxyEnvFile(at path: String, content: String) throws {
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: path
+        )
     }
 
     /// プロキシ停止時に設定ファイルを削除

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 
 /// プロキシの環境変数設定を管理する
 ///
@@ -48,22 +51,74 @@ enum SetupManager {
         try writeProxyEnvFile(at: proxyEnvPath, content: content)
     }
 
-    /// プロキシ設定ファイルを 0600 (rw-------) で書き込む
+    /// プロキシ設定ファイルの書き込みで発生しうるエラー
+    enum ProxyEnvWriteError: Error {
+        case open(errno: Int32)
+        case write(errno: Int32)
+        case rename(errno: Int32)
+        case encoding
+    }
+
+    /// プロキシ設定ファイルを 0600 (rw-------) で atomic に書き込む
     ///
     /// このファイルには `AIKEYCHAIN_SESSION_TOKEN`（ループバックプロキシの唯一の
-    /// 認証情報。ユーザーの Keychain API キーで署名を行う）が含まれる。
-    /// umask 022 環境ではデフォルト 0644 (world-readable) になり、macOS では
-    /// 全ローカルアカウントが group `staff` に属するため、他アカウントから読み取れて
-    /// しまう。書き込み後に明示的に 0600 を適用してトークンの漏洩を防ぐ。
+    /// 認証情報。ユーザーの Keychain API キーで署名を行う）が含まれる。macOS では
+    /// 全ローカルアカウントが group `staff` に属するため、0644 で一瞬でも公開されると
+    /// co-resident 攻撃者がトークンを読み取れてしまう (#113 / TOCTOU)。
     ///
-    /// `String.write(atomically:true)` は一時ファイルへ書いて rename するため、
-    /// mode がリセットされうる。したがって **書き込み後** に chmod する。
+    /// 実装: 同ディレクトリ内の一時ファイルを
+    /// `open(O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, 0o600)` で作成する。mode 0600 は
+    /// umask で緩む方向にしか作用しないため、**umask に依存せず確実に 0600** で生成
+    /// される（0644 になる瞬間が一切存在しない）。content を書き込んでから
+    /// `rename(2)` で最終パスへ atomic に差し替える。.zshrc が source するため
+    /// atomic 性が必要だが、rename の前後どちらのパスにも 0600 より緩いモードの
+    /// ファイルは一度も現れない。
+    ///
+    /// fail-closed: 途中で失敗した場合は一時ファイルを unlink し、0644 の残骸を
+    /// 残さず throw する。
     static func writeProxyEnvFile(at path: String, content: String) throws {
-        try content.write(toFile: path, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: path
-        )
+        guard let data = content.data(using: .utf8) else {
+            throw ProxyEnvWriteError.encoding
+        }
+
+        let dir = (path as NSString).deletingLastPathComponent
+        let base = (path as NSString).lastPathComponent
+        let tmpPath = "\(dir)/.\(base).tmp.\(getpid()).\(UInt32.random(in: 0..<UInt32.max))"
+
+        // 一時ファイルを umask 非依存の 0600 で排他作成。シンボリックリンク攻撃も拒否。
+        let fd = open(tmpPath, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        if fd < 0 {
+            throw ProxyEnvWriteError.open(errno: errno)
+        }
+
+        do {
+            try data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+                var written = 0
+                let total = raw.count
+                let bytes = raw.bindMemory(to: UInt8.self).baseAddress
+                while written < total {
+                    let n = Darwin.write(fd, bytes!.advanced(by: written), total - written)
+                    if n < 0 {
+                        if errno == EINTR { continue }
+                        throw ProxyEnvWriteError.write(errno: errno)
+                    }
+                    written += n
+                }
+            }
+        } catch {
+            close(fd)
+            unlink(tmpPath)   // fail-closed: 中途半端な 0600 ファイルも残さない
+            throw error
+        }
+
+        close(fd)
+
+        // atomic に最終パスへ。失敗したら一時ファイルを掃除して throw。
+        if rename(tmpPath, path) != 0 {
+            let err = errno
+            unlink(tmpPath)
+            throw ProxyEnvWriteError.rename(errno: err)
+        }
     }
 
     /// プロキシ停止時に設定ファイルを削除

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -66,6 +66,43 @@ struct SetupManagerTests {
         #expect(!FileManager.default.fileExists(atPath: path))
     }
 
+    @Test("writeProxyEnvFile creates file with 0600 permissions (token not world-readable)")
+    func proxyEnvFilePermissions() throws {
+        // 一時ロケーションに書き込み、最終ファイルの POSIX 権限を検証する。
+        // #113: セッショントークンを含むため 0600 (rw-------) でなければならない。
+        let tmpDir = NSTemporaryDirectory()
+        let path = tmpDir + "aikeychain_proxy_perm_test_\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let content = """
+        export ANTHROPIC_BASE_URL=http://localhost:18121
+        export AIKEYCHAIN_SESSION_TOKEN=super-secret-token
+        """
+        try SetupManager.writeProxyEnvFile(at: path, content: content)
+
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms == 0o600, "Expected 0600, got \(String(format: "%o", perms ?? -1))")
+
+        // 上書きしても 0600 を維持すること
+        try SetupManager.writeProxyEnvFile(at: path, content: content + "\n# updated")
+        let attrs2 = try FileManager.default.attributesOfItem(atPath: path)
+        let perms2 = (attrs2[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms2 == 0o600, "Expected 0600 after overwrite, got \(String(format: "%o", perms2 ?? -1))")
+    }
+
+    @Test("activateProxy writes proxy env file with 0600 permissions")
+    func activateProxyPermissions() throws {
+        defer { SetupManager.deactivateProxy() }
+        try SetupManager.activateProxy(port: 18121, sessionToken: "test-token")
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: SetupManager.proxyEnvPath)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms == 0o600, "Expected 0600, got \(String(format: "%o", perms ?? -1))")
+    }
+
     @Test("isProxyActive reflects file existence")
     func proxyActiveState() throws {
         // まずクリーンな状態にする

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -91,6 +91,31 @@ struct SetupManagerTests {
         let attrs2 = try FileManager.default.attributesOfItem(atPath: path)
         let perms2 = (attrs2[.posixPermissions] as? NSNumber)?.intValue
         #expect(perms2 == 0o600, "Expected 0600 after overwrite, got \(String(format: "%o", perms2 ?? -1))")
+
+        // 一時ファイル (.<base>.tmp.*) が残っていないこと (atomic rename が完了)
+        let dir = (path as NSString).deletingLastPathComponent
+        let base = (path as NSString).lastPathComponent
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: dir))?
+            .filter { $0.hasPrefix(".\(base).tmp.") } ?? []
+        #expect(leftovers.isEmpty, "Temp file left behind: \(leftovers)")
+    }
+
+    @Test("writeProxyEnvFile yields 0600 even under umask 022 (TOCTOU: no 0644 window)")
+    func proxyEnvFileUmaskIndependent() throws {
+        // #113 TOCTOU: umask 022 でも一切 0644 にならず 0600 で生成されることを検証。
+        // O_CREAT の mode 0600 は umask で緩む方向にしか効かないため umask 非依存。
+        let old = umask(0o022)
+        defer { umask(old) }
+
+        let path = NSTemporaryDirectory() + "aikeychain_proxy_umask_test_\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        try SetupManager.writeProxyEnvFile(
+            at: path,
+            content: "export AIKEYCHAIN_SESSION_TOKEN=secret"
+        )
+        let perms = (try FileManager.default.attributesOfItem(atPath: path)[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms == 0o600, "Expected 0600 under umask 022, got \(String(format: "%o", perms ?? -1))")
     }
 
     @Test("activateProxy writes proxy env file with 0600 permissions")


### PR DESCRIPTION
## 概要

Closes #113

`AIkeychain/Services/SetupManager.swift` の `activateProxy(port:sessionToken:)` は
`~/.aikeychain_proxy` を明示的な POSIX mode 指定なしで書き込んでいた。
`String.write(toFile:atomically:true)` は umask に従うため、umask 022 環境では
**0644 (world-readable)** のファイルが生成されていた。

## 脅威 (Threat)

このファイルには以下が含まれる:

```
export AIKEYCHAIN_SESSION_TOKEN=<token>
```

このトークンは **ループバックプロキシの唯一の認証情報** であり、プロキシは
このトークンで受理したリクエストをユーザーの Keychain API キーで署名して
上流 (Anthropic / OpenAI / xAI) に転送する。

macOS では全ローカルアカウントが group `staff` に属する。0644 のファイルは
group / other から読めるため、**同一マシンの別ローカルアカウントがトークンを
読み取り、被害者の Keychain API キーを使って課金・データアクセスを行える**。

## 修正 (Fix)

- 書き込みロジックをテスト可能な内部ヘルパー `writeProxyEnvFile(at:content:)` に抽出。
- `String.write(atomically:true)` は temp ファイルへ書いて rename する（mode が
  リセットされうる）ため、**書き込み後** に `FileManager.setAttributes([.posixPermissions: 0o600])`
  で 0600 (rw-------) を明示適用。上書き時も毎回 chmod するため 0600 を維持する。
- 挙動はそれ以外一切変更なし。
- 権限を検証するユニットテストを 2 件追加（ヘルパー直接 + `activateProxy` 経由）。

## 動作確認 (Evidence)

### swift test (新しい権限テストがパス)

```
◇ Test "writeProxyEnvFile creates file with 0600 permissions (token not world-readable)" started.
✔ Test "writeProxyEnvFile creates file with 0600 permissions (token not world-readable)" passed after 0.001 seconds.
◇ Test "activateProxy writes proxy env file with 0600 permissions" started.
✔ Test "activateProxy writes proxy env file with 0600 permissions" passed after 0.001 seconds.
✔ Suite "SetupManager Tests" passed after 0.310 seconds.
✔ Test run with 95 tests in 15 suites passed after 2.012 seconds.
```

### ファイル権限 (umask 022 環境で helper ロジックを実行)

```
=== ls -l ===
-rw-------@ 1 takehiro  wheel  98  ... /tmp/aikeychain_proxy_evidence
=== stat ===
-rw------- /tmp/aikeychain_proxy_evidence
```

`-rw-------` = 0600。所有者のみ読み書き可能で、group `staff` / other からは
読み取れないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
