### PR TITLE
fix(security): 配布ハードニング(暫定) — README の sudo 撤廃 + Hardened Runtime + DMG チェックサム公開 (#114)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -138,8 +138,10 @@ jobs:
           cp "$SRC/icon_1024x1024.png" "$ICONSET/icon_512x512@2x.png"
           iconutil -c icns "$ICONSET" -o "$APP/Resources/AppIcon.icns"
 
-          # Ad-hoc 署名
-          codesign --force --deep --sign - "build/AI KeyChain.app"
+          # Ad-hoc 署名 (+ Hardened Runtime: defense-in-depth against
+          # DYLD_INSERT_LIBRARIES injection / debugger attach into a process
+          # that holds decrypted secrets in memory. See #114.)
+          codesign --force --deep --options runtime --sign - "build/AI KeyChain.app"
 
       - name: Install create-dmg
         if: steps.check.outputs.exists == 'false'
@@ -164,6 +166,14 @@ jobs:
             "build/AIKeyChain-v${VERSION}.dmg" \
             "build/AI KeyChain.app"
 
+      - name: Compute DMG checksum
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cd build
+          shasum -a 256 "AIKeyChain-v${VERSION}.dmg" > "AIKeyChain-v${VERSION}.dmg.sha256"
+          cat "AIKeyChain-v${VERSION}.dmg.sha256"
+
       - name: Create GitHub Release
         if: steps.check.outputs.exists == 'false'
         env:
@@ -175,6 +185,7 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file /tmp/release-body.md \
-            "build/AIKeyChain-v${VERSION}.dmg#AIKeyChain-v${VERSION}.dmg"
+            "build/AIKeyChain-v${VERSION}.dmg#AIKeyChain-v${VERSION}.dmg" \
+            "build/AIKeyChain-v${VERSION}.dmg.sha256#AIKeyChain-v${VERSION}.dmg.sha256"
 
-          echo "Release $TAG created with DMG attached."
+          echo "Release $TAG created with DMG + checksum attached."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -143,6 +143,24 @@ jobs:
           # that holds decrypted secrets in memory. See #114.)
           codesign --force --deep --options runtime --sign - "build/AI KeyChain.app"
 
+      - name: Verify code signature and Hardened Runtime flag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          APP="build/AI KeyChain.app"
+
+          # 署名そのものが壊れていないか
+          codesign --verify --deep --strict "$APP"
+
+          # Hardened Runtime フラグが実際に付与されているか検証
+          # (付与に失敗した署名をサイレントに出荷しないためのゲート)
+          if codesign -dvvv "$APP" 2>&1 | grep -qE 'flags=.*runtime'; then
+            echo "Hardened Runtime flag confirmed on $APP"
+          else
+            echo "ERROR: Hardened Runtime flag missing on $APP" >&2
+            codesign -dvvv "$APP" 2>&1 || true
+            exit 1
+          fi
+
       - name: Install create-dmg
         if: steps.check.outputs.exists == 'false'
         run: brew install create-dmg
@@ -168,8 +186,9 @@ jobs:
 
       - name: Compute DMG checksum
         if: steps.check.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           cd build
           shasum -a 256 "AIKeyChain-v${VERSION}.dmg" > "AIKeyChain-v${VERSION}.dmg.sha256"
           cat "AIKeyChain-v${VERSION}.dmg.sha256"

--- a/README.md
+++ b/README.md
@@ -50,30 +50,32 @@ AI developers juggle dozens of API keys. Most store them in `.env` or `.zshrc` i
 
 Download the latest release from [Releases](https://github.com/aieo-product/AIkeychain/releases).
 
-1. Open the DMG and drag **AI KeyChain.app** to **Applications**
-2. **Verify the download's checksum first** — see [Verify your download](#verify-your-download) below.
+1. **Verify the download's checksum** — see [Verify your download](#verify-your-download) below.
+2. Open the DMG and drag **AI KeyChain.app** to **Applications**
 3. Run the following command to trust the app (required before first launch):
 
 ```bash
 xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
 ```
 
-> **Note:** This app is not yet notarized with the Apple Developer Program, so macOS Gatekeeper quarantines it on download (tracking: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)). The command above removes the quarantine attribute so the app can launch without a security warning. **Never run this with `sudo`** — removing a quarantine attribute never requires root, and running it as root only widens the blast radius if the downloaded file were ever tampered with. Always verify the checksum (below) before running it.
+> **Note:** This app is not yet notarized with the Apple Developer Program, so macOS Gatekeeper quarantines it on download (tracking: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)). The command above removes the quarantine attribute so the app can launch without a security warning. **Never run this with `sudo`** — removing a quarantine attribute never requires root, and running it as root only widens the blast radius if the downloaded file were ever tampered with.
 
 ### Verify your download
 
-Each release publishes a `.sha256` checksum file alongside the DMG (e.g. `AIKeyChain-v1.6.1.dmg.sha256`). Download both files from the same [release](https://github.com/aieo-product/AIkeychain/releases) and verify before opening:
+Each release publishes a `.sha256` checksum file alongside the DMG (e.g. `AIKeyChain-vX.Y.Z.dmg.sha256`). Download both files from the same [release](https://github.com/aieo-product/AIkeychain/releases) and verify before opening:
 
 ```bash
-shasum -a 256 -c "AIKeyChain-v1.6.1.dmg.sha256"
+shasum -a 256 -c "AIKeyChain-vX.Y.Z.dmg.sha256"
 ```
 
 Or compare manually:
 
 ```bash
-shasum -a 256 "AIKeyChain-v1.6.1.dmg"
-# compare the printed hash against the value in AIKeyChain-v1.6.1.dmg.sha256 from the same release
+shasum -a 256 "AIKeyChain-vX.Y.Z.dmg"
+# compare the printed hash against the value in AIKeyChain-vX.Y.Z.dmg.sha256 from the same release
 ```
+
+> **Note:** The `.sha256` file is hosted in the same GitHub Release as the DMG, so this is a **download-integrity check only** — it catches corrupted downloads or a tampered mirror, but an attacker who can replace the release asset could also replace the checksum. It is **not** a substitute for code signing / notarization (tracking: [#114](https://github.com/aieo-product/AIkeychain/issues/114)).
 
 ### Build from Source
 
@@ -231,30 +233,32 @@ AI 開発では多数の API キーを扱います。多くの開発者はこれ
 
 [Releases](https://github.com/aieo-product/AIkeychain/releases) から最新版をダウンロードしてください。
 
-1. DMG を開き、**AI KeyChain.app** を **Applications** フォルダにドラッグ
-2. **先にダウンロードのチェックサムを検証してください**（下記「ダウンロードの検証」参照）。
+1. **ダウンロードのチェックサムを検証してください**（下記「ダウンロードの検証」参照）。
+2. DMG を開き、**AI KeyChain.app** を **Applications** フォルダにドラッグ
 3. 初回起動前に以下のコマンドを実行してアプリを信頼させてください:
 
 ```bash
 xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
 ```
 
-> **注意:** Apple Developer Program 未登録のため（トラッキング: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)）、macOS Gatekeeper がダウンロード時に quarantine（検疫）属性を付与します。上記コマンドはその検疫属性を削除し、警告なしで起動できるようにします。**`sudo` は絶対に付けないでください** — 検疫属性の削除に root 権限は不要であり、`sudo` を付けると万一ダウンロードしたファイルが改ざんされていた場合の被害が拡大するだけです。実行前に必ずチェックサムを検証してください（下記）。
+> **注意:** Apple Developer Program 未登録のため（トラッキング: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)）、macOS Gatekeeper がダウンロード時に quarantine（検疫）属性を付与します。上記コマンドはその検疫属性を削除し、警告なしで起動できるようにします。**`sudo` は絶対に付けないでください** — 検疫属性の削除に root 権限は不要であり、`sudo` を付けると万一ダウンロードしたファイルが改ざんされていた場合の被害が拡大するだけです。
 
 #### ダウンロードの検証
 
-各リリースには DMG と同時に `.sha256` チェックサムファイルが公開されます（例: `AIKeyChain-v1.6.1.dmg.sha256`）。同じ[リリース](https://github.com/aieo-product/AIkeychain/releases)から両方をダウンロードし、開く前に検証してください:
+各リリースには DMG と同時に `.sha256` チェックサムファイルが公開されます（例: `AIKeyChain-vX.Y.Z.dmg.sha256`）。同じ[リリース](https://github.com/aieo-product/AIkeychain/releases)から両方をダウンロードし、開く前に検証してください:
 
 ```bash
-shasum -a 256 -c "AIKeyChain-v1.6.1.dmg.sha256"
+shasum -a 256 -c "AIKeyChain-vX.Y.Z.dmg.sha256"
 ```
 
 または手動で比較:
 
 ```bash
-shasum -a 256 "AIKeyChain-v1.6.1.dmg"
-# 出力されたハッシュ値を同リリースの AIKeyChain-v1.6.1.dmg.sha256 の値と比較する
+shasum -a 256 "AIKeyChain-vX.Y.Z.dmg"
+# 出力されたハッシュ値を同リリースの AIKeyChain-vX.Y.Z.dmg.sha256 の値と比較する
 ```
+
+> **注意:** `.sha256` ファイルは DMG と同じ GitHub Release に置かれているため、これは**ダウンロードの完全性チェック**にすぎません（破損したダウンロードやミラーの改ざんは検出できますが、リリース資産を差し替えられる攻撃者はチェックサムも差し替えられます）。コード署名／公証（トラッキング: [#114](https://github.com/aieo-product/AIkeychain/issues/114)）の代替ではありません。
 
 #### ソースからビルド
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,29 @@ AI developers juggle dozens of API keys. Most store them in `.env` or `.zshrc` i
 Download the latest release from [Releases](https://github.com/aieo-product/AIkeychain/releases).
 
 1. Open the DMG and drag **AI KeyChain.app** to **Applications**
-2. Run the following command to trust the app (required before first launch):
+2. **Verify the download's checksum first** — see [Verify your download](#verify-your-download) below.
+3. Run the following command to trust the app (required before first launch):
 
 ```bash
-sudo xattr -rd com.apple.quarantine /Applications/AI\ KeyChain.app
+xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
 ```
 
-> **Note:** This app is not yet notarized with Apple Developer Program. The command above removes the Gatekeeper quarantine attribute so the app can launch without a security warning.
+> **Note:** This app is not yet notarized with the Apple Developer Program, so macOS Gatekeeper quarantines it on download (tracking: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)). The command above removes the quarantine attribute so the app can launch without a security warning. **Never run this with `sudo`** — removing a quarantine attribute never requires root, and running it as root only widens the blast radius if the downloaded file were ever tampered with. Always verify the checksum (below) before running it.
+
+### Verify your download
+
+Each release publishes a `.sha256` checksum file alongside the DMG (e.g. `AIKeyChain-v1.6.1.dmg.sha256`). Download both files from the same [release](https://github.com/aieo-product/AIkeychain/releases) and verify before opening:
+
+```bash
+shasum -a 256 -c "AIKeyChain-v1.6.1.dmg.sha256"
+```
+
+Or compare manually:
+
+```bash
+shasum -a 256 "AIKeyChain-v1.6.1.dmg"
+# compare the printed hash against the value in AIKeyChain-v1.6.1.dmg.sha256 from the same release
+```
 
 ### Build from Source
 
@@ -216,13 +232,29 @@ AI 開発では多数の API キーを扱います。多くの開発者はこれ
 [Releases](https://github.com/aieo-product/AIkeychain/releases) から最新版をダウンロードしてください。
 
 1. DMG を開き、**AI KeyChain.app** を **Applications** フォルダにドラッグ
-2. 初回起動前に以下のコマンドを実行してアプリを信頼させてください:
+2. **先にダウンロードのチェックサムを検証してください**（下記「ダウンロードの検証」参照）。
+3. 初回起動前に以下のコマンドを実行してアプリを信頼させてください:
 
 ```bash
-sudo xattr -rd com.apple.quarantine /Applications/AI\ KeyChain.app
+xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
 ```
 
-> **注意:** Apple Developer Program 未登録のため、このコマンドなしでは macOS Gatekeeper の警告が表示されます。
+> **注意:** Apple Developer Program 未登録のため（トラッキング: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)）、macOS Gatekeeper がダウンロード時に quarantine（検疫）属性を付与します。上記コマンドはその検疫属性を削除し、警告なしで起動できるようにします。**`sudo` は絶対に付けないでください** — 検疫属性の削除に root 権限は不要であり、`sudo` を付けると万一ダウンロードしたファイルが改ざんされていた場合の被害が拡大するだけです。実行前に必ずチェックサムを検証してください（下記）。
+
+#### ダウンロードの検証
+
+各リリースには DMG と同時に `.sha256` チェックサムファイルが公開されます（例: `AIKeyChain-v1.6.1.dmg.sha256`）。同じ[リリース](https://github.com/aieo-product/AIkeychain/releases)から両方をダウンロードし、開く前に検証してください:
+
+```bash
+shasum -a 256 -c "AIKeyChain-v1.6.1.dmg.sha256"
+```
+
+または手動で比較:
+
+```bash
+shasum -a 256 "AIKeyChain-v1.6.1.dmg"
+# 出力されたハッシュ値を同リリースの AIKeyChain-v1.6.1.dmg.sha256 の値と比較する
+```
 
 #### ソースからビルド
 

--- a/docs/dev/packaging.md
+++ b/docs/dev/packaging.md
@@ -115,8 +115,9 @@ cat > /tmp/aikeychain.entitlements << 'ENTITLEMENTS'
 </plist>
 ENTITLEMENTS
 
-# entitlements 付きで署名
-codesign --force --deep --sign - \
+# entitlements 付きで署名 (+ Hardened Runtime: DYLD_INSERT_LIBRARIES 注入や
+# デコード済みシークレットを保持するプロセスへのデバッガアタッチへの防御。#114)
+codesign --force --deep --options runtime --sign - \
   --entitlements /tmp/aikeychain.entitlements \
   "build/AI KeyChain.app"
 ```
@@ -124,6 +125,14 @@ codesign --force --deep --sign - \
 ::: warning entitlements なしの場合
 `--entitlements` を省略すると Proxy モードの upstream TLS 接続がブロックされ、
 API 呼び出しがタイムアウトします（Standard / Secret Reference モードは影響なし）。
+:::
+
+::: warning Hardened Runtime + Ad-hoc 署名について
+Hardened Runtime の library validation は、Ad-hoc 署名との組み合わせで
+署名されていないサードパーティ dylib の読み込みに影響する可能性がある。
+本アプリはシステムフレームワークと自前の SwiftPM コードのみをリンクしているため
+基本的に問題ないはずだが、**CI では実機起動確認ができないため、リリースごとに
+実機でアプリを起動して動作確認すること**（#114 フォローアップ）。
 :::
 
 ### 6. グラフィカル DMG 作成
@@ -205,7 +214,7 @@ cp "$SRC/icon_512x512.png" "$ICONSET/icon_256x256@2x.png" && \
 cp "$SRC/icon_512x512.png" "$ICONSET/icon_512x512.png" && \
 cp "$SRC/icon_1024x1024.png" "$ICONSET/icon_512x512@2x.png" && \
 iconutil -c icns "$ICONSET" -o "$APP/Resources/AppIcon.icns" && \
-codesign --force --deep --sign - "build/AI KeyChain.app" && \
+codesign --force --deep --options runtime --sign - "build/AI KeyChain.app" && \
 create-dmg \
   --volname "AI KeyChain" \
   --volicon "$APP/Resources/AppIcon.icns" \

--- a/docs/dev/packaging.md
+++ b/docs/dev/packaging.md
@@ -100,6 +100,15 @@ iconutil -c icns "$ICONSET" -o "$APP_DIR/Resources/AppIcon.icns"
 Developer ID がない場合の署名（「壊れているため開けません」エラーを防止）。
 **Proxy モードの outbound TLS 接続には network entitlements が必須。**
 
+::: warning 正典レシピは CI 側
+実際に出荷されるアーティファクトは **CI（`.github/workflows/auto-release.yml`）が生成する DMG** であり、
+CI の ad-hoc 署名は **network entitlements を付けていない**。この §5 の手動署名（entitlements 付き）は
+ローカル動作確認用であり、出荷物とは署名内容が異なる。**Hardened Runtime の実機起動テストは
+必ず CI 生成物（Release にアップロードされた DMG）に対して行うこと**。
+Proxy モードの upstream TLS 挙動は entitlements の有無で変わるため、手動署名版で
+「動いた／動かない」を CI 生成物の判断材料にしないこと。
+:::
+
 ```bash
 # network entitlements を作成（初回のみ）
 cat > /tmp/aikeychain.entitlements << 'ENTITLEMENTS'


### PR DESCRIPTION
## Summary

Refs #114. This PR implements the parts of the distribution-hardening issue that do **not** require Apple Developer Program enrollment. Developer ID signing + Notarization remain **deferred** and #114 stays open for that work.

Three changes, all defense-in-depth for a native macOS app that reads decrypted secrets from Keychain into process memory:

1. **README: remove `sudo` from the Gatekeeper-quarantine instructions (EN + JA)**
   `sudo xattr -rd com.apple.quarantine /Applications/AI\ KeyChain.app` → `xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"`.
   Removing the quarantine attribute never requires root — running it as root only widens the blast radius if the downloaded file were ever tampered with. Added a note explaining this step exists only because the app isn't notarized yet (tracking: #114, #34), plus a nudge to verify the checksum (item 3) before running the command.

2. **Hardened Runtime on the release codesign step**
   `.github/workflows/auto-release.yml` and `docs/dev/packaging.md`: added `--options runtime` to the existing ad-hoc `codesign --force --deep --sign -` invocations. This hardens against `DYLD_INSERT_LIBRARIES` injection and debugger attach into a process holding decrypted secrets in memory.

   **Caveat (please read before merging):** Hardened Runtime + library validation on an **ad-hoc** signature can, in principle, affect loading of unsigned/third-party dylibs. This app links only system frameworks + its own SwiftPM code, so it *should* be fine — but CI cannot verify that the built `.app` actually launches with these flags (GitHub's macOS runners have no interactive session to fully exercise Gatekeeper/AMFI checks against a running GUI app). **This must be verified on real hardware** by building via the same recipe and launching the app before this is trusted in a real release. I have not done that verification here — flagging it explicitly rather than claiming it's proven safe. Added a corresponding warning callout in `docs/dev/packaging.md`.

3. **DMG checksum publication**
   `auto-release.yml`: after the DMG is built, compute `shasum -a 256` and upload the resulting `.sha256` file as an additional release asset alongside the DMG. README gets a new "Verify your download" / "ダウンロードの検証" section (EN + JA) showing `shasum -a 256 -c "AIKeyChain-vX.Y.Z.dmg.sha256"` and the manual-compare fallback.

## Out of scope (deferred, tracked by #114)

- Developer ID Application signing
- `notarytool` submission / stapling
- Anything requiring an enrolled Apple Developer Program account

## 動作確認 (Evidence)

```
$ ruby -e 'require "yaml"; YAML.load_file(".github/workflows/auto-release.yml"); puts "yaml OK (ruby)"'
yaml OK (ruby)

$ /usr/bin/python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/auto-release.yml')); print('yaml OK (system python3)')"
yaml OK (system python3)

$ grep -n "options runtime\|shasum -a 256\|xattr" .github/workflows/auto-release.yml README.md
.github/workflows/auto-release.yml:144:          codesign --force --deep --options runtime --sign - "build/AI KeyChain.app"
.github/workflows/auto-release.yml:174:          shasum -a 256 "AIKeyChain-v${VERSION}.dmg" > "AIKeyChain-v${VERSION}.dmg.sha256"
README.md:58:xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
README.md:68:shasum -a 256 -c "AIKeyChain-v1.6.1.dmg.sha256"
README.md:74:shasum -a 256 "AIKeyChain-v1.6.1.dmg"
README.md:239:xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
README.md:249:shasum -a 256 -c "AIKeyChain-v1.6.1.dmg.sha256"
README.md:255:shasum -a 256 "AIKeyChain-v1.6.1.dmg"

$ ! grep -rn "sudo xattr" README.md docs/ && echo "no sudo xattr remains"
no sudo xattr remains
```

(Note: the sandbox's `python3` lacked PyYAML and `pip install` failed due to an unrelated local libexpat symbol mismatch, so YAML validity was confirmed with both Ruby's YAML parser and the system `/usr/bin/python3`, which does have PyYAML available.)

## Test plan

- [x] YAML for `auto-release.yml` parses successfully (Ruby + system Python)
- [x] No `sudo xattr` remains anywhere in `README.md` / `docs/`
- [x] `--options runtime` present in both `auto-release.yml` and `docs/dev/packaging.md`
- [x] `shasum -a 256` checksum step present in `auto-release.yml`, wired into the `gh release create` asset list
- [ ] **Not done / needs a human with real hardware:** build the `.app` via the updated recipe, ad-hoc sign with `--options runtime`, and confirm it actually launches (Standard, Secret Reference, and Proxy modes) without Hardened Runtime blocking anything. Please do this before cutting the next real release.

## Hard gate before the next release tag

Merging this PR does **not** clear the app for release. The following must be verified **on real hardware against the CI-produced DMG** (not a local build) and is a **blocking gate** for the next release tag — do not ship until every box is checked:

- [ ] Download the CI-built DMG from the draft/latest Release, verify its `.sha256`, and remove quarantine per the README steps.
- [ ] Launch the app and confirm **Standard** mode works end-to-end (no Hardened Runtime / AMFI launch failure).
- [ ] Confirm **Secret Reference** mode works end-to-end (`akc run` injection).
- [ ] Confirm **Proxy** mode works end-to-end, including upstream TLS (this is where the CI signature's lack of network entitlements vs. the manual §5 recipe matters most).
- [ ] Confirm the CI `Verify code signature and Hardened Runtime flag` step passed for that build (green in Actions).

If any box fails, hold the release and reopen the Hardened Runtime decision on #114.

## Fable review follow-up (2nd commit)

Applied the APPROVE-WITH-MINOR-FIXES items from the Fable review (see the `## Fable レビュー対応` PR comment for the full list): reordered the install steps to verify-checksum-first, added the same-channel checksum caveat (integrity check, not a signing substitute), replaced the hardcoded version with `vX.Y.Z`, added a CI codesign sanity step that fails the job if the Hardened Runtime flag is missing, moved the checksum step's version interpolation into an `env:` block, and documented in `packaging.md` that the CI recipe (no entitlements) is the canonical shipped artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

