### PR TITLE
feat(security): キー共有に送信者認証（署名 + フィンガープリント確認 + 値プレビュー）(#112)

### DIFF
--- a/AIkeychain/Services/KeyShareService.swift
+++ b/AIkeychain/Services/KeyShareService.swift
@@ -2,41 +2,101 @@ import Foundation
 import CryptoKit
 
 /// 公開鍵暗号方式による Keychain 共有サービス
-/// P-256 + ECDH + AES-256-GCM
+/// P-256 + ECDH + AES-256-GCM（機密性）に加え、
+/// P-256 ECDSA 署名（送信者認証・完全性）を付与する。
+///
+/// 脅威モデル: 受信者の公開鍵は共有される前提のため、暗号化だけでは
+/// 「復号できた＝正しい送信者が作った」とは言えない。公開鍵を持つ第三者は
+/// 完全に有効な `.aikeychain` を偽造でき、受信者に攻撃者が選んだキー値を
+/// 掴ませる（credential substitution）ことが可能。これを防ぐため送信者の
+/// 署名鍵で正規メッセージに署名し、受信者はフィンガープリントを帯域外で
+/// 照合する（有効な署名 ≠ 信頼できる送信者。UI がこの照合を強制する）。
 enum KeyShareService {
 
     private static let privateKeyTag = "com.aieo.aikeychain.sharekey"
+    private static let signKeyTag = "com.aieo.aikeychain.signkey"
+
+    /// createdAt の直列化に使う ISO8601 フォーマッタ（正規メッセージにも埋め込む）。
+    private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
 
     // MARK: - Key Pair Management
 
-    /// 鍵ペアを生成して秘密鍵を Keychain に保存
+    /// 鍵ペア（鍵共有 + 署名）を生成して秘密鍵を Keychain に保存
     static func generateKeyPair() throws -> P256.KeyAgreement.PublicKey {
         let privateKey = P256.KeyAgreement.PrivateKey()
 
         // 秘密鍵を Keychain に保存
         try savePrivateKey(privateKey)
 
+        // 署名鍵も同時に用意する
+        _ = try ensureSigningKey()
+
         return privateKey.publicKey
     }
 
-    /// 秘密鍵が既に存在するか
+    /// 秘密鍵（鍵共有）が既に存在するか
     static func hasKeyPair() -> Bool {
         loadPrivateKey() != nil
     }
 
-    /// 公開鍵を取得
+    /// 公開鍵（鍵共有）を取得
     static func getPublicKey() -> P256.KeyAgreement.PublicKey? {
         loadPrivateKey()?.publicKey
     }
 
-    /// 鍵ペアを削除
+    /// 鍵ペアを削除（鍵共有 + 署名の両方）
     static func deleteKeyPair() {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: privateKeyTag,
-            kSecAttrAccount as String: "private_key",
-        ]
-        SecItemDelete(query as CFDictionary)
+        for (service, account) in [(privateKeyTag, "private_key"), (signKeyTag, "signing_key")] {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: account,
+            ]
+            SecItemDelete(query as CFDictionary)
+        }
+    }
+
+    // MARK: - Signing Identity
+
+    /// 署名鍵を取得（無ければ生成して保存 = 既存ユーザーにも透過的に付与）
+    @discardableResult
+    static func ensureSigningKey() throws -> P256.Signing.PrivateKey {
+        if let existing = loadSigningPrivateKey() {
+            return existing
+        }
+        let key = P256.Signing.PrivateKey()
+        try saveSigningPrivateKey(key)
+        return key
+    }
+
+    /// 署名用公開鍵を取得（存在する場合のみ。無ければ nil）
+    static func getSigningPublicKey() -> P256.Signing.PublicKey? {
+        loadSigningPrivateKey()?.publicKey
+    }
+
+    /// 自分の署名フィンガープリント（無ければ生成して算出）
+    static func ownSigningFingerprint() -> String? {
+        guard let key = try? ensureSigningKey() else { return nil }
+        return fingerprint(of: key.publicKey)
+    }
+
+    /// 署名公開鍵の SHA256(x963) を 256bit フル長で、4桁ずつスペース区切りの
+    /// 大文字16進として返す（例: "1A2B 3C4D ..."）。64bit などに切り詰めない。
+    static func fingerprint(of signingPublicKey: P256.Signing.PublicKey) -> String {
+        let hash = SHA256.hash(data: signingPublicKey.x963Representation)
+        let hex = hash.map { String(format: "%02X", $0) }.joined()
+        var groups: [String] = []
+        var idx = hex.startIndex
+        while idx < hex.endIndex {
+            let end = hex.index(idx, offsetBy: 4, limitedBy: hex.endIndex) ?? hex.endIndex
+            groups.append(String(hex[idx..<end]))
+            idx = end
+        }
+        return groups.joined(separator: " ")
     }
 
     // MARK: - Public Key Export/Import
@@ -68,14 +128,65 @@ enum KeyShareService {
         return try P256.KeyAgreement.PublicKey(x963Representation: keyData)
     }
 
+    // MARK: - Canonical Signed Message (pure / testable)
+
+    /// 署名対象の正規（canonical）メッセージを構築する。
+    ///
+    /// バイト列レイアウト（UTF-8、フィールドは固定順、`\n`(0x0A) 区切り、末尾改行なし）:
+    /// ```
+    /// AIKEYCHAIN-SHARE-SIG-V1\n
+    /// version:<version>\n
+    /// ephemeralPublicKey:<base64 x963>\n
+    /// encryptedData:<base64 sealed box>\n
+    /// keyCount:<int>\n
+    /// senderSigningPublicKey:<base64 x963>\n
+    /// createdAt:<ISO8601>
+    /// ```
+    /// base64 アルファベット（A-Za-z0-9+/=）は `:` も `\n` も含まないため、
+    /// フィールド境界は一意に定まる。createdAt は `:` を含むが最終フィールドなので曖昧さは無い。
+    /// 署名検証時は、パース済みの各フィールドから同一のバイト列を再構築して照合する。
+    static func canonicalMessage(
+        version: Int,
+        ephemeralPublicKeyB64: String,
+        encryptedDataB64: String,
+        keyCount: Int,
+        senderSigningPublicKeyB64: String,
+        createdAt: String
+    ) -> Data {
+        let s = """
+        AIKEYCHAIN-SHARE-SIG-V1
+        version:\(version)
+        ephemeralPublicKey:\(ephemeralPublicKeyB64)
+        encryptedData:\(encryptedDataB64)
+        keyCount:\(keyCount)
+        senderSigningPublicKey:\(senderSigningPublicKeyB64)
+        createdAt:\(createdAt)
+        """
+        return Data(s.utf8)
+    }
+
+    /// 正規メッセージへ署名し rawRepresentation を返す（純粋・鍵引数）
+    static func signMessage(_ message: Data, with signingKey: P256.Signing.PrivateKey) throws -> Data {
+        try signingKey.signature(for: message).rawRepresentation
+    }
+
+    /// 署名を検証（純粋・鍵引数）。壊れた署名バイト列は false を返す。
+    static func verify(_ message: Data, signature: Data, publicKey: P256.Signing.PublicKey) -> Bool {
+        guard let sig = try? P256.Signing.ECDSASignature(rawRepresentation: signature) else {
+            return false
+        }
+        return publicKey.isValidSignature(sig, for: message)
+    }
+
     // MARK: - Encrypt (送信者)
 
-    /// 選択したキーを受信者の公開鍵で暗号化して .aikeychain ファイルに書き出し
-    static func encryptAndExport(
+    /// 暗号化 + 署名済みの EncryptedFile を構築する（純粋・鍵引数。Keychain 非依存）。
+    static func makeEncryptedFile(
         keys: [(envVarName: String, value: String)],
         recipientPublicKey: P256.KeyAgreement.PublicKey,
-        to url: URL
-    ) throws {
+        signingPrivateKey: P256.Signing.PrivateKey,
+        createdAt: Date = Date()
+    ) throws -> ShareFileFormat.EncryptedFile {
         // 1. エフェメラル鍵ペアを生成
         let ephemeralKey = P256.KeyAgreement.PrivateKey()
 
@@ -100,12 +211,46 @@ enum KeyShareService {
             throw ShareError.encryptionFailed
         }
 
-        // 6. ファイルに書き出し
-        let file = ShareFileFormat.EncryptedFile(
-            version: 1,
-            ephemeralPublicKey: ephemeralKey.publicKey.x963Representation.base64EncodedString(),
-            encryptedData: combined.base64EncodedString(),
-            keyCount: keys.count
+        // 6. 正規メッセージへ署名（v2）
+        let version = 2
+        let ephB64 = ephemeralKey.publicKey.x963Representation.base64EncodedString()
+        let encB64 = combined.base64EncodedString()
+        let signPubB64 = signingPrivateKey.publicKey.x963Representation.base64EncodedString()
+        let createdAtStr = iso8601.string(from: createdAt)
+
+        let message = canonicalMessage(
+            version: version,
+            ephemeralPublicKeyB64: ephB64,
+            encryptedDataB64: encB64,
+            keyCount: keys.count,
+            senderSigningPublicKeyB64: signPubB64,
+            createdAt: createdAtStr
+        )
+        let signature = try signMessage(message, with: signingPrivateKey)
+
+        return ShareFileFormat.EncryptedFile(
+            version: version,
+            ephemeralPublicKey: ephB64,
+            encryptedData: encB64,
+            keyCount: keys.count,
+            senderSigningPublicKey: signPubB64,
+            signature: signature.base64EncodedString(),
+            createdAt: createdAtStr
+        )
+    }
+
+    /// 選択したキーを受信者の公開鍵で暗号化し、自分の署名鍵で署名して
+    /// .aikeychain ファイル(v2)に書き出し
+    static func encryptAndExport(
+        keys: [(envVarName: String, value: String)],
+        recipientPublicKey: P256.KeyAgreement.PublicKey,
+        to url: URL
+    ) throws {
+        let signingKey = try ensureSigningKey()
+        let file = try makeEncryptedFile(
+            keys: keys,
+            recipientPublicKey: recipientPublicKey,
+            signingPrivateKey: signingKey
         )
         let json = try JSONEncoder().encode(file)
         try json.write(to: url)
@@ -113,24 +258,53 @@ enum KeyShareService {
 
     // MARK: - Decrypt (受信者)
 
-    /// .aikeychain ファイルを自分の秘密鍵で復号
-    static func decryptAndImport(from url: URL) throws -> [(envVarName: String, value: String)] {
-        guard let privateKey = loadPrivateKey() else {
-            throw ShareError.noKeyPair
-        }
+    /// 復号結果 + 送信者認証情報
+    struct DecryptedShare {
+        let entries: [(envVarName: String, value: String)]
+        let senderFingerprint: String?
+        let isAuthenticated: Bool
+        let createdAt: Date?
+    }
 
-        // 1. ファイル読み込み
-        let json = try Data(contentsOf: url)
-        let file = try JSONDecoder().decode(ShareFileFormat.EncryptedFile.self, from: json)
-
-        // 2. エフェメラル公開鍵を復元
+    /// EncryptedFile を受信者秘密鍵で復号し、v2 なら署名を検証する（純粋・鍵引数。Keychain 非依存）。
+    static func decrypt(
+        file: ShareFileFormat.EncryptedFile,
+        recipientPrivateKey: P256.KeyAgreement.PrivateKey
+    ) throws -> DecryptedShare {
+        // 1. エフェメラル公開鍵を復元
         guard let ephemeralKeyData = Data(base64Encoded: file.ephemeralPublicKey) else {
             throw ShareError.invalidFile
         }
         let ephemeralPublicKey = try P256.KeyAgreement.PublicKey(x963Representation: ephemeralKeyData)
 
+        // 2. 署名検証（v2: senderSigningPublicKey + signature が両方存在する場合）
+        var isAuthenticated = false
+        var senderFingerprint: String?
+        if let sigB64 = file.signature, let senderPubB64 = file.senderSigningPublicKey {
+            guard
+                let sigData = Data(base64Encoded: sigB64),
+                let senderPubData = Data(base64Encoded: senderPubB64),
+                let senderKey = try? P256.Signing.PublicKey(x963Representation: senderPubData)
+            else {
+                throw ShareError.signatureInvalid
+            }
+            let message = canonicalMessage(
+                version: file.version,
+                ephemeralPublicKeyB64: file.ephemeralPublicKey,
+                encryptedDataB64: file.encryptedData,
+                keyCount: file.keyCount,
+                senderSigningPublicKeyB64: senderPubB64,
+                createdAt: file.createdAt ?? ""
+            )
+            guard verify(message, signature: sigData, publicKey: senderKey) else {
+                throw ShareError.signatureInvalid
+            }
+            isAuthenticated = true
+            senderFingerprint = fingerprint(of: senderKey)
+        }
+
         // 3. ECDH で共有秘密を導出
-        let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: ephemeralPublicKey)
+        let sharedSecret = try recipientPrivateKey.sharedSecretFromKeyAgreement(with: ephemeralPublicKey)
 
         // 4. 対称鍵を導出
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
@@ -149,21 +323,59 @@ enum KeyShareService {
 
         // 6. キーデータをパース
         let entries = try JSONDecoder().decode([ShareFileFormat.KeyEntry].self, from: plaintext)
-        return entries.map { ($0.envVarName, $0.value) }
+
+        let createdAtDate = file.createdAt.flatMap { iso8601.date(from: $0) }
+        return DecryptedShare(
+            entries: entries.map { ($0.envVarName, $0.value) },
+            senderFingerprint: senderFingerprint,
+            isAuthenticated: isAuthenticated,
+            createdAt: createdAtDate
+        )
+    }
+
+    /// .aikeychain ファイルを自分の秘密鍵で復号（v2 なら署名検証付き）
+    static func decryptAndImport(from url: URL) throws -> DecryptedShare {
+        guard let privateKey = loadPrivateKey() else {
+            throw ShareError.noKeyPair
+        }
+        let json = try Data(contentsOf: url)
+        let file = try JSONDecoder().decode(ShareFileFormat.EncryptedFile.self, from: json)
+        return try decrypt(file: file, recipientPrivateKey: privateKey)
     }
 
     // MARK: - Private Key Storage
 
     private static func savePrivateKey(_ key: P256.KeyAgreement.PrivateKey) throws {
-        let rawKey = key.rawRepresentation
+        try saveRawKey(key.rawRepresentation, service: privateKeyTag, account: "private_key")
+    }
 
+    private static func loadPrivateKey() -> P256.KeyAgreement.PrivateKey? {
+        guard let data = loadRawKey(service: privateKeyTag, account: "private_key") else { return nil }
+        return try? P256.KeyAgreement.PrivateKey(rawRepresentation: data)
+    }
+
+    private static func saveSigningPrivateKey(_ key: P256.Signing.PrivateKey) throws {
+        try saveRawKey(key.rawRepresentation, service: signKeyTag, account: "signing_key")
+    }
+
+    private static func loadSigningPrivateKey() -> P256.Signing.PrivateKey? {
+        guard let data = loadRawKey(service: signKeyTag, account: "signing_key") else { return nil }
+        return try? P256.Signing.PrivateKey(rawRepresentation: data)
+    }
+
+    private static func saveRawKey(_ rawKey: Data, service: String, account: String) throws {
         // 既存を削除
-        deleteKeyPair()
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: privateKeyTag,
-            kSecAttrAccount as String: "private_key",
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
             kSecValueData as String: rawKey,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
@@ -174,11 +386,11 @@ enum KeyShareService {
         }
     }
 
-    private static func loadPrivateKey() -> P256.KeyAgreement.PrivateKey? {
+    private static func loadRawKey(service: String, account: String) -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: privateKeyTag,
-            kSecAttrAccount as String: "private_key",
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
@@ -187,8 +399,7 @@ enum KeyShareService {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
         guard status == errSecSuccess, let data = result as? Data else { return nil }
-
-        return try? P256.KeyAgreement.PrivateKey(rawRepresentation: data)
+        return data
     }
 
     // MARK: - Errors
@@ -198,6 +409,7 @@ enum KeyShareService {
         case invalidPublicKey
         case invalidFile
         case encryptionFailed
+        case signatureInvalid
         case keychainError(OSStatus)
 
         var errorDescription: String? {
@@ -206,6 +418,11 @@ enum KeyShareService {
             case .invalidPublicKey: "Invalid public key file."
             case .invalidFile: "Invalid or corrupted .aikeychain file."
             case .encryptionFailed: "Encryption failed."
+            case .signatureInvalid:
+                L10n.s(
+                    ja: "署名の検証に失敗しました。ファイルが改ざんされたか、送信者の署名鍵と一致しません。",
+                    en: "Signature verification failed. The file was tampered with, or does not match the sender's signing key."
+                )
             case .keychainError(let s): "Keychain error: \(s)"
             }
         }
@@ -220,11 +437,35 @@ enum ShareFileFormat {
         let publicKey: String // base64 x963
     }
 
+    /// 暗号化ファイル。v2 で送信者署名フィールドを追加したが、
+    /// 追加分は Optional なので v1 JSON（署名フィールド無し）もそのままデコードできる。
     struct EncryptedFile: Codable {
         let version: Int
         let ephemeralPublicKey: String // base64 x963
         let encryptedData: String      // base64 AES-GCM sealed box
         let keyCount: Int
+        // v2+ optional fields（v1 では欠落 → nil）
+        let senderSigningPublicKey: String? // base64 x963 of P256.Signing.PublicKey
+        let signature: String?              // base64 P256.Signing signature (raw)
+        let createdAt: String?              // ISO8601
+
+        init(
+            version: Int,
+            ephemeralPublicKey: String,
+            encryptedData: String,
+            keyCount: Int,
+            senderSigningPublicKey: String? = nil,
+            signature: String? = nil,
+            createdAt: String? = nil
+        ) {
+            self.version = version
+            self.ephemeralPublicKey = ephemeralPublicKey
+            self.encryptedData = encryptedData
+            self.keyCount = keyCount
+            self.senderSigningPublicKey = senderSigningPublicKey
+            self.signature = signature
+            self.createdAt = createdAt
+        }
     }
 
     struct KeyEntry: Codable {

--- a/AIkeychain/Services/KeyShareService.swift
+++ b/AIkeychain/Services/KeyShareService.swift
@@ -165,6 +165,17 @@ enum KeyShareService {
         return Data(s.utf8)
     }
 
+    /// ECDH 共有秘密から AES-256-GCM 用の対称鍵を導出する。
+    /// `sharedInfo` は v2 で送信者署名公開鍵に束縛される（v1 は空）。salt は固定。
+    private static func deriveSymmetricKey(from sharedSecret: SharedSecret, sharedInfo: Data) -> SymmetricKey {
+        sharedSecret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("AIKeyChain-v1".utf8),
+            sharedInfo: sharedInfo,
+            outputByteCount: 32
+        )
+    }
+
     /// 正規メッセージへ署名し rawRepresentation を返す（純粋・鍵引数）
     static func signMessage(_ message: Data, with signingKey: P256.Signing.PrivateKey) throws -> Data {
         try signingKey.signature(for: message).rawRepresentation
@@ -193,13 +204,13 @@ enum KeyShareService {
         // 2. ECDH で共有秘密を導出
         let sharedSecret = try ephemeralKey.sharedSecretFromKeyAgreement(with: recipientPublicKey)
 
-        // 3. 共有秘密から対称鍵を導出
-        let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
-            using: SHA256.self,
-            salt: Data("AIKeyChain-v1".utf8),
-            sharedInfo: Data(),
-            outputByteCount: 32
-        )
+        // 3. 送信者署名公開鍵を HKDF の sharedInfo に束縛して対称鍵を導出（v2）。
+        //    こうすると senderSigningPublicKey を後から差し替えると GCM 復号自体が
+        //    失敗するため、他人の暗号文を自分の鍵で「再署名」して自分のものとして
+        //    提示する attribution swap を防げる。送信者は自分の署名鍵を知っているので
+        //    この sharedInfo を導出できる。
+        let signPubData = signingPrivateKey.publicKey.x963Representation
+        let symmetricKey = deriveSymmetricKey(from: sharedSecret, sharedInfo: signPubData)
 
         // 4. キーデータを JSON 化
         let payload = keys.map { ShareFileFormat.KeyEntry(envVarName: $0.envVarName, value: $0.value) }
@@ -215,7 +226,7 @@ enum KeyShareService {
         let version = 2
         let ephB64 = ephemeralKey.publicKey.x963Representation.base64EncodedString()
         let encB64 = combined.base64EncodedString()
-        let signPubB64 = signingPrivateKey.publicKey.x963Representation.base64EncodedString()
+        let signPubB64 = signPubData.base64EncodedString()
         let createdAtStr = iso8601.string(from: createdAt)
 
         let message = canonicalMessage(
@@ -271,6 +282,21 @@ enum KeyShareService {
         file: ShareFileFormat.EncryptedFile,
         recipientPrivateKey: P256.KeyAgreement.PrivateKey
     ) throws -> DecryptedShare {
+        // 0. バージョン & 構造整合性チェック（crypto 層で fail-closed）。
+        //    この関数は GUI 以外（将来 CLI 等）からも再利用される想定のため、
+        //    人間ゲートに依存せずここで不整合を弾く。
+        //    - 未知バージョンは best-effort 処理せず拒否。
+        //    - signature と senderSigningPublicKey は「両方あり／両方なし」のみ許容
+        //      （片方だけ present は構造改ざんの兆候）。
+        //    - v2 以降で署名フィールドが欠落しているのは署名 strip 攻撃 → 拒否。
+        guard (1...2).contains(file.version) else { throw ShareError.invalidFile }
+        if (file.signature == nil) != (file.senderSigningPublicKey == nil) {
+            throw ShareError.signatureInvalid
+        }
+        if file.version >= 2 && file.signature == nil {
+            throw ShareError.signatureInvalid
+        }
+
         // 1. エフェメラル公開鍵を復元
         guard let ephemeralKeyData = Data(base64Encoded: file.ephemeralPublicKey) else {
             throw ShareError.invalidFile
@@ -278,8 +304,10 @@ enum KeyShareService {
         let ephemeralPublicKey = try P256.KeyAgreement.PublicKey(x963Representation: ephemeralKeyData)
 
         // 2. 署名検証（v2: senderSigningPublicKey + signature が両方存在する場合）
+        //    併せて HKDF の sharedInfo を決定する（v2 は送信者署名公開鍵に束縛、v1 は空）。
         var isAuthenticated = false
         var senderFingerprint: String?
+        var sharedInfo = Data() // v1: 空（後方互換）
         if let sigB64 = file.signature, let senderPubB64 = file.senderSigningPublicKey {
             guard
                 let sigData = Data(base64Encoded: sigB64),
@@ -301,18 +329,14 @@ enum KeyShareService {
             }
             isAuthenticated = true
             senderFingerprint = fingerprint(of: senderKey)
+            sharedInfo = senderPubData // v2: 送信者署名公開鍵を束縛（attribution swap 防止）
         }
 
         // 3. ECDH で共有秘密を導出
         let sharedSecret = try recipientPrivateKey.sharedSecretFromKeyAgreement(with: ephemeralPublicKey)
 
-        // 4. 対称鍵を導出
-        let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
-            using: SHA256.self,
-            salt: Data("AIKeyChain-v1".utf8),
-            sharedInfo: Data(),
-            outputByteCount: 32
-        )
+        // 4. 対称鍵を導出（v2 は senderSigningPublicKey を sharedInfo に束縛）
+        let symmetricKey = deriveSymmetricKey(from: sharedSecret, sharedInfo: sharedInfo)
 
         // 5. 復号
         guard let encryptedData = Data(base64Encoded: file.encryptedData) else {
@@ -404,7 +428,7 @@ enum KeyShareService {
 
     // MARK: - Errors
 
-    enum ShareError: LocalizedError {
+    enum ShareError: LocalizedError, Equatable {
         case noKeyPair
         case invalidPublicKey
         case invalidFile

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -273,6 +273,21 @@ private struct SendTab: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
 
+                    if let ownFP = KeyShareService.ownSigningFingerprint() {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(L10n.s(ja: "あなたの署名フィンガープリント（受信者に帯域外で伝えてください）:", en: "Your signing fingerprint (share it out-of-band with the recipient):"))
+                                .font(.system(size: 9))
+                                .foregroundStyle(.secondary)
+                            Text(ownFP)
+                                .font(.system(size: 10, design: .monospaced))
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                        .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+                        .padding(.horizontal, 16)
+                    }
+
                     HStack {
                         Text(L10n.s(ja: "転送するキーを選択:", en: "Select keys to transfer:"))
                             .font(.system(size: 12, weight: .medium))
@@ -409,110 +424,257 @@ private struct SendTab: View {
 
 private struct ReceiveTab: View {
     var onImport: () -> Void = {}
-    @State private var decryptedKeys: [(envVarName: String, value: String)] = []
+    @State private var share: KeyShareService.DecryptedShare?
+    @State private var revealed: Set<String> = []          // envVarName ごとの値表示トグル
+    @State private var fingerprintConfirmed = false        // 帯域外照合の必須チェック
+    @State private var unsignedAck = false                 // 未署名ファイルの追加承諾
+    @State private var overwriteConfirmed = false          // 既存上書きの明示承諾
     @State private var imported = false
     @State private var importCount = 0
     @State private var errorMessage: String?
 
+    private var entries: [(envVarName: String, value: String)] { share?.entries ?? [] }
+
+    private var overwriteCount: Int {
+        entries.filter { KeychainService.shared.exists(for: $0.envVarName) }.count
+    }
+
+    /// インポート可能条件: 指紋照合済み ∧ (認証済み ∨ 未署名承諾) ∧ (上書き無し ∨ 上書き承諾)
+    private var canImport: Bool {
+        guard let share else { return false }
+        let authGate = share.isAuthenticated || unsignedAck
+        let overwriteGate = overwriteCount == 0 || overwriteConfirmed
+        return fingerprintConfirmed && authGate && overwriteGate
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            if decryptedKeys.isEmpty && !imported {
-                VStack(spacing: 16) {
-                    Spacer()
-                    Image(systemName: "lock.open.rotation")
-                        .font(.system(size: 40))
-                        .foregroundStyle(AppColors.commGreen)
-
-                    if KeyShareService.hasKeyPair() {
-                        Text(L10n.s(ja: "暗号化された .aikeychain ファイルを\n自分の秘密鍵で復号します", en: "Decrypt the encrypted .aikeychain file\nusing your private key"))
-                            .font(.system(size: 14))
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.center)
-
-                        Button("Open .aikeychain...") {
-                            decryptFile()
-                        }
-                        .buttonStyle(.borderedProminent)
-                    } else {
-                        Text(L10n.s(ja: "鍵ペアが必要です。\n「My Keys」タブで生成してください。", en: "A key pair is required.\nGenerate one in the \"My Keys\" tab."))
-                            .font(.system(size: 14))
-                            .foregroundStyle(.orange)
-                            .multilineTextAlignment(.center)
-                    }
-
-                    if let error = errorMessage {
-                        Text(error).font(.system(size: 11)).foregroundStyle(.red)
-                    }
-                    Spacer()
-                }
-            } else if !decryptedKeys.isEmpty && !imported {
-                // Preview decrypted keys
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Decrypted \(decryptedKeys.count) keys:")
-                        .font(.system(size: 12, weight: .medium))
-                        .padding(.horizontal, 16)
-                        .padding(.top, 8)
-                }
-
-                List {
-                    ForEach(decryptedKeys, id: \.envVarName) { entry in
-                        HStack {
-                            let service = ServiceType.allCases.first { $0.envVarName == entry.envVarName }
-                            Image(systemName: service?.systemImage ?? "key")
-                                .foregroundStyle(service?.category.color ?? .secondary)
-                                .frame(width: 20)
-                            VStack(alignment: .leading) {
-                                Text(service?.displayName ?? entry.envVarName)
-                                    .font(.system(size: 12, weight: .medium))
-                                Text(entry.envVarName)
-                                    .font(.system(size: 10, design: .monospaced))
-                                    .foregroundStyle(.tertiary)
-                            }
-                            Spacer()
-                            if KeychainService.shared.exists(for: entry.envVarName) {
-                                Text("Overwrite")
-                                    .font(.system(size: 10))
-                                    .foregroundStyle(.orange)
-                            }
-                        }
-                    }
-                }
-                .listStyle(.inset)
-
-                Divider()
-
-                HStack {
-                    Spacer()
-                    Button("Import to Keychain") {
-                        importDecrypted()
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-                .padding(12)
+            if share == nil && !imported {
+                startView
+            } else if let share, !imported {
+                previewView(share)
             } else {
-                // Import complete
-                VStack(spacing: 16) {
-                    Spacer()
-                    Image(systemName: "checkmark.seal.fill")
-                        .font(.system(size: 48))
-                        .foregroundStyle(AppColors.configured)
-                    Text("\(importCount) keys imported!")
-                        .font(.system(size: 16, weight: .semibold))
-                    Text(L10n.s(ja: "Keychain に保存されました", en: "Saved to Keychain"))
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+                completeView
+            }
+        }
+    }
 
-                    Button {
-                        NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Applications/Utilities/Keychain Access.app"))
-                    } label: {
-                        Label("Open Keychain Access", systemImage: "lock.rectangle")
+    // MARK: Start
+
+    private var startView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "lock.open.rotation")
+                .font(.system(size: 40))
+                .foregroundStyle(AppColors.commGreen)
+
+            if KeyShareService.hasKeyPair() {
+                Text(L10n.s(ja: "暗号化された .aikeychain ファイルを\n自分の秘密鍵で復号します", en: "Decrypt the encrypted .aikeychain file\nusing your private key"))
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Button("Open .aikeychain...") {
+                    decryptFile()
+                }
+                .buttonStyle(.borderedProminent)
+            } else {
+                Text(L10n.s(ja: "鍵ペアが必要です。\n「My Keys」タブで生成してください。", en: "A key pair is required.\nGenerate one in the \"My Keys\" tab."))
+                    .font(.system(size: 14))
+                    .foregroundStyle(.orange)
+                    .multilineTextAlignment(.center)
+            }
+
+            if let error = errorMessage {
+                Text(error).font(.system(size: 11)).foregroundStyle(.red)
+            }
+            Spacer()
+        }
+    }
+
+    // MARK: Preview
+
+    @ViewBuilder
+    private func previewView(_ share: KeyShareService.DecryptedShare) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                senderBanner(share)
+
+                Text(L10n.s(ja: "復号された \(entries.count) 件のキー:", en: "Decrypted \(entries.count) keys:"))
+                    .font(.system(size: 12, weight: .medium))
+
+                VStack(spacing: 0) {
+                    ForEach(entries, id: \.envVarName) { entry in
+                        keyRow(entry)
+                        Divider()
                     }
-                    .buttonStyle(.bordered)
+                }
+                .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
 
-                    Spacer()
+                gates(share)
+            }
+            .padding(16)
+        }
+
+        Divider()
+
+        HStack {
+            Button("Cancel") { resetPreview() }
+                .font(.system(size: 11))
+            Spacer()
+            Button("Import to Keychain") {
+                importDecrypted()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!canImport)
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private func senderBanner(_ share: KeyShareService.DecryptedShare) -> some View {
+        if share.isAuthenticated, let fp = share.senderFingerprint {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(L10n.s(ja: "送信者の署名を検証しました", en: "Sender signature verified"), systemImage: "checkmark.seal.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(AppColors.configured)
+                Text(L10n.s(ja: "送信者フィンガープリント:", en: "Sender fingerprint:"))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                Text(fp)
+                    .font(.system(size: 12, design: .monospaced))
+                    .textSelection(.enabled)
+                if let created = share.createdAt {
+                    Text(L10n.s(ja: "作成日時: ", en: "Created: ") + created.formatted(date: .abbreviated, time: .shortened))
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                }
+                Text(L10n.s(ja: "有効な署名は「その署名鍵の保有者が作成した」ことしか証明しません。上の指紋を信頼できる経路（対面/電話等）で送信者本人と照合してください。", en: "A valid signature only proves the file was made by whoever holds that signing key. Compare the fingerprint above with the sender over a trusted channel (in person / phone)."))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(10)
+            .background(AppColors.configured.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(L10n.s(ja: "送信者を認証できません", en: "Sender could NOT be authenticated"), systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.red)
+                Text(L10n.s(ja: "⚠ 送信者を認証できません。このファイル (v1/未署名) はあなたの公開鍵を持つ第三者が偽造した可能性があります。攻撃者が選んだキー値を掴まされる恐れがあります。", en: "⚠ Sender could NOT be authenticated. This file (v1/unsigned) may have been forged by anyone holding your public key — the values could be attacker-chosen."))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.red)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(10)
+            .background(Color.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    @ViewBuilder
+    private func keyRow(_ entry: (envVarName: String, value: String)) -> some View {
+        let service = ServiceType.allCases.first { $0.envVarName == entry.envVarName }
+        let isRevealed = revealed.contains(entry.envVarName)
+        let overwrites = KeychainService.shared.exists(for: entry.envVarName)
+        HStack {
+            Image(systemName: service?.systemImage ?? "key")
+                .foregroundStyle(service?.category.color ?? .secondary)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(service?.displayName ?? entry.envVarName)
+                        .font(.system(size: 12, weight: .medium))
+                    if overwrites {
+                        Text(L10n.s(ja: "上書き", en: "Overwrite"))
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.orange)
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(Color.orange.opacity(0.15), in: Capsule())
+                    }
+                }
+                Text(entry.envVarName)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                Text(isRevealed ? entry.value : SecretMask.mask(entry.value))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(isRevealed ? .primary : .secondary)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button {
+                if isRevealed { revealed.remove(entry.envVarName) }
+                else { revealed.insert(entry.envVarName) }
+            } label: {
+                Image(systemName: isRevealed ? "eye.slash" : "eye")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help(L10n.s(ja: "値を表示/非表示", en: "Show / hide value"))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func gates(_ share: KeyShareService.DecryptedShare) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: $fingerprintConfirmed) {
+                Text(L10n.s(ja: "送信者のフィンガープリントを信頼できる経路で確認しました", en: "I verified the sender's fingerprint via a trusted channel"))
+                    .font(.system(size: 11))
+            }
+
+            if !share.isAuthenticated {
+                Toggle(isOn: $unsignedAck) {
+                    Text(L10n.s(ja: "このファイルは送信者を認証できないことを理解し、リスクを承知でインポートします", en: "I understand this file's sender cannot be authenticated and import at my own risk"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(.red)
+                }
+            }
+
+            if overwriteCount > 0 {
+                Toggle(isOn: $overwriteConfirmed) {
+                    Text(L10n.s(ja: "既存の \(overwriteCount) 件を上書きします", en: "Overwrite \(overwriteCount) existing key(s)"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
                 }
             }
         }
+        .toggleStyle(.checkbox)
+    }
+
+    // MARK: Complete
+
+    private var completeView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(AppColors.configured)
+            Text(L10n.s(ja: "\(importCount) 件のキーをインポートしました", en: "\(importCount) keys imported!"))
+                .font(.system(size: 16, weight: .semibold))
+            Text(L10n.s(ja: "Keychain に保存されました", en: "Saved to Keychain"))
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+
+            Button {
+                NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Applications/Utilities/Keychain Access.app"))
+            } label: {
+                Label("Open Keychain Access", systemImage: "lock.rectangle")
+            }
+            .buttonStyle(.bordered)
+
+            Spacer()
+        }
+    }
+
+    private func resetPreview() {
+        share = nil
+        revealed = []
+        fingerprintConfirmed = false
+        unsignedAck = false
+        overwriteConfirmed = false
     }
 
     private func decryptFile() {
@@ -522,7 +684,8 @@ private struct ReceiveTab: View {
 
         if panel.runModal() == .OK, let url = panel.url {
             do {
-                decryptedKeys = try KeyShareService.decryptAndImport(from: url)
+                share = try KeyShareService.decryptAndImport(from: url)
+                errorMessage = nil
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -530,8 +693,9 @@ private struct ReceiveTab: View {
     }
 
     private func importDecrypted() {
+        guard canImport else { return }
         var count = 0
-        for entry in decryptedKeys {
+        for entry in entries {
             // 外部由来の .aikeychain ファイルの envVarName は信頼できない。
             // シェル export に不正な名前はスキップする（KeychainService.save 側でも
             // 弾かれるが、ここで明示的に skip して意図を明確化 / #116）。

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -74,6 +74,7 @@ private struct KeyPairManagementTab: View {
     @State private var hasKeyPair = KeyShareService.hasKeyPair()
     @State private var publicKeyDisplay: String = ""
     @State private var errorMessage: String?
+    @State private var showDeleteConfirm = false
 
     var body: some View {
         ScrollView {
@@ -114,9 +115,24 @@ private struct KeyPairManagementTab: View {
                         .buttonStyle(.borderedProminent)
 
                         Button("Delete Key Pair", role: .destructive) {
-                            KeyShareService.deleteKeyPair()
-                            hasKeyPair = false
-                            publicKeyDisplay = ""
+                            showDeleteConfirm = true
+                        }
+                        .confirmationDialog(
+                            L10n.s(ja: "鍵ペアを削除しますか？", en: "Delete key pair?"),
+                            isPresented: $showDeleteConfirm,
+                            titleVisibility: .visible
+                        ) {
+                            Button(L10n.s(ja: "削除する", en: "Delete"), role: .destructive) {
+                                KeyShareService.deleteKeyPair()
+                                hasKeyPair = false
+                                publicKeyDisplay = ""
+                            }
+                            Button(L10n.s(ja: "キャンセル", en: "Cancel"), role: .cancel) {}
+                        } message: {
+                            Text(L10n.s(
+                                ja: "鍵共有鍵に加えて署名アイデンティティも破棄されます。再生成すると署名フィンガープリントが変わり、以前あなたの指紋を確認した相手は改めて照合し直す必要があります。",
+                                en: "This also destroys your signing identity, not just the key-agreement key. Regenerating produces a NEW signing fingerprint, so anyone who previously verified your fingerprint must re-verify it."
+                            ))
                         }
                     }
                 } else {
@@ -197,6 +213,10 @@ private struct SendTab: View {
     @State private var exported = false
     @State private var cachedValues: [String: String] = [:] // 一括取得キャッシュ
     @State private var isLoading = false
+    // 署名フィンガープリントは Keychain I/O（初回は鍵生成）を伴うので body 内で毎回
+    // 呼ばず、onAppear で一度だけ解決して state に持つ（finding 6）。
+    @State private var ownSigningFingerprint: String?
+    @State private var signingKeyError = false
 
     private var configuredKeys: [APIKey] {
         keys.filter(\.isConfigured)
@@ -273,7 +293,7 @@ private struct SendTab: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
 
-                    if let ownFP = KeyShareService.ownSigningFingerprint() {
+                    if let ownFP = ownSigningFingerprint {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(L10n.s(ja: "あなたの署名フィンガープリント（受信者に帯域外で伝えてください）:", en: "Your signing fingerprint (share it out-of-band with the recipient):"))
                                 .font(.system(size: 9))
@@ -286,6 +306,12 @@ private struct SendTab: View {
                         .padding(8)
                         .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
                         .padding(.horizontal, 16)
+                    } else if signingKeyError {
+                        Text(L10n.s(ja: "署名鍵を準備できませんでした（Keychain アクセスを確認してください）。", en: "Could not prepare the signing key (check Keychain access)."))
+                            .font(.system(size: 9))
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16)
                     }
 
                     HStack {
@@ -350,6 +376,14 @@ private struct SendTab: View {
                     .disabled(selectedKeys.isEmpty)
                 }
                 .padding(12)
+            }
+        }
+        .onAppear {
+            // 署名鍵の解決（初回は生成）を一度だけ実行。失敗時はエラー行を出す。
+            if let fp = KeyShareService.ownSigningFingerprint() {
+                ownSigningFingerprint = fp
+            } else {
+                signingKeyError = true
             }
         }
     }
@@ -432,12 +466,12 @@ private struct ReceiveTab: View {
     @State private var imported = false
     @State private var importCount = 0
     @State private var errorMessage: String?
+    // 復号時に envVarName で重複排除（先勝ち）した表示用エントリ（finding 10）と、
+    // その時点で一度だけ Keychain を引いて数えた上書き件数（finding 11）。
+    @State private var entries: [(envVarName: String, value: String)] = []
+    @State private var overwriteNames: Set<String> = []
 
-    private var entries: [(envVarName: String, value: String)] { share?.entries ?? [] }
-
-    private var overwriteCount: Int {
-        entries.filter { KeychainService.shared.exists(for: $0.envVarName) }.count
-    }
+    private var overwriteCount: Int { overwriteNames.count }
 
     /// インポート可能条件: 指紋照合済み ∧ (認証済み ∨ 未署名承諾) ∧ (上書き無し ∨ 上書き承諾)
     private var canImport: Bool {
@@ -575,7 +609,7 @@ private struct ReceiveTab: View {
     private func keyRow(_ entry: (envVarName: String, value: String)) -> some View {
         let service = ServiceType.allCases.first { $0.envVarName == entry.envVarName }
         let isRevealed = revealed.contains(entry.envVarName)
-        let overwrites = KeychainService.shared.exists(for: entry.envVarName)
+        let overwrites = overwriteNames.contains(entry.envVarName)
         HStack {
             Image(systemName: service?.systemImage ?? "key")
                 .foregroundStyle(service?.category.color ?? .secondary)
@@ -621,7 +655,11 @@ private struct ReceiveTab: View {
     private func gates(_ share: KeyShareService.DecryptedShare) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Toggle(isOn: $fingerprintConfirmed) {
-                Text(L10n.s(ja: "送信者のフィンガープリントを信頼できる経路で確認しました", en: "I verified the sender's fingerprint via a trusted channel"))
+                // 未認証(v1)は照合すべき指紋自体が無いので、確認対象を「送信者本人への
+                // 直接確認」に変える（finding 7）。
+                Text(share.isAuthenticated
+                     ? L10n.s(ja: "送信者のフィンガープリントを信頼できる経路で確認しました", en: "I verified the sender's fingerprint via a trusted channel")
+                     : L10n.s(ja: "送信者本人に、このファイルを送ったことを信頼できる経路で直接確認しました", en: "I directly confirmed with the sender, over a trusted channel, that they sent this file"))
                     .font(.system(size: 11))
             }
 
@@ -671,6 +709,8 @@ private struct ReceiveTab: View {
 
     private func resetPreview() {
         share = nil
+        entries = []
+        overwriteNames = []
         revealed = []
         fingerprintConfirmed = false
         unsignedAck = false
@@ -684,7 +724,17 @@ private struct ReceiveTab: View {
 
         if panel.runModal() == .OK, let url = panel.url {
             do {
-                share = try KeyShareService.decryptAndImport(from: url)
+                let decrypted = try KeyShareService.decryptAndImport(from: url)
+                // envVarName で重複排除（先勝ち）。ForEach の ID 衝突と、
+                // 後勝ちで意図せぬ値を保存する事故を防ぐ（finding 10）。
+                var seen = Set<String>()
+                let deduped = decrypted.entries.filter { seen.insert($0.envVarName).inserted }
+                // 上書き対象は decrypt 時に一度だけ Keychain を引いて確定（毎描画で
+                // 引かない / finding 11）。
+                let owNames = Set(deduped.map(\.envVarName).filter { KeychainService.shared.exists(for: $0) })
+                entries = deduped
+                overwriteNames = owNames
+                share = decrypted
                 errorMessage = nil
             } catch {
                 errorMessage = error.localizedDescription

--- a/Tests/AIkeychainTests/KeyShareServiceTests.swift
+++ b/Tests/AIkeychainTests/KeyShareServiceTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import CryptoKit
+import Testing
+@testable import AIkeychain
+
+/// #112 送信者認証（署名 + フィンガープリント + v2 フォーマット）
+///
+/// Keychain に触れずにテストできるよう、鍵はメモリ上に生成し、
+/// pure な makeEncryptedFile / decrypt / canonicalMessage / fingerprint を直接叩く。
+@Suite("KeyShareService Sender Auth (#112)")
+struct KeyShareServiceTests {
+
+    private let sampleKeys: [(envVarName: String, value: String)] = [
+        ("OPENAI_API_KEY", "sk-test-value-1234567890abcdef"),
+        ("GITHUB_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"),
+    ]
+
+    // MARK: v2 round trip
+
+    @Test("v2 round trip: encrypt (sender) → decrypt (recipient) authenticates and matches")
+    func v2RoundTrip() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys,
+            recipientPublicKey: recipient.publicKey,
+            signingPrivateKey: signing
+        )
+        #expect(file.version == 2)
+        #expect(file.signature != nil)
+        #expect(file.senderSigningPublicKey != nil)
+        #expect(file.createdAt != nil)
+
+        let share = try KeyShareService.decrypt(file: file, recipientPrivateKey: recipient)
+        #expect(share.isAuthenticated == true)
+        #expect(share.entries.count == sampleKeys.count)
+        #expect(share.entries.map(\.envVarName) == sampleKeys.map(\.envVarName))
+        #expect(share.entries.map(\.value) == sampleKeys.map(\.value))
+        #expect(share.senderFingerprint == KeyShareService.fingerprint(of: signing.publicKey))
+        #expect(share.createdAt != nil)
+    }
+
+    // MARK: Tamper detection
+
+    @Test("Tampering with encryptedData throws signatureInvalid")
+    func tamperEncryptedData() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+
+        // 別の暗号文（有効な base64）に差し替える
+        let other = try KeyShareService.makeEncryptedFile(
+            keys: [("X", "yyyyyyyyyyyyyyyyyy")], recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        let tampered = ShareFileFormat.EncryptedFile(
+            version: file.version,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: other.encryptedData,   // ← 改ざん
+            keyCount: file.keyCount,
+            senderSigningPublicKey: file.senderSigningPublicKey,
+            signature: file.signature,
+            createdAt: file.createdAt
+        )
+
+        #expect(throws: KeyShareService.ShareError.self) {
+            _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Tampering with keyCount throws signatureInvalid")
+    func tamperKeyCount() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        let tampered = ShareFileFormat.EncryptedFile(
+            version: file.version,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount + 99,          // ← 改ざん
+            senderSigningPublicKey: file.senderSigningPublicKey,
+            signature: file.signature,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.self) {
+            _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Swapping senderSigningPublicKey (with unchanged signature) throws signatureInvalid")
+    func tamperSenderKey() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        let attackerKey = P256.Signing.PrivateKey()
+        let tampered = ShareFileFormat.EncryptedFile(
+            version: file.version,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: attackerKey.publicKey.x963Representation.base64EncodedString(), // ← 改ざん
+            signature: file.signature,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.self) {
+            _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
+        }
+    }
+
+    // MARK: Forgery-with-different-key
+
+    @Test("Forgery with a different signing key verifies but yields a DIFFERENT fingerprint")
+    func forgeryDifferentKey() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let expectedSender = P256.Signing.PrivateKey()
+        let attacker = P256.Signing.PrivateKey()
+
+        // 攻撃者は自分の署名鍵で完全に有効なファイルを作れる
+        let forged = try KeyShareService.makeEncryptedFile(
+            keys: [("OPENAI_API_KEY", "sk-attacker-substituted-value-000")],
+            recipientPublicKey: recipient.publicKey,
+            signingPrivateKey: attacker
+        )
+        let share = try KeyShareService.decrypt(file: forged, recipientPrivateKey: recipient)
+
+        // 署名としては有効（isAuthenticated=true）だが、指紋が期待送信者と異なる
+        #expect(share.isAuthenticated == true)
+        #expect(share.senderFingerprint == KeyShareService.fingerprint(of: attacker.publicKey))
+        #expect(share.senderFingerprint != KeyShareService.fingerprint(of: expectedSender.publicKey))
+    }
+
+    // MARK: v1 backward compatibility
+
+    @Test("Hand-constructed v1 file (no signature fields) decodes, decrypts, unauthenticated")
+    func v1BackwardCompat() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+
+        // v1 相当の暗号文をその場で生成（署名なし・追加フィールドなしの JSON）
+        let ephemeral = P256.KeyAgreement.PrivateKey()
+        let shared = try ephemeral.sharedSecretFromKeyAgreement(with: recipient.publicKey)
+        let symKey = shared.hkdfDerivedSymmetricKey(
+            using: SHA256.self, salt: Data("AIKeyChain-v1".utf8), sharedInfo: Data(), outputByteCount: 32
+        )
+        let payload = sampleKeys.map { ShareFileFormat.KeyEntry(envVarName: $0.envVarName, value: $0.value) }
+        let plaintext = try JSONEncoder().encode(payload)
+        let combined = try AES.GCM.seal(plaintext, using: symKey).combined!
+
+        // 追加フィールドを含まない v1 JSON を手で組む
+        let v1Json = """
+        {
+          "version": 1,
+          "ephemeralPublicKey": "\(ephemeral.publicKey.x963Representation.base64EncodedString())",
+          "encryptedData": "\(combined.base64EncodedString())",
+          "keyCount": \(sampleKeys.count)
+        }
+        """
+        let file = try JSONDecoder().decode(ShareFileFormat.EncryptedFile.self, from: Data(v1Json.utf8))
+        #expect(file.signature == nil)
+        #expect(file.senderSigningPublicKey == nil)
+        #expect(file.createdAt == nil)
+
+        let share = try KeyShareService.decrypt(file: file, recipientPrivateKey: recipient)
+        #expect(share.isAuthenticated == false)
+        #expect(share.senderFingerprint == nil)
+        #expect(share.entries.map(\.envVarName) == sampleKeys.map(\.envVarName))
+        #expect(share.entries.map(\.value) == sampleKeys.map(\.value))
+    }
+
+    // MARK: Fingerprint
+
+    @Test("Fingerprint is full-length (256-bit) and stable for the same key")
+    func fingerprintFullLength() {
+        let key = P256.Signing.PrivateKey()
+        let fp = KeyShareService.fingerprint(of: key.publicKey)
+
+        // 64 hex chars (256-bit) grouped in 4 => 16 groups, 15 spaces
+        let hexOnly = fp.replacingOccurrences(of: " ", with: "")
+        #expect(hexOnly.count == 64) // 32 bytes * 2 — NOT truncated to 64-bit (16 chars)
+        #expect(hexOnly.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isUppercase) })
+        #expect(fp.split(separator: " ").count == 16)
+
+        // Stable
+        #expect(KeyShareService.fingerprint(of: key.publicKey) == fp)
+
+        // Distinct keys differ
+        let other = P256.Signing.PrivateKey()
+        #expect(KeyShareService.fingerprint(of: other.publicKey) != fp)
+    }
+
+    // MARK: Canonical message
+
+    @Test("canonicalMessage is deterministic and field-order sensitive")
+    func canonicalDeterministic() {
+        let a = KeyShareService.canonicalMessage(
+            version: 2, ephemeralPublicKeyB64: "AAA", encryptedDataB64: "BBB",
+            keyCount: 3, senderSigningPublicKeyB64: "CCC", createdAt: "2026-07-04T00:00:00Z"
+        )
+        let same = KeyShareService.canonicalMessage(
+            version: 2, ephemeralPublicKeyB64: "AAA", encryptedDataB64: "BBB",
+            keyCount: 3, senderSigningPublicKeyB64: "CCC", createdAt: "2026-07-04T00:00:00Z"
+        )
+        let diff = KeyShareService.canonicalMessage(
+            version: 2, ephemeralPublicKeyB64: "AAA", encryptedDataB64: "BBB",
+            keyCount: 4, senderSigningPublicKeyB64: "CCC", createdAt: "2026-07-04T00:00:00Z"
+        )
+        #expect(a == same)
+        #expect(a != diff)
+    }
+
+    @Test("sign / verify round trip over canonical message")
+    func signVerify() throws {
+        let signing = P256.Signing.PrivateKey()
+        let msg = KeyShareService.canonicalMessage(
+            version: 2, ephemeralPublicKeyB64: "AAA", encryptedDataB64: "BBB",
+            keyCount: 1, senderSigningPublicKeyB64: "CCC", createdAt: "2026-07-04T00:00:00Z"
+        )
+        let sig = try KeyShareService.signMessage(msg, with: signing)
+        #expect(KeyShareService.verify(msg, signature: sig, publicKey: signing.publicKey) == true)
+
+        let otherKey = P256.Signing.PrivateKey()
+        #expect(KeyShareService.verify(msg, signature: sig, publicKey: otherKey.publicKey) == false)
+
+        // Garbage signature bytes verify false, not crash
+        #expect(KeyShareService.verify(msg, signature: Data([0x00, 0x01]), publicKey: signing.publicKey) == false)
+    }
+}

--- a/Tests/AIkeychainTests/KeyShareServiceTests.swift
+++ b/Tests/AIkeychainTests/KeyShareServiceTests.swift
@@ -65,7 +65,7 @@ struct KeyShareServiceTests {
             createdAt: file.createdAt
         )
 
-        #expect(throws: KeyShareService.ShareError.self) {
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
             _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
         }
     }
@@ -86,7 +86,7 @@ struct KeyShareServiceTests {
             signature: file.signature,
             createdAt: file.createdAt
         )
-        #expect(throws: KeyShareService.ShareError.self) {
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
             _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
         }
     }
@@ -108,9 +108,181 @@ struct KeyShareServiceTests {
             signature: file.signature,
             createdAt: file.createdAt
         )
-        #expect(throws: KeyShareService.ShareError.self) {
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
             _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
         }
+    }
+
+    @Test("Tampering with createdAt throws signatureInvalid")
+    func tamperCreatedAt() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        let tampered = ShareFileFormat.EncryptedFile(
+            version: file.version,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: file.senderSigningPublicKey,
+            signature: file.signature,
+            createdAt: "2000-01-01T00:00:00Z"        // ← 改ざん
+        )
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
+            _ = try KeyShareService.decrypt(file: tampered, recipientPrivateKey: recipient)
+        }
+    }
+
+    // MARK: fail-closed structural checks (#112 Fable review)
+
+    @Test("Signature-stripping (drop sig fields from a v2 file) throws signatureInvalid")
+    func signatureStripping() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        // version は 2 のまま署名フィールドを除去 → strip 攻撃
+        let stripped = ShareFileFormat.EncryptedFile(
+            version: 2,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: nil,
+            signature: nil,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
+            _ = try KeyShareService.decrypt(file: stripped, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Version downgrade 2→1 while keeping signature throws signatureInvalid")
+    func versionDowngrade() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        // version を 1 に書き換え（署名は残す）→ 正規メッセージの version が食い違い署名不一致
+        let downgraded = ShareFileFormat.EncryptedFile(
+            version: 1,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: file.senderSigningPublicKey,
+            signature: file.signature,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
+            _ = try KeyShareService.decrypt(file: downgraded, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Structural inconsistency: only one of signature/senderSigningPublicKey present throws signatureInvalid")
+    func inconsistentSignatureFields() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        // signature だけ present（senderSigningPublicKey を落とす）
+        let onlySig = ShareFileFormat.EncryptedFile(
+            version: file.version,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: nil,
+            signature: file.signature,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
+            _ = try KeyShareService.decrypt(file: onlySig, recipientPrivateKey: recipient)
+        }
+        // senderSigningPublicKey だけ present（signature を落とす）
+        let onlyKey = ShareFileFormat.EncryptedFile(
+            version: file.version,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: file.senderSigningPublicKey,
+            signature: nil,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.signatureInvalid) {
+            _ = try KeyShareService.decrypt(file: onlyKey, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Unknown version is rejected (invalidFile)")
+    func unknownVersion() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        let future = ShareFileFormat.EncryptedFile(
+            version: 99,
+            ephemeralPublicKey: file.ephemeralPublicKey,
+            encryptedData: file.encryptedData,
+            keyCount: file.keyCount,
+            senderSigningPublicKey: file.senderSigningPublicKey,
+            signature: file.signature,
+            createdAt: file.createdAt
+        )
+        #expect(throws: KeyShareService.ShareError.invalidFile) {
+            _ = try KeyShareService.decrypt(file: future, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Attribution swap: re-sign with attacker key over another's ciphertext fails GCM decryption")
+    func attributionSwap() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let sender = P256.Signing.PrivateKey()
+        let legit = try KeyShareService.makeEncryptedFile(
+            keys: sampleKeys, recipientPublicKey: recipient.publicKey, signingPrivateKey: sender
+        )
+        // 攻撃者は他人の暗号文をそのまま流用し、senderSigningPublicKey を自分の鍵に
+        // 差し替えて「自分の鍵で有効に署名し直す」。署名検証は通ってしまうが、
+        // HKDF sharedInfo が送信者署名公開鍵に束縛されているため、対称鍵が食い違い
+        // GCM 復号自体が失敗する。
+        let attacker = P256.Signing.PrivateKey()
+        let attackerPubB64 = attacker.publicKey.x963Representation.base64EncodedString()
+        let message = KeyShareService.canonicalMessage(
+            version: legit.version,
+            ephemeralPublicKeyB64: legit.ephemeralPublicKey,
+            encryptedDataB64: legit.encryptedData,
+            keyCount: legit.keyCount,
+            senderSigningPublicKeyB64: attackerPubB64,
+            createdAt: legit.createdAt ?? ""
+        )
+        let attackerSig = try KeyShareService.signMessage(message, with: attacker).base64EncodedString()
+        let swapped = ShareFileFormat.EncryptedFile(
+            version: legit.version,
+            ephemeralPublicKey: legit.ephemeralPublicKey,
+            encryptedData: legit.encryptedData,
+            keyCount: legit.keyCount,
+            senderSigningPublicKey: attackerPubB64,
+            signature: attackerSig,
+            createdAt: legit.createdAt
+        )
+        #expect(throws: (any Error).self) {
+            _ = try KeyShareService.decrypt(file: swapped, recipientPrivateKey: recipient)
+        }
+    }
+
+    @Test("Empty key list round trip")
+    func emptyRoundTrip() throws {
+        let recipient = P256.KeyAgreement.PrivateKey()
+        let signing = P256.Signing.PrivateKey()
+        let file = try KeyShareService.makeEncryptedFile(
+            keys: [], recipientPublicKey: recipient.publicKey, signingPrivateKey: signing
+        )
+        #expect(file.keyCount == 0)
+        let share = try KeyShareService.decrypt(file: file, recipientPrivateKey: recipient)
+        #expect(share.isAuthenticated == true)
+        #expect(share.entries.isEmpty)
     }
 
     // MARK: Forgery-with-different-key


### PR DESCRIPTION
Closes #112

## 脅威 (Threat)
`KeyShareService` はこれまで受信者の公開鍵に対する ephemeral-static ECDH + AES-256-GCM で `.aikeychain` を暗号化するだけで、**送信者の署名が一切なかった**。受信者の公開鍵は共有される前提のため、それを持つ第三者は誰でも「復号に成功する完全に有効なファイル」を偽造できる。「復号できた」ことは作成者について何も証明しない。結果として `decryptAndImport` は攻撃者が選んだ `(envVarName, value)` を返し、`ShareKeysView` がそれを Keychain へ黙って上書き保存してしまう（**credential substitution**: 例えば `OPENAI_API_KEY` を攻撃者管理のキーに差し替えて挙動を傍受）。旧 UI は値プレビューも上書き確認も無かった。

## 修正: 3層 (3-layer fix)
1. **送信者署名アイデンティティ (P256.Signing)** — 鍵共有鍵とは別に署名鍵ペアを追加。ストレージタグ `com.aieo.aikeychain.signkey` / account `signing_key`、`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`。`ensureSigningKey()` で **既存ユーザー（鍵共有鍵はあるが署名鍵が無い）にも透過的に生成**。`generateKeyPair()` も同時生成。`fingerprint(of:)` は `SHA256(x963)` を **256bit フル長**で 4桁ずつスペース区切りの大文字16進として返す（64bit へ切り詰めない）。
2. **ファイルフォーマット v2（後方互換）** — `EncryptedFile` に Optional フィールド `senderSigningPublicKey` / `signature` / `createdAt` を追加。追加分が Optional なので **v1 JSON もそのままデコード・復号できる**。署名は決定的な正規メッセージ（固定順・`\n`区切り・バイトレイアウトをコメントで明文化）に対して行い、受信側は同一メッセージを再構築して `isValidSignature` で検証。改ざん時は `ShareError.signatureInvalid` を throw。v1（署名なし）は復号しつつ `isAuthenticated=false` で返す。
3. **インポート UI ゲート + 値プレビュー + 上書き確認** — 送信者フィンガープリントを大きく表示し、「信頼できる経路で確認しました」の**必須チェックが入るまで Import を無効化**。未署名(v1)ファイルは**赤い警告バナー** + 追加承諾を要求。各キーは `SecretMask.mask` でマスク表示し eye トグルで開示。既存キーは「上書き」バッジ + 件数付きの上書き承諾チェックを必須化。エクスポート側には自分の署名フィンガープリントを表示（帯域外共有用）。

## 信頼モデル (Trust model)
有効な署名は「**その署名鍵の保有者**がこのファイルを作った」ことしか証明しない — 攻撃者は自分の署名鍵で有効なファイルを作れる（テスト `forgeryDifferentKey` で実証: 認証は通るが指紋が異なる）。したがって**人間が指紋を帯域外（対面・電話等）で送信者本人と照合する必要があり、UI がその照合チェックを必須ゲートとして強制する**。

## 後方互換 (Backward compatibility)
v1 の `EncryptedFile` JSON（署名フィールド無し）は引き続きインポート可能。ただし「送信者を認証できない」として赤警告付きでフラグされ、追加承諾が必要。

## 動作確認 (Evidence)
```
$ swift build 2>&1 | tail -3
[52/53] Applying AIkeychain
Build complete! (6.20s)

$ swift test 2>&1 | tail -6
✔ Suite "KeyShareService Sender Auth (#112)" passed after 0.314 seconds.
...
✔ Test run with 116 tests in 20 suites passed after 2.013 seconds.
```
新規スイート `KeyShareService Sender Auth (#112)`（9 テスト）を追加。v2 ラウンドトリップ / encryptedData・keyCount・senderKey の各改ざん検出 / 別署名鍵での偽造（認証は通るが指紋が違う）/ v1 後方互換（未認証で復号）/ 指紋のフル長・安定性 / 正規メッセージの決定性 / sign-verify を網羅。ベースライン 107 → 116（+9）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
