### PR TITLE
chore(npm): republish aikeychain@0.5.1 with #136/#138 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to AI KeyChain are documented in this file.
 
+## npm `aikeychain@0.5.1` - 2026-07-09
+
+Republish carrying fixes merged to `main` after the `0.5.0` release.
+
+### Fixed
+- **CLI mask leak** — `cli/src/keychain.js` `maskValue` printed `****** (N chars)`, leaking the secret's character count. Now emits a fixed-length `********` mask, matching the `scripts/akc` behavior fixed earlier under #115/#123 (#136)
+- **Manual key-retrieval guidance** — `akc init` template, MCP `usage_guide`, and README taught only the `security find-generic-password -s "ENV_VAR_NAME" -w` form, which returns exit 44 for keys stored via the AI KeyChain GUI (`service=com.aieo.aikeychain`) and falsely suggested the key was missing. `akc get <KEY>` is now the primary recommendation everywhere; both `security` lookup forms are documented with an explicit warning that exit 44 on the bare form is not proof of "unregistered" (#137, #138)
+
 ## [1.6.1] - 2026-05-13
 
 ### Fixed

--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "aikeychain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aikeychain",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "os": [
         "darwin"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aikeychain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI KeyChain CLI & MCP server — resolve keychain:// secret references from macOS Keychain and let AI agents (Claude, Codex) use them safely. Run `akc init` to set up discovery.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `cli/package.json` + `cli/npm-shrinkwrap.json` to `0.5.1` and adds a CHANGELOG entry
- The npm `aikeychain@0.5.0` release predated the CLI mask-length leak fix (#136) and the manual key-retrieval guidance correction (#137/#138) merged after it
- **Already published to the npm registry** (`npm view aikeychain version` → `0.5.1`, `dist-tags.latest` → `0.5.1`) — this PR just syncs the repo state to match what's live

## Test plan
- [x] `node --test test/unit.test.js test/cli.test.js test/init.test.js` → 59/59 pass
- [x] `npm publish --ignore-scripts --access public --dry-run` reviewed (tarball contents/version correct) before real publish
- [x] `npm view aikeychain version` confirms `0.5.1` is live as `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)