### PR TITLE
fix(#137): store キーの手動取得ガイダンスを訂正（-s com.aieo.aikeychain -a / akc get 推奨）

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Terminal                                                          API Server
 > the account (the key name), matching exactly how the GUI stores the entry — this
 > avoids the `-a "$USER"` pitfall of stale or duplicate `acct` values.
 
+> **Common AI-agent mistake:** looking up a GUI-stored key with the bare
+> `security find-generic-password -s "API_KEY" -w` (service name only, no `-a`)
+> returns "could not be found" (exit 44). That is **not** proof the key is
+> unregistered — it just means the wrong lookup form was used for a GUI-store
+> key. Use `akc get API_KEY` / `akc check API_KEY` (see [CLI & MCP
+> Server](#cli--mcp-server-npm) below), or the two-attribute `security` form
+> shown above, instead of concluding the key is missing.
+
 ### Proxy Mode
 ```
 Terminal               AI KeyChain Proxy          API Server
@@ -226,6 +234,14 @@ AI 開発では多数の API キーを扱います。多くの開発者はこれ
 | SDK 直接実行 | 可能 | `akc run` 必要 | 可能 |
 | セキュリティレベル | ★☆☆ | ★★☆ | ★★★ |
 | 向いている用途 | シンプルに使いたい | 1Password 方式（`op://` 同等） | セキュリティ重視の環境 |
+
+> **AI エージェントによくある誤り:** GUI ストアに保存したキーを `security
+> find-generic-password -s "API_KEY" -w`（サービス名のみ、`-a` なし）で引くと
+> "could not be found"（exit 44）になりますが、これは**「未登録」の証拠ではありません**。
+> GUI ストアのキーには誤ったルックアップ方法を使っているだけです。
+> `akc get API_KEY` / `akc check API_KEY`（後述の「CLI & MCP サーバー」）か、
+> `security find-generic-password -s "com.aieo.aikeychain" -a "API_KEY" -w`
+> （service + account の両方を指定する形）を使ってください。
 
 ### インストール
 

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -12,6 +12,7 @@ import {
   deleteKey,
   maskValue,
   KeychainError,
+  GUI_SERVICE,
 } from '../src/keychain.js';
 import { cmdRun } from '../src/run.js';
 import { runDoctor, formatReport } from '../src/doctor.js';
@@ -125,6 +126,13 @@ async function cmdCheck(name) {
       .filter(Boolean)
       .join(', ');
     process.stdout.write(`✅ ${name} exists (${stores})\n`);
+    if (result.app && !result.manual) {
+      // Store-only key: the bare `security -s <KEY> -w` form (no -a) returns
+      // exit 44 for these — a false "not registered" signal (issue #137).
+      process.stdout.write(
+        `   ↳ security CLI: use -s "${GUI_SERVICE}" -a "${name}"  (or: akc get ${name})\n`
+      );
+    }
     return 0;
   }
   process.stdout.write(`❌ ${name} not found in Keychain\n`);

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -130,7 +130,7 @@ async function cmdCheck(name) {
       // Store-only key: the bare `security -s <KEY> -w` form (no -a) returns
       // exit 44 for these — a false "not registered" signal (issue #137).
       process.stdout.write(
-        `   ↳ security CLI: use -s "${GUI_SERVICE}" -a "${name}"  (or: akc get ${name})\n`
+        `   ↳ security CLI: use -s "${GUI_SERVICE}" -a "${name}" -w  (or: akc get ${name})\n`
       );
     }
     return 0;

--- a/cli/src/agent-setup.js
+++ b/cli/src/agent-setup.js
@@ -20,10 +20,12 @@ value into \`.env\`, source code, logs, or commits.
   export OPENAI_API_KEY=keychain://OPENAI_API_KEY
   akc run -- <command>            # resolves keychain:// refs into the child process only
   \`\`\`
-- Read a key manually — prefer \`akc get <KEY>\`: it checks both stores (AI
-  KeyChain GUI + manually-registered) and never exposes the value beyond the
-  child process. If you must use the raw \`security\` CLI, pick the form that
-  matches where the key lives:
+- Check / read a key — prefer \`akc get <KEY>\`: it checks both stores (AI
+  KeyChain GUI + manually-registered) and by default prints only the
+  \`keychain://\` reference (never the value). Add \`--reveal\` only when you
+  truly need the raw value on stdout; to inject it into a process instead, use
+  \`akc run -- <command>\`. If you must use the raw \`security\` CLI, pick the
+  form that matches where the key lives:
   \`\`\`bash
   # [app] store keys (saved via the AI KeyChain GUI):
   security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w

--- a/cli/src/agent-setup.js
+++ b/cli/src/agent-setup.js
@@ -20,11 +20,21 @@ value into \`.env\`, source code, logs, or commits.
   export OPENAI_API_KEY=keychain://OPENAI_API_KEY
   akc run -- <command>            # resolves keychain:// refs into the child process only
   \`\`\`
-- Read a key manually by **service name only** — do NOT pin \`-a "$USER"\`
-  (account attributes are inconsistent; pinning can return a stale value):
+- Read a key manually — prefer \`akc get <KEY>\`: it checks both stores (AI
+  KeyChain GUI + manually-registered) and never exposes the value beyond the
+  child process. If you must use the raw \`security\` CLI, pick the form that
+  matches where the key lives:
   \`\`\`bash
-  security find-generic-password -s "ENV_VAR_NAME" -w
+  # [app] store keys (saved via the AI KeyChain GUI):
+  security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w
+  # [manual] keys (registered by hand) — service name only, do NOT pin
+  # -a "$USER" (account attributes are inconsistent; pinning can return a
+  # stale value):
+  security find-generic-password -s "<KEY>" -w
   \`\`\`
+  ⚠️ The bare \`-s "<KEY>"\` form returns "could not be found" (exit 44) for
+  [app] store keys — that is NOT proof the key is unregistered. Confirm with
+  \`akc check <KEY>\` / \`akc get <KEY>\` before concluding a key is missing.
 - Store/update a key without exposing it in argv or shell history:
   \`\`\`bash
   akc set ENV_VAR_NAME          # hidden prompt (or pipe via stdin)

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -15,11 +15,20 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    - Launch tools through akc:                  akc run -- <command>
    - akc resolves the references from the macOS Keychain and injects the real
      values ONLY into the child process. The parent shell never sees them.
-3. When reading a key manually with the security CLI, look it up by SERVICE
-   NAME ONLY — do NOT pin the account with -a "$USER":
-     security find-generic-password -s "ENV_VAR_NAME" -w
-   Account attributes are inconsistent across entries; pinning -a can return a
-   stale/invalid duplicate (AIkeychain issue #91).
+3. To read a key manually, prefer \`akc get <KEY>\`: it checks both stores and
+   never exposes the value beyond the child process. If you must use the raw
+   security CLI directly, use the form that matches where the key lives:
+     [app] store keys (saved via the AI KeyChain GUI):
+       security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w
+     [manual] keys (registered by hand) — service name only, do NOT pin the
+     account with -a "$USER":
+       security find-generic-password -s "<KEY>" -w
+   ⚠️ The bare -s "<KEY>" form (no -a) returns "could not be found" (exit 44)
+   for [app] store keys — that is NOT proof the key is unregistered. Confirm
+   with \`akc check <KEY>\` / \`akc get <KEY>\` before concluding a key is
+   missing. (Account attributes on [manual] entries are inconsistent across
+   entries; pinning -a there can return a stale/invalid duplicate — AIkeychain
+   issue #91.)
 4. To save/update a key, overwrite with -U so no duplicate entries are created:
      security add-generic-password -s "KEY_NAME" -a "KEY_NAME" -w "<value>" -U
    (prefer \`akc set KEY_NAME\`: the value is read from a hidden prompt or stdin

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -15,8 +15,10 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    - Launch tools through akc:                  akc run -- <command>
    - akc resolves the references from the macOS Keychain and injects the real
      values ONLY into the child process. The parent shell never sees them.
-3. To read a key manually, prefer \`akc get <KEY>\`: it checks both stores and
-   never exposes the value beyond the child process. If you must use the raw
+3. To check/read a key, prefer \`akc get <KEY>\`: it checks both stores and by
+   default prints only the keychain:// reference (never the value). Add
+   --reveal only when you truly need the raw value on stdout; to inject it into
+   a process instead, use \`akc run -- <command>\`. If you must use the raw
    security CLI directly, use the form that matches where the key lives:
      [app] store keys (saved via the AI KeyChain GUI):
        security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -199,7 +199,7 @@ test('check on a store-only key hints the correct `security` form (issue #137)',
   // so the correct two-attribute form (or `akc get`) is discoverable.
   const good = await runAkc(['check', 'GOOD_KEY']);
   assert.equal(good.code, 0);
-  assert.match(good.stdout, /-s "com\.aieo\.aikeychain" -a "GOOD_KEY"/);
+  assert.match(good.stdout, /-s "com\.aieo\.aikeychain" -a "GOOD_KEY" -w/);
   assert.match(good.stdout, /akc get GOOD_KEY/);
 
   // A manual-only key must NOT get the hint — the bare `-s <KEY>` form already

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -190,6 +190,26 @@ test('check reports store and missing keys', async () => {
   assert.equal(missing.code, 1);
 });
 
+test('check on a store-only key hints the correct `security` form (issue #137)', async () => {
+  // GOOD_KEY exists only under service="com.aieo.aikeychain" account="GOOD_KEY"
+  // (the stub reports it found ONLY for that query, not for the bare -s
+  // GOOD_KEY form). That mismatch is exactly the #137 false-negative: an agent
+  // running `security find-generic-password -s "GOOD_KEY" -w` gets exit 44 and
+  // wrongly concludes the key is unregistered. `akc check` must append a hint
+  // so the correct two-attribute form (or `akc get`) is discoverable.
+  const good = await runAkc(['check', 'GOOD_KEY']);
+  assert.equal(good.code, 0);
+  assert.match(good.stdout, /-s "com\.aieo\.aikeychain" -a "GOOD_KEY"/);
+  assert.match(good.stdout, /akc get GOOD_KEY/);
+
+  // A manual-only key must NOT get the hint — the bare `-s <KEY>` form already
+  // works for it, so the extra line would be noise.
+  const manual = await runAkc(['check', 'MANUAL_KEY']);
+  assert.equal(manual.code, 0);
+  assert.match(manual.stdout, /manual entry/);
+  assert.doesNotMatch(manual.stdout, /security CLI: use/);
+});
+
 test('get prints a reference by default, raw value only with --reveal', async () => {
   const ref = await runAkc(['get', 'GOOD_KEY']);
   assert.equal(ref.code, 0);

--- a/cli/test/init.test.js
+++ b/cli/test/init.test.js
@@ -266,6 +266,14 @@ test('akc init --print previews machine-wide setup without writing, using absolu
   assert.match(claudeLine, /\bmcp$/);
   assert.ok(r.stdout.includes(`command = "${REAL_LAUNCH.nodeBin}"`));
   assert.ok(r.stdout.includes(`args = ["${REAL_LAUNCH.akcJs}", "mcp"]`));
+  // End-to-end: the rendered template shows BOTH security lookup forms
+  // (store + manual) and recommends `akc get`, so the #137 correction is
+  // guaranteed at the CLI-output level, not just in the AGENT_INSTRUCTIONS
+  // constant.
+  assert.match(r.stdout, /-s "com\.aieo\.aikeychain" -a "<KEY>" -w/); // [app] store form
+  assert.match(r.stdout, /-s "<KEY>" -w/); // [manual] form
+  assert.match(r.stdout, /akc get <KEY>/);
+  assert.doesNotMatch(r.stdout, /-s "ENV_VAR_NAME" -w/); // old sole-method form is gone
 });
 
 test('akc init (default machine-wide) writes ~/.claude + ~/.codex under HOME, idempotently', async () => {

--- a/cli/test/init.test.js
+++ b/cli/test/init.test.js
@@ -31,9 +31,25 @@ const REAL_LAUNCH = resolveAkcLaunch();
 test('AGENT_INSTRUCTIONS teaches the core rules', () => {
   assert.match(AGENT_INSTRUCTIONS, /keychain:\/\//);
   assert.match(AGENT_INSTRUCTIONS, /akc run/);
-  assert.match(AGENT_INSTRUCTIONS, /-s "ENV_VAR_NAME" -w/);
-  assert.match(AGENT_INSTRUCTIONS, /do NOT pin `-a "\$USER"`/);
   assert.match(AGENT_INSTRUCTIONS, /usage_guide/);
+});
+
+test('AGENT_INSTRUCTIONS recommends `akc get` and presents both security lookup forms (#137)', () => {
+  // Root cause of #137: the old guidance taught a single `-s ENV_VAR_NAME -w`
+  // form. That form only works for [manual] keys; for AI KeyChain GUI ("app"
+  // store) keys it returns exit 44, so agents falsely concluded the key was
+  // unregistered. `akc get` handles both stores and must be the primary
+  // recommendation; if raw `security` is shown, both forms must be present
+  // and labeled, with a warning that exit 44 on the bare -s form is not proof
+  // of "unregistered".
+  assert.match(AGENT_INSTRUCTIONS, /akc get <KEY>/);
+  assert.match(AGENT_INSTRUCTIONS, /-s "com\.aieo\.aikeychain" -a "<KEY>" -w/); // [app] store form
+  assert.match(AGENT_INSTRUCTIONS, /-s "<KEY>" -w/); // [manual] form
+  assert.match(AGENT_INSTRUCTIONS, /exit 44/);
+  assert.match(AGENT_INSTRUCTIONS, /akc check <KEY>/);
+  assert.match(AGENT_INSTRUCTIONS, /do NOT pin[\s\S]*-a "\$USER"/);
+  // The bare single-service form must no longer be presented as the sole method.
+  assert.doesNotMatch(AGENT_INSTRUCTIONS, /-s "ENV_VAR_NAME" -w/);
 });
 
 test('upsertManagedBlock creates a block in empty content', () => {


### PR DESCRIPTION
Closes #137

## 根本原因（確定）

`#137` の issue 本文にある「DP Keychain 移行が原因」という仮説は**誤り**です（DP Keychain への移行は既に中止済み — `project_proxy_mode_broken` 参照）。

実際の root cause は **サービス名の不一致** です:

- AI KeyChain GUI で保存したキー（`[app]` ストア）は `service="com.aieo.aikeychain"`, `account=<KEY>` で保存される（`AIkeychain/Services/KeychainService.swift`）。
- これらは legacy `security` CLI から読めるが、**正しい service + account の両方**を指定した場合のみ:
  - `[app]` ストアのキー → `security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w`
  - `[manual]` キー → `security find-generic-password -s "<KEY>" -w`（#91 により `-a "$USER"` は付けない）
- ところが `akc init` の CLAUDE.md/AGENTS.md テンプレート、README、MCP の `usage_guide` はすべて **単一の** `security find-generic-password -s "ENV_VAR_NAME" -w` 形式のみを手動取得方法として案内していた。この形式は `[manual]` キーにしか通用せず、`[app]` ストアのキーに対しては exit 44（"item could not be found"）を返す。
- 結果として、エージェントは「未登録／失効している」と誤診断していた（実例: `SLACK_BOT_TOKEN` が「未登録」と誤報告、`GITLAB_TOKEN` が「失効」と誤診断）。
- 実機検証済み: `security -s GITLAB_TOKEN` → exit 44 だが `security -s com.aieo.aikeychain -a GITLAB_TOKEN` → exit 0、`akc get GITLAB_TOKEN` → exit 0。

## 変更内容（4点）

1. **`akc init` テンプレート**（`cli/src/agent-setup.js` の `AGENT_INSTRUCTIONS`）: 手動取得の第一推奨を `akc get <KEY>` に変更。生の `security` を示す場合は `[app]` ストア用（`-s "com.aieo.aikeychain" -a "<KEY>"`）と `[manual]` 用（`-s "<KEY>"`、`-a "$USER"` 禁止）の**両方**を明示し、単一形式での exit 44 は「未登録の証拠ではない」と警告を追加。
2. **MCP `usage_guide`**（`cli/src/usage-guide.js`）: golden rule #3 を同様に訂正。`akc get` を優先案内し、両方の `security` 形式とラベル、exit 44 警告を追加。
3. **README.md**（EN / JA 両方）: Standard Mode の説明の直後に、GUI ストアキーを単一 `-s` 形式で引いて exit 44 になった場合の誤解を防ぐ注記を追加。
4. **`akc check` の出力**（`cli/bin/akc.js`）: `[app]` ストアのみに存在するキー（bare `-s <KEY>` 形式が失敗する対象）に対して、正しい `security` 呼び出し方法のヒントを1行追加:
   ```
   ✅ GITLAB_TOKEN exists (AI KeyChain store)
      ↳ security CLI: use -s "com.aieo.aikeychain" -a "GITLAB_TOKEN"  (or: akc get GITLAB_TOKEN)
   ```
   `[manual]` のみのキーにはヒントを追加しない（bare `-s <KEY>` で既に動作するため）。

`akc` 自体のキー保存・取得ロジック（2段階ルックアップ）は変更していません。今回はガイダンス文言の訂正 + `akc check` の1行ヒント追加のみです。

既存ユーザーは `akc init` を再実行することで、訂正済みの CLAUDE.md / AGENTS.md を再取得できます（#134 のアップグレード導線と同じ）。

## 動作確認 (Evidence)

```
$ node --test test/unit.test.js test/cli.test.js test/init.test.js 2>&1 | tail -8
ℹ tests 59
ℹ suites 0
ℹ pass 59
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1349.537375
```

（`test/mcp.test.js` はこのサンドボックス環境で ~10秒でタイムアウトする既知の環境依存事象であり、本変更とは無関係のため上記の3スイートのみを明示的に実行しています。）

訂正後の `akc init --print` 出力（抜粋）:

```
$ node bin/akc.js init --print 2>&1 | grep -A3 -i "security find-generic-password"
  security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w
  # [manual] keys (registered by hand) — service name only, do NOT pin
  # -a "$USER" (account attributes are inconsistent; pinning can return a
  # stale value):
  security find-generic-password -s "<KEY>" -w
```

## 補足

issue #137 で提案されていた「not-found と access-denied を exit code で区別する」案（提案 #3）は、今回のスコープ外のフォローアップとして保留します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
