### PR TITLE
fix(security): CLI の security バイナリを /usr/bin/security 絶対パスに固定 (#117)

### DIFF
--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -44,6 +44,9 @@ async function applyUpsert(path, upsert) {
 /** Is the aikeychain MCP server already registered with Claude Code? */
 async function claudeMcpRegistered() {
   try {
+    // `claude` is invoked by bare name (PATH lookup) intentionally: unlike
+    // `security` (see issue #117 / cli/src/keychain.js), this command never
+    // handles secret material, so a hijacked PATH entry has nothing to steal.
     const { stdout } = await pExecFile('claude', ['mcp', 'list'], { timeout: 15000 });
     return /(^|\n)\s*aikeychain[:\s]/.test(stdout);
   } catch {

--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -44,9 +44,13 @@ async function applyUpsert(path, upsert) {
 /** Is the aikeychain MCP server already registered with Claude Code? */
 async function claudeMcpRegistered() {
   try {
-    // `claude` is invoked by bare name (PATH lookup) intentionally: unlike
-    // `security` (see issue #117 / cli/src/keychain.js), this command never
-    // handles secret material, so a hijacked PATH entry has nothing to steal.
+    // `claude` is invoked by bare name (PATH lookup) intentionally. Unlike
+    // `security` (issue #117 / cli/src/keychain.js), no secret is ever passed to
+    // it (no secret args, no stdin), so this is not the secret-interception
+    // vector #117 closes. Bare lookup is accepted on parity grounds — an
+    // attacker who can plant a fake `claude` on PATH already gets code execution
+    // the moment the user runs `claude` themselves — and because `claude` has no
+    // single stable absolute path (npm-global / Homebrew / ~/.claude/local).
     const { stdout } = await pExecFile('claude', ['mcp', 'list'], { timeout: 15000 });
     return /(^|\n)\s*aikeychain[:\s]/.test(stdout);
   } catch {

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -11,6 +11,19 @@ import { promisify } from 'node:util';
 
 const pExecFile = promisify(execFile);
 
+// Always invoke the `security` binary by absolute path (issue #117): a bare
+// 'security' command name is resolved via PATH lookup, so a same-uid
+// attacker (or a malicious postinstall from any other npm package) could
+// place a fake `security` earlier on PATH and intercept secrets — including
+// the hex-encoded value fed to `add-generic-password` on stdin — without the
+// real Keychain's ACL/authorization prompt ever appearing. The Swift GUI
+// already hardcodes /usr/bin/security; the CLI must match.
+//
+// AIKEYCHAIN_SECURITY_BIN is an override for tests only (to point at a PATH
+// stub instead of the real binary) — it must never be relied on in
+// production, where the default below is always used.
+export const SECURITY_BIN = process.env.AIKEYCHAIN_SECURITY_BIN || '/usr/bin/security';
+
 export const KEY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
 export const GUI_SERVICE = 'com.aieo.aikeychain';
@@ -29,7 +42,7 @@ export function assertMacOS() {
 
 async function security(args) {
   try {
-    const { stdout, stderr } = await pExecFile('security', args, {
+    const { stdout, stderr } = await pExecFile(SECURITY_BIN, args, {
       maxBuffer: 16 * 1024 * 1024,
     });
     return { ok: true, stdout, stderr };
@@ -72,7 +85,7 @@ export function redactSecrets(text) {
 /** Run a command through `security -i`, which reads commands from stdin. */
 function securityInteractive(commandLine) {
   return new Promise((resolve) => {
-    const child = spawn('security', ['-i'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawn(SECURITY_BIN, ['-i'], { stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (chunk) => (stdout += chunk));

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -8,6 +8,7 @@
 
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
+import { isAbsolute } from 'node:path';
 
 const pExecFile = promisify(execFile);
 
@@ -22,7 +23,16 @@ const pExecFile = promisify(execFile);
 // AIKEYCHAIN_SECURITY_BIN is an override for tests only (to point at a PATH
 // stub instead of the real binary) — it must never be relied on in
 // production, where the default below is always used.
-export const SECURITY_BIN = process.env.AIKEYCHAIN_SECURITY_BIN || '/usr/bin/security';
+//
+// The override MUST be an absolute path. A relative value (e.g. "security")
+// would fall back to PATH lookup inside execFile/spawn and silently
+// reintroduce the very #117 vulnerability this fix closes, so a non-absolute
+// override is ignored in favor of the hardcoded default.
+const securityBinOverride = process.env.AIKEYCHAIN_SECURITY_BIN;
+export const SECURITY_BIN =
+  securityBinOverride && isAbsolute(securityBinOverride)
+    ? securityBinOverride
+    : '/usr/bin/security';
 
 export const KEY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -6,7 +6,7 @@ import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { mkdtemp, writeFile, chmod } from 'node:fs/promises';
+import { mkdtemp, writeFile, chmod, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -110,6 +110,32 @@ test('run passes through when no refs exist', async () => {
   const r = await runAkc(['run', '--', 'echo', 'hello']);
   assert.equal(r.code, 0);
   assert.match(r.stdout, /hello/);
+});
+
+test('a `security` stub on PATH is ignored when the override is unset (issue #117)', async () => {
+  // The actual fix: even with a hostile `security` first on PATH, the CLI must
+  // invoke the hardcoded absolute /usr/bin/security and never the PATH stub.
+  // (execFile with an absolute path does not search PATH, so this holds even on
+  // platforms where /usr/bin/security is absent — the stub is simply never run.)
+  const hijackDir = await mkdtemp(join(tmpdir(), 'akc-hijack-'));
+  const marker = join(hijackDir, 'INVOKED');
+  const hijack = join(hijackDir, 'security');
+  await writeFile(hijack, `#!/bin/bash\ntouch "${marker}"\nexit 0\n`);
+  await chmod(hijack, 0o755);
+
+  // Read-only command, hijack dir first on PATH, and crucially NO
+  // AIKEYCHAIN_SECURITY_BIN override.
+  await pExecFile(process.execPath, [AKC, 'check', 'DEFINITELY_NOT_A_REAL_KEY_117'], {
+    env: { PATH: `${hijackDir}:${process.env.PATH}` },
+  }).catch(() => {});
+
+  let stubWasInvoked = true;
+  try {
+    await access(marker);
+  } catch {
+    stubWasInvoked = false;
+  }
+  assert.equal(stubWasInvoked, false, 'PATH `security` stub was executed — absolute path not enforced');
 });
 
 test('run resolves GUI-store and manual refs into the child env only', async () => {

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -1,5 +1,7 @@
-// CLI integration tests. A stub `security` command is placed first on PATH so
-// these run without touching the real Keychain.
+// CLI integration tests. A stub `security` command is pointed to via
+// AIKEYCHAIN_SECURITY_BIN (the test-only override for the hardcoded
+// /usr/bin/security default, issue #117) so these run without touching the
+// real Keychain.
 import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
@@ -71,7 +73,7 @@ before(async () => {
 
 function runAkc(args, env = {}) {
   return pExecFile(process.execPath, [AKC, ...args], {
-    env: { PATH: `${stubDir}:${process.env.PATH}`, ...env },
+    env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security'), ...env },
   }).then(
     (r) => ({ code: 0, ...r }),
     (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
@@ -178,7 +180,7 @@ test('set stores a piped value via security -i stdin, never argv', async () => {
   const r = await pExecFile(
     'bash',
     ['-c', `echo "piped-secret" | ${process.execPath} ${AKC} set NEW_KEY`],
-    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
   ).then(
     (r) => ({ code: 0, ...r }),
     (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
@@ -194,7 +196,7 @@ test('set failure stderr never leaks the value, even when security echoes the co
   const r = await pExecFile(
     'bash',
     ['-c', `printf '%s' "${value}" | ${process.execPath} ${AKC} set ECHO_KEY`],
-    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
   ).then(
     () => ({ code: 0, stdout: '', stderr: '' }),
     (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
@@ -210,7 +212,7 @@ test('set rejects invalid names and control characters before touching security'
   const badName = await pExecFile(
     'bash',
     ['-c', `echo "v" | ${process.execPath} ${AKC} set 'BAD KEY'`],
-    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
   ).then(
     () => ({ code: 0 }),
     (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })
@@ -221,7 +223,7 @@ test('set rejects invalid names and control characters before touching security'
   const ctrl = await pExecFile(
     'bash',
     ['-c', `printf 'line1\\nline2\\n' | ${process.execPath} ${AKC} set NEW_KEY`],
-    { env: { PATH: `${stubDir}:${process.env.PATH}` } }
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
   ).then(
     () => ({ code: 0 }),
     (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })


### PR DESCRIPTION
Closes #117

## 脅威 (Threat)

`cli/src/keychain.js` は macOS の `security` バイナリをベア名（`'security'`）で
`execFile`/`spawn` していた。これは PATH 経由のルックアップになるため:

- 同一 uid の攻撃者、または npm でインストールした**別パッケージの悪意ある
  `postinstall`** が、`PATH` 上で本物の `/usr/bin/security` より手前に偽の
  `security` を配置できる。
- 次に `akc set` を実行すると、hex エンコードされた秘密値が `security -i`
  の stdin 経由で**偽バイナリ**に渡ってしまい、本物の Keychain の
  ACL/認可プロンプトを一切経由しない。
- Swift 側 (GUI) は既に `/usr/bin/security` を絶対パスで固定済みで、この非対称性が
  Node CLI 側の抜け穴だった。

## 修正 (Fix)

- `cli/src/keychain.js` にモジュールレベル定数 `SECURITY_BIN`
  （デフォルト `/usr/bin/security`）を追加し、`execFile('security', …)` と
  `spawn('security', ['-i'], …)` の両方をこの定数経由に統一。引数配列は変更なし。
- テストでのみ有効な `AIKEYCHAIN_SECURITY_BIN` 環境変数オーバーライドを追加。
  本番のデフォルトは常に絶対パスで、テストのみがスタブ `security` への差し替えに使う。
- `cli/test/cli.test.js` は従来 PATH 先頭にスタブ `security` を差し込む方式
  だったが、絶対パス化により PATH 経由では届かなくなるため、
  `AIKEYCHAIN_SECURITY_BIN` 経由でスタブを注入する方式に切り替え（テストの意図は
  そのまま維持）。
- `cli/src/doctor.js` 等、他に `security` をベア名 spawn している箇所がないか
  `grep` で確認済み（`doctor.js` はテキスト解析のみで実際の spawn はなし）。
- `cli/src/init.js` の `claude mcp ...` 呼び出しは秘密を扱わないため意図的に
  PATH ルックアップのままとし、その理由を示す一行コメントを追加。

## 動作確認 (Evidence)

`npm test` の末尾（全 37 件 pass）:

```
✔ set stores a piped value via security -i stdin, never argv (131.047667ms)
✔ set failure stderr never leaks the value, even when security echoes the command (97.50525ms)
✔ set rejects invalid names and control characters before touching security (185.813375ms)
✔ AGENT_INSTRUCTIONS teaches the core rules (0.393458ms)
✔ upsertManagedBlock creates a block in empty content (0.12025ms)
✔ upsertManagedBlock appends after existing content with separation (0.048709ms)
✔ upsertManagedBlock is idempotent (re-run reports unchanged) (0.10425ms)
✔ upsertManagedBlock replaces an outdated block in place (no duplicate) (0.074417ms)
✔ upsertManagedBlock refuses to edit a dangling BEGIN (no END) — never truncates user content (0.052708ms)
✔ upsertManagedBlock refuses a dangling END (no BEGIN) (0.044708ms)
✔ upsertManagedBlock canonicalizes duplicate blocks to exactly one, preserving surrounding text (0.084917ms)
✔ upsertCodexBlock appends once and is idempotent (never reformats existing TOML) (0.092417ms)
✔ upsertCodexBlock refuses to append when a marker-less aikeychain table already exists (0.105417ms)
✔ akc init --print previews machine-wide setup without writing (33.828917ms)
✔ akc init (default machine-wide) writes ~/.claude + ~/.codex under HOME, idempotently (65.116917ms)
✔ akc init --local writes cwd CLAUDE.md + AGENTS.md, preserving existing content (94.049375ms)
✔ mcp server lists the expected tools and none returns raw values (85.010625ms)
✔ usage_guide returns the agent guide text (77.423292ms)
✔ delete_secret refuses without confirm=true (77.050375ms)
✔ parseDump extracts genp service/account pairs only (0.861625ms)
✔ MANUAL_NAME_PATTERN accepts env-var names and rejects bundle ids (0.086167ms)
✔ maskValue never includes the value (0.04375ms)
✔ findAmbiguousDuplicates flags same-service multi-acct entries (issue #91) (0.094125ms)
✔ findAmbiguousDuplicates returns empty when every service is unique (0.055875ms)
✔ collectRefs picks only keychain:// values (0.073ms)
✔ scanShellConfig finds refs, security lookups, and the -a $USER pitfall (0.235ms)
ℹ tests 37
ℹ suites 0
ℹ pass 37
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1393.506
```

ベア `security` spawn が残っていないことの確認:

```
$ grep -rn "spawn(['\"]security\|execFile(['\"]security\|'security'\|\"security\"" src
src/keychain.js:15:// 'security' command name is resolved via PATH lookup, so a same-uid
no bare security refs remain (実コードでの一致なし。上記1件は説明コメント内の引用のみ)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
