### PR TITLE
fix(security): supply-chain — ルート package.json を private 化 + CLI に shrinkwrap 同梱 (#118)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,6 +9,18 @@ akc init                    # teach the AI agents on this machine to use it
 
 > macOS only (uses the `security` command). Node.js 18+.
 
+### Supply-chain hardening (optional)
+
+`aikeychain` ships an `npm-shrinkwrap.json` so `npm install -g` resolves the exact,
+integrity-checked dependency tree that was tested and published — not a floating
+range. This package defines no `preinstall`/`postinstall`/`prepare` scripts, so you
+can additionally install with scripts disabled for defense-in-depth against a
+compromised transitive dependency:
+
+```bash
+npm install -g aikeychain --ignore-scripts
+```
+
 ## For AI agents (Claude, Codex, …)
 
 Run **`akc init`** once. It sets up **every AI session on this machine** (AI KeyChain is not a per-project tool):

--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,13 +1,16 @@
 {
   "name": "aikeychain",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aikeychain",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
+      "os": [
+        "darwin"
+      ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.25.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,7 +10,8 @@
   "files": [
     "bin",
     "src",
-    "README.md"
+    "README.md",
+    "npm-shrinkwrap.json"
   ],
   "engines": {
     "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "aikeychain",
+  "name": "aikeychain-docs",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aikeychain",
+      "name": "aikeychain-docs",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "vitepress": "^1.6.4"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aikeychain-docs",
   "version": "1.0.0",
   "private": true,
-  "description": "<p align=\"center\">   <img src=\"https://img.shields.io/badge/platform-macOS%2014+-blue?style=for-the-badge&logo=apple\" />   <img src=\"https://img.shields.io/badge/Swift-5.9+-orange?style=for-the-badge&logo=swift\" />   <img src=\"https://img.shields.io/badge/SwiftUI-Native-purple?style=for-the-badge\" />   <img src=\"https://img.shields.io/badge/license-MIT-green?style=for-the-badge\" /> </p>",
+  "description": "Docs/tooling scaffold for AI KeyChain (private; the published CLI is in cli/).",
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
@@ -14,7 +14,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/aieo-product/AIkeychain/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "aikeychain",
+  "name": "aikeychain-docs",
   "version": "1.0.0",
+  "private": true,
   "description": "<p align=\"center\">   <img src=\"https://img.shields.io/badge/platform-macOS%2014+-blue?style=for-the-badge&logo=apple\" />   <img src=\"https://img.shields.io/badge/Swift-5.9+-orange?style=for-the-badge&logo=swift\" />   <img src=\"https://img.shields.io/badge/SwiftUI-Native-purple?style=for-the-badge\" />   <img src=\"https://img.shields.io/badge/license-MIT-green?style=for-the-badge\" /> </p>",
-  "main": "index.js",
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",


### PR DESCRIPTION
Closes #118

## 脅威 (Threat)

1. **ルート `package.json` による npm 名の乗っ取りリスク**
   リポジトリルートの `package.json` は、`cli/` が実際に npm へ公開している CLI パッケージと同じ名前 `"aikeychain"` を、`private` フラグなし・`version: "1.0.0"`（`cli/package.json` の `0.5.0` より高い）で保持していた。ルート自体は VitePress ドキュメント用のスキャフォールドに過ぎないが、この状態で誰かが誤ってリポジトリルートから `npm publish` を実行すると、実物の CLI パッケージ (`cli/` 由来) を **より高いバージョン番号で上書き公開してしまい、正規ユーザーの `npm install -g aikeychain` を乗っ取る**サプライチェーン攻撃が成立し得た。さらに存在しない `index.js` を指す `main` フィールドも残っていた。

2. **CLI にロックファイルが同梱されておらず、依存が pin されない**
   `cli/` は `package-lock.json` をリポジトリ内には持っていたが、npm パッケージの公開物（tarball）には lockfile 相当のファイルが含まれておらず、`npm install -g aikeychain` を行う消費者側では **約90個の推移的依存**がレンジ指定のまま解決されていた（`npm ci` で `added 92 packages`）。依存が pin・integrity 検証されないため、上流パッケージの汚染（依存混乱、乗っ取り、悪意あるバージョン公開）の影響を受けやすい状態だった。

## 修正 (Fixes)

1. ルート `package.json`
   - `"private": true` を追加（誤 publish を npm レベルでブロック）
   - パッケージ名を `"aikeychain"` → `"aikeychain-docs"` に変更（実 CLI パッケージ名と衝突しないようにする）
   - 存在しない `index.js` を指す `"main"` フィールドを削除
   - `cli/package.json` の name/version には一切手を加えていない

2. `cli/`
   - `npm shrinkwrap` を実行し、既存の `package-lock.json` から `npm-shrinkwrap.json` を生成（npm がリネームする挙動どおり、`package-lock.json` は `npm-shrinkwrap.json` に置き換わる）。`npm-shrinkwrap.json` は npm が公開物へ常時同梱する特別ファイルだが、`cli/package.json` の `files` 配列にも明記して意図を明確化した。
   - `cli/README.md` に `npm install -g aikeychain --ignore-scripts` によるハードニングオプションの説明を追記（本パッケージは `preinstall`/`postinstall`/`prepare` スクリプトを一切定義していないため安全に併用可能）。

## 動作確認 (Evidence)

```
$ cd cli && rm -rf node_modules && npm ci
added 92 packages, and audited 93 packages in 384ms
found 0 vulnerabilities

$ node --test test/unit.test.js test/cli.test.js 2>&1 | tail -6
ℹ pass 23
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1313.593375

$ npm test   # 全テストスイート
ℹ tests 39
ℹ suites 0
ℹ pass 39
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0

$ npm pack --dry-run 2>&1 | grep -i "shrinkwrap"
npm notice 41.0kB npm-shrinkwrap.json

$ node -e "const p=require('./package.json'); console.log('private:', p.private, 'name:', p.name)"
private: true name: aikeychain-docs

$ node -e "const p=require('./cli/package.json'); console.log('cli name:', p.name, 'cli version:', p.version)"
cli name: aikeychain cli version: 0.5.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
