### PR TITLE
fix(security): scripts/akc の security を /usr/bin/security 絶対パスに固定 (#124)

### DIFF
--- a/scripts/akc
+++ b/scripts/akc
@@ -18,6 +18,12 @@
 
 set -euo pipefail
 
+# security(1) をバイナリ名解決 (PATH lookup) で呼ぶと、同一UIDの攻撃者や
+# npm パッケージの悪意ある postinstall が PATH 上に偽の "security" を
+# 先に置くことでシークレットを横取りできてしまう (#117 と同種の脅威)。
+# 絶対パスに固定して PATH ハイジャックを防ぐ。
+readonly SECURITY_BIN="/usr/bin/security"
+
 VERSION="1.6.1"
 
 usage() {
@@ -48,12 +54,12 @@ resolve_keychain() {
     local key_name="$1"
     local value
 
-    value=$(security find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null) \
+    value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null) \
         && [ -n "$value" ] && { printf '%s' "$value"; return 0; }
 
     # 手動登録キーのフォールバック。-a はあえて指定しない: acct の値が
     # エントリごとに一定しないため、service 名のみで引く方が安定する (issue #91)
-    security find-generic-password -s "$key_name" -w 2>/dev/null
+    "$SECURITY_BIN" find-generic-password -s "$key_name" -w 2>/dev/null
 }
 
 mask_value() {

--- a/scripts/akc
+++ b/scripts/akc
@@ -23,6 +23,9 @@ set -euo pipefail
 # 先に置くことでシークレットを横取りできてしまう (#117 と同種の脅威)。
 # 絶対パスに固定して PATH ハイジャックを防ぐ。
 readonly SECURITY_BIN="/usr/bin/security"
+# env も秘密解決パス上にある: `< <(env)` の env が偽装されると
+# `VAR=keychain://KEY` 行を捏造して任意の Keychain 値を解決・export させられる。
+readonly ENV_BIN="/usr/bin/env"
 
 VERSION="1.6.1"
 
@@ -133,7 +136,7 @@ cmd_run() {
                 fi
                 ;;
         esac
-    done < <(env)
+    done < <("$ENV_BIN")
 
     if $dry_run; then
         echo ""


### PR DESCRIPTION
Closes #124

## 脅威

`scripts/akc` の `resolve_keychain()` が macOS `security` バイナリを **バイナリ名 (PATH lookup)** で呼んでいた。同一UIDで動く攻撃者や、任意の npm パッケージの悪意ある postinstall スクリプトが、`$PATH` 上で本物の `/usr/bin/security` より前に偽の `security` 実行ファイルを置けば、`akc run` 実行時に呼ばれる `security find-generic-password` を横取りし、Keychain から解決されたシークレット値（`keychain://` 参照経由で子プロセスに注入される値）を盗聴・改ざんできてしまう。

これは Node CLI / Swift GUI に対して #117 で修正済みの脅威クラスと同一で、シェルラッパー (`scripts/akc`) だけが未対応だった。

## 修正

- `set -euo pipefail` の直後に `readonly SECURITY_BIN="/usr/bin/security"` を追加。
- `resolve_keychain()` 内の 2 箇所のバイナリ名呼び出し（AI KeyChain GUI 用 `-a "$key_name"` 参照と、手動登録キー用のフォールバック参照）を `"$SECURITY_BIN" find-generic-password ...` に変更。
- 引数の順序・フラグは変更していない（`-a "$USER"` を付けない挙動は #91 対応のまま維持）。
- `scripts/akc` 以外のファイルは変更していない。

## 動作確認 (Evidence)

```
$ bash -n scripts/akc && echo "syntax OK"
syntax OK

$ grep -n "security find-generic-password\|security add-generic-password\| security " scripts/akc
10:# via macOS Keychain (security find-generic-password) and injected into the
```

（10行目はヘッダーコメント内の説明文のみで、実際の呼び出し箇所（旧51行目・56行目）は全て `"$SECURITY_BIN"` 経由に置き換え済み。`add-generic-password` 呼び出しは `scripts/akc` 内に存在しない。）

```
$ bash scripts/test_akc.sh 2>&1 | tail -15
  ✅ exit=1 (expected 1): .../scripts/akc invalid_command
  ✅ exit=1 (expected 1): .../scripts/akc run
  ✅ exit=1 (expected 1): .../scripts/akc run --invalid-flag

--- Run with no keychain refs ---
  ✅ exit=0 (expected 0): env -i ... scripts/akc run -- echo hello
  ✅ output contains 'hello'

--- Dry run ---
  ✅ exit=0 (expected 0): env -i ... scripts/akc run --dry-run
  ✅ output contains 'Resolved: 0'

--- Dry run with keychain ref ---
  ✅ output contains 'not found'

=== Results: 11 passed, 1 failed ===
```

1件の失敗は既存の無関係な問題（テストが期待する `akc 1.0.0` に対し、実際のバージョンは `1.6.1` — バージョン文字列の期待値がテスト側で更新されていないだけ）で、本修正とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
