### PR TITLE
fix(proxy): zsh フックの /dev/tcp probe を修正し Proxy モードのシェル統合を復旧 (#142)

### DIFF
--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -142,6 +142,10 @@ enum SetupManager {
 
     /// .zshrc に AI KeyChain ブロックが設定済みか確認
     static func isConfigured() -> Bool {
+        isConfigured(zshrcPath: zshrcPath)
+    }
+
+    static func isConfigured(zshrcPath: String) -> Bool {
         guard let content = try? String(contentsOfFile: zshrcPath, encoding: .utf8) else {
             return false
         }
@@ -149,7 +153,7 @@ enum SetupManager {
     }
 
     /// レガシー形式かどうか（マーカーなしの旧バージョン）
-    private static var hasLegacyFormat: Bool {
+    private static func hasLegacyFormat(zshrcPath: String) -> Bool {
         guard let content = try? String(contentsOfFile: zshrcPath, encoding: .utf8) else { return false }
         return content.contains(".aikeychain_proxy") && !content.contains(markerBegin)
     }
@@ -157,15 +161,23 @@ enum SetupManager {
     /// .zshrc にフックを追記（BEGIN/END マーカーで囲む）
     /// レガシー形式が存在する場合は先に削除してからマーカー形式で再追加
     static func configure() throws {
+        try configure(zshrcPath: zshrcPath)
+    }
+
+    static func configure(zshrcPath: String) throws {
         // レガシー形式 → マーカー形式にアップグレード
-        if hasLegacyFormat {
-            try unconfigure()
+        if hasLegacyFormat(zshrcPath: zshrcPath) {
+            try unconfigure(zshrcPath: zshrcPath)
         }
 
-        // マーカー形式が既に存在する場合はスキップ
+        // 現行のマーカー形式が既に存在する場合はスキップ。古い形式は置き換える。
         if let content = try? String(contentsOfFile: zshrcPath, encoding: .utf8),
            content.contains(markerBegin) {
-            return
+            let currentBlock = "\(markerBegin)\n\(zshrcSourceLine)\n\(markerEnd)"
+            if content.contains(currentBlock) {
+                return
+            }
+            try unconfigure(zshrcPath: zshrcPath)
         }
 
         var content = (try? String(contentsOfFile: zshrcPath, encoding: .utf8)) ?? ""
@@ -256,7 +268,11 @@ enum SetupManager {
 
     /// .zshrc から AI KeyChain 管理ブロック全体を削除（マーカー間 + レガシー行）
     static func unconfigure() throws {
-        guard isConfigured() else { return }
+        try unconfigure(zshrcPath: zshrcPath)
+    }
+
+    static func unconfigure(zshrcPath: String) throws {
+        guard isConfigured(zshrcPath: zshrcPath) else { return }
 
         let content = try String(contentsOfFile: zshrcPath, encoding: .utf8)
         let lines = content.components(separatedBy: "\n")

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -18,17 +18,21 @@ enum SetupManager {
     /// ファイルが存在し、かつプロキシポートが実際に応答する場合のみ source する。
     /// 強制シャットダウン等でファイルが残っても、プロキシ未稼働なら読み込まれない。
     /// また、残ったファイルを自動削除する（次回起動時にクリーンな状態になる）。
-    private static let zshrcSourceLine = """
-    if [ -f ~/.aikeychain_proxy ]; then
-      _aikp=$(grep -om1 'localhost:[0-9]*' ~/.aikeychain_proxy | head -1 | cut -d: -f2)
-      if [ -n "$_aikp" ] && (echo >/dev/tcp/127.0.0.1/$_aikp) 2>/dev/null; then
-        source ~/.aikeychain_proxy
+    static func proxySourceSnippet(proxyEnvPath: String) -> String {
+        """
+    if [ -f \(proxyEnvPath) ]; then
+      _aikp=$(grep -om1 'localhost:[0-9]*' \(proxyEnvPath) | head -1 | cut -d: -f2)
+      if [ -n "$_aikp" ] && /usr/bin/nc -z -G 1 127.0.0.1 "$_aikp" >/dev/null 2>&1; then
+        source \(proxyEnvPath)
       else
-        rm -f ~/.aikeychain_proxy
+        rm -f \(proxyEnvPath)
       fi
       unset _aikp
     fi
     """
+    }
+
+    private static let zshrcSourceLine = proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy")
 
     private static var zshrcPath: String {
         NSHomeDirectory() + "/.zshrc"

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -6,9 +6,64 @@ import Testing
 @Suite("SetupManager Tests", .serialized)
 struct SetupManagerTests {
 
-    /// テスト用の一時ファイルで検証するためのヘルパー
-    /// 注意: SetupManager は直接 ~/.zshrc を操作するため、
-    /// ここでは生成されるコンフィグブロックの内容を検証する
+    @Test("configure migrates a stale managed block")
+    func configureMigratesStaleManagedBlock() throws {
+        let path = temporaryZshrcPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let oldContent = """
+        export EDITOR=vim
+
+        # >>> AI KeyChain >>>
+        if [ -n "$_aikp" ] && (echo >/dev/tcp/127.0.0.1/$_aikp) 2>/dev/null; then
+          source ~/.aikeychain_proxy
+        fi
+        # <<< AI KeyChain <<<
+
+        alias k=kubectl
+        """
+        try oldContent.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(result.contains("/usr/bin/nc -z"))
+        #expect(!result.contains("/dev/tcp"))
+        #expect(result.contains("export EDITOR=vim"))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(result.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
+    }
+
+    @Test("configure is idempotent when managed block is current")
+    func configureIsIdempotentWhenCurrent() throws {
+        let path = temporaryZshrcPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let userLine = "export EDITOR=vim\n"
+        try userLine.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+        let first = try String(contentsOfFile: path, encoding: .utf8)
+        try SetupManager.configure(zshrcPath: path)
+        let second = try String(contentsOfFile: path, encoding: .utf8)
+
+        #expect(second == first)
+        #expect(second.contains("export EDITOR=vim"))
+        #expect(second.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
+    }
+
+    @Test("configure adds current managed block to a fresh zshrc")
+    func configureAddsCurrentBlockToFreshZshrc() throws {
+        let path = temporaryZshrcPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let userLine = "alias k=kubectl\n"
+        try userLine.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(result.contains("/usr/bin/nc -z"))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(result.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
+    }
 
     @Test("Config block contains BASE_URL for all supported services")
     func configBlockContent() {
@@ -180,6 +235,10 @@ struct SetupManagerTests {
 
     private func temporaryProxyEnvPath() -> String {
         NSTemporaryDirectory() + "aikeychain_proxy_zsh_test_\(UUID().uuidString)"
+    }
+
+    private func temporaryZshrcPath() -> String {
+        NSTemporaryDirectory() + "aikeychain_zshrc_test_\(UUID().uuidString)"
     }
 
     private func writeProxyEnvFile(at path: String, port: UInt16) throws {

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import Testing
 @testable import AIkeychain
 
@@ -141,5 +142,104 @@ struct SetupManagerTests {
         // deactivate → ファイル削除 → inactive
         SetupManager.deactivateProxy()
         #expect(!SetupManager.isProxyActive())
+    }
+
+    @Test("zsh proxy hook keeps live config and sources it")
+    func zshProxyHookLive() throws {
+        let listener = try makeListeningSocket()
+        defer { close(listener.fd) }
+
+        let path = temporaryProxyEnvPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try writeProxyEnvFile(at: path, port: listener.port)
+
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: path)
+        let result = try runZsh("\(snippet)\nprintf '%s\\n' \"$OPENAI_BASE_URL\"")
+
+        #expect(result.status == 0, "zsh failed: \(result.stderr)")
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.stdout.contains("http://localhost:\(listener.port)"))
+    }
+
+    @Test("zsh proxy hook deletes config for closed port")
+    func zshProxyHookClosed() throws {
+        let reserved = try makeListeningSocket()
+        let port = reserved.port
+        close(reserved.fd)
+
+        let path = temporaryProxyEnvPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try writeProxyEnvFile(at: path, port: port)
+
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: path)
+        let result = try runZsh(snippet)
+
+        #expect(result.status == 0, "zsh failed: \(result.stderr)")
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    private func temporaryProxyEnvPath() -> String {
+        NSTemporaryDirectory() + "aikeychain_proxy_zsh_test_\(UUID().uuidString)"
+    }
+
+    private func writeProxyEnvFile(at path: String, port: UInt16) throws {
+        let content = """
+        export OPENAI_BASE_URL=http://localhost:\(port)
+        export AIKEYCHAIN_SESSION_TOKEN=tok
+        """
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    private func makeListeningSocket() throws -> (fd: Int32, port: UInt16) {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw POSIXError(.EIO) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, listen(fd, 1) == 0 else {
+            let error = POSIXErrorCode(rawValue: errno) ?? .EIO
+            close(fd)
+            throw POSIXError(error)
+        }
+
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        guard nameResult == 0 else {
+            let error = POSIXErrorCode(rawValue: errno) ?? .EIO
+            close(fd)
+            throw POSIXError(error)
+        }
+
+        return (fd, UInt16(bigEndian: address.sin_port))
+    }
+
+    private func runZsh(_ command: String) throws -> (status: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", command]
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, stdoutText, stderrText)
     }
 }

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -160,7 +160,7 @@ export AIKEYCHAIN_SESSION_TOKEN=<UUID>
 ```bash
 if [ -f ~/.aikeychain_proxy ]; then
     _aikp=$(grep -om1 'localhost:[0-9]*' ~/.aikeychain_proxy | head -1 | cut -d: -f2)
-    if [ -n "$_aikp" ] && (echo >/dev/tcp/127.0.0.1/$_aikp) 2>/dev/null; then
+    if [ -n "$_aikp" ] && /usr/bin/nc -z -G 1 127.0.0.1 "$_aikp" >/dev/null 2>&1; then
         source ~/.aikeychain_proxy
     else
         rm -f ~/.aikeychain_proxy  # プロキシ未稼働なら設定を削除


### PR DESCRIPTION
Closes #142

## 背景
gpt-5.6-sol の全体レビューで発見。Proxy モードの `.zshrc` readiness probe が bash 専用 `/dev/tcp` を使い、**zsh（macOS デフォルトシェル）で常に失敗** → 稼働中の proxy を dead 判定し `~/.aikeychain_proxy` を毎回削除、BASE_URL/token が一切 source されない。**Red 実機再現済み**（live listener でも設定削除、エビデンス添付）。

## 変更
- probe を `/usr/bin/nc -z -G 1 127.0.0.1 "$_aikp"` に置換（絶対パスで #117 の PATH ハードニングと整合）。他挙動は不変
- `zshrcSourceLine` を `proxySourceSnippet(proxyEnvPath:)` にリファクタし任意パスでレンダリング可能に（実 `.zshrc` 出力は従来と byte 同一）
- **既存ユーザー移行**（敵対的レビュー BLOCKER 対応）: `configure()` はマーカー既存時に早期 return し旧 probe を残していた → 現行ブロックと不一致なら in-place で置換（#131 と同様の移行）。冪等
- `isConfigured/hasLegacyFormat/configure/unconfigure` に `zshrcPath` 明示版を追加し実 `~/.zshrc` を触らずテスト可能に（無引数版は従来動作のまま委譲）
- `docs/design/security.md` の probe 例を新形式へ同期

## テスト（swift test 144/144 pass）
実 `/bin/zsh` でスニペットを実行する回帰テスト + 移行テスト:
- `zsh proxy hook keeps live config and sources it` — live listener → source され保持
- `zsh proxy hook deletes config for closed port` — closed → 削除（stale クリーンアップ維持）
- `configure migrates a stale managed block` — 旧 /dev/tcp ブロックが nc へ移行、周辺ユーザー行保持、マーカー重複なし
- `configure is idempotent when managed block is current` — 現行なら no-op
- `configure adds current managed block to a fresh zshrc`

## レビュー
実装 = Codex (gpt-5.6-sol) / 設計・敵対的レビュー・検証 = Claude (Fable 5)。敵対的レビューで案1(nc) vs 案2(ztcp) を検討し **nc 維持**（ztcp も real connection は避けられず module 依存・$REPLY 汚染が増える）。

### スコープ外（follow-up 予定・別 issue）
敵対的レビューが挙げた以下は本 PR のスコープ外（probe 修正に集中し regression を避けるため）:
- probe が「任意の TCP listener」を信用（正しい proxy 同定なし）
- `activateProxy` が listener `.ready` 前に設定ファイルを publish する起動レース
- port 文字列の弱いバリデーション（`localhost:123junk`）

## エビデンス
[📎 issue142-red-devtcp.log](https://github.com/aieo-product/AIkeychain/blob/evidence/evidence/issue-142/issue142-red-devtcp.log?raw=true)（Red: 修正前が live proxy を削除）
[📎 issue142-green-summary.log](https://github.com/aieo-product/AIkeychain/blob/evidence/evidence/issue-142/issue142-green-summary.log?raw=true)（Green: 5 テスト + 144/144）

🤖 Generated with [Claude Code](https://claude.com/claude-code)