### PR TITLE
fix(setup): unconfigure() の dangling BEGIN 切り詰めを防止（データ損失） (#146)

### DIFF
--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -140,6 +140,17 @@ enum SetupManager {
     private static let markerBegin = "# >>> AI KeyChain >>>"
     private static let markerEnd   = "# <<< AI KeyChain <<<"
 
+    enum SetupError: LocalizedError, Equatable {
+        case malformedMarkers
+
+        var errorDescription: String? {
+            switch self {
+            case .malformedMarkers:
+                return "AI KeyChain の .zshrc マーカー構造が壊れています。ファイルは変更せず、バックアップを作成しました。"
+            }
+        }
+    }
+
     /// .zshrc に AI KeyChain ブロックが設定済みか確認
     static func isConfigured() -> Bool {
         isConfigured(zshrcPath: zshrcPath)
@@ -266,7 +277,8 @@ enum SetupManager {
         return lookup(["find-generic-password", "-s", account, "-w"])
     }
 
-    /// .zshrc から AI KeyChain 管理ブロック全体を削除（マーカー間 + レガシー行）
+    /// .zshrc から AI KeyChain 管理ブロック全体を削除（マーカー間 + レガシー行）。
+    /// マーカー構造が壊れている場合は 0600 のバックアップだけを作り、元ファイルを変更せず throw する。
     static func unconfigure() throws {
         try unconfigure(zshrcPath: zshrcPath)
     }
@@ -277,11 +289,11 @@ enum SetupManager {
         let content = try String(contentsOfFile: zshrcPath, encoding: .utf8)
         let lines = content.components(separatedBy: "\n")
 
-        var markerStructureIsWellFormed = true
         var hasOpenBlock = false
+        var markerStructureIsWellFormed = true
 
         for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed == markerBegin {
                 if hasOpenBlock {
                     markerStructureIsWellFormed = false
@@ -299,27 +311,29 @@ enum SetupManager {
             markerStructureIsWellFormed = false
         }
 
-        // 書き換え前の内容を退避する
+        // 変更またはエラーを返す前に、秘密情報を含み得る元の内容を 0600 で退避する。
         let backupPath = zshrcPath + ".aikeychain.bak"
-        try content.write(toFile: backupPath, atomically: true, encoding: .utf8)
+        try writeProxyEnvFile(at: backupPath, content: content)
+
+        // 壊れたブロックを部分的に削除すると shell 構文まで破壊し得るため、元ファイルは触らない。
+        guard markerStructureIsWellFormed else {
+            throw SetupError.malformedMarkers
+        }
 
         var result: [String] = []
         var inBlock = false
 
         for line in lines {
-            if line.trimmingCharacters(in: .whitespaces) == markerBegin {
-                if markerStructureIsWellFormed {
-                    inBlock = true
-                }
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == markerBegin {
+                inBlock = true
                 continue
             }
-            if line.trimmingCharacters(in: .whitespaces) == markerEnd {
-                if markerStructureIsWellFormed {
-                    inBlock = false
-                }
+            if trimmed == markerEnd {
+                inBlock = false
                 continue
             }
-            if !markerStructureIsWellFormed || !inBlock {
+            if !inBlock {
                 // レガシー形式のフォールバック削除
                 if line.contains(".aikeychain_proxy") || line.contains("AI KeyChain — proxy env") {
                     continue

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -277,19 +277,49 @@ enum SetupManager {
         let content = try String(contentsOfFile: zshrcPath, encoding: .utf8)
         let lines = content.components(separatedBy: "\n")
 
+        var markerStructureIsWellFormed = true
+        var hasOpenBlock = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == markerBegin {
+                if hasOpenBlock {
+                    markerStructureIsWellFormed = false
+                }
+                hasOpenBlock = true
+            } else if trimmed == markerEnd {
+                if !hasOpenBlock {
+                    markerStructureIsWellFormed = false
+                }
+                hasOpenBlock = false
+            }
+        }
+
+        if hasOpenBlock {
+            markerStructureIsWellFormed = false
+        }
+
+        // 書き換え前の内容を退避する
+        let backupPath = zshrcPath + ".aikeychain.bak"
+        try content.write(toFile: backupPath, atomically: true, encoding: .utf8)
+
         var result: [String] = []
         var inBlock = false
 
         for line in lines {
             if line.trimmingCharacters(in: .whitespaces) == markerBegin {
-                inBlock = true
+                if markerStructureIsWellFormed {
+                    inBlock = true
+                }
                 continue
             }
             if line.trimmingCharacters(in: .whitespaces) == markerEnd {
-                inBlock = false
+                if markerStructureIsWellFormed {
+                    inBlock = false
+                }
                 continue
             }
-            if !inBlock {
+            if !markerStructureIsWellFormed || !inBlock {
                 // レガシー形式のフォールバック削除
                 if line.contains(".aikeychain_proxy") || line.contains("AI KeyChain — proxy env") {
                     continue

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -284,10 +284,15 @@ enum SetupManager {
     }
 
     static func unconfigure(zshrcPath: String) throws {
-        guard isConfigured(zshrcPath: zshrcPath) else { return }
-
-        let content = try String(contentsOfFile: zshrcPath, encoding: .utf8)
+        guard let content = try? String(contentsOfFile: zshrcPath, encoding: .utf8) else { return }
         let lines = content.components(separatedBy: "\n")
+        let hasManagedMarker = lines.contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed == markerBegin || trimmed == markerEnd
+        }
+        let hasLegacyContent = content.contains(".aikeychain_proxy")
+            || content.contains("AI KeyChain — proxy env")
+        guard hasManagedMarker || hasLegacyContent else { return }
 
         var hasOpenBlock = false
         var markerStructureIsWellFormed = true

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -37,8 +37,41 @@ struct SetupManagerTests {
         #expect(!result.contains(".aikeychain_proxy"))
     }
 
-    @Test("unconfigure preserves user lines after a dangling BEGIN")
-    func unconfigurePreservesUserLinesAfterDanglingBegin() throws {
+    @Test("unconfigure fails safely for a dangling BEGIN around the current hook")
+    func unconfigureFailsSafelyForDanglingCurrentHook() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        let original = """
+        export PATH="$HOME/bin:$PATH"
+
+        # >>> AI KeyChain >>>
+        \(SetupManager.proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy"))
+
+        export OPENAI_BASE_URL=https://user.example
+        alias k=kubectl
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+        let originalData = try Data(contentsOf: URL(fileURLWithPath: path))
+
+        #expect(throws: SetupManager.SetupError.malformedMarkers) {
+            try SetupManager.unconfigure(zshrcPath: path)
+        }
+
+        let resultData = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(resultData == originalData)
+        #expect(try zshSyntaxIsValid(at: path))
+
+        #expect(FileManager.default.fileExists(atPath: backupPath))
+        let backupData = try Data(contentsOf: URL(fileURLWithPath: backupPath))
+        #expect(backupData == originalData)
+    }
+
+    @Test("unconfigure leaves a simple dangling BEGIN byte-identical")
+    func unconfigureLeavesSimpleDanglingBeginUnchanged() throws {
         let path = temporaryZshrcPath()
         let backupPath = path + ".aikeychain.bak"
         defer {
@@ -53,19 +86,21 @@ struct SetupManagerTests {
         source ~/.secrets
         """
         try original.write(toFile: path, atomically: true, encoding: .utf8)
+        let originalData = try Data(contentsOf: URL(fileURLWithPath: path))
 
-        try SetupManager.unconfigure(zshrcPath: path)
+        #expect(throws: SetupManager.SetupError.malformedMarkers) {
+            try SetupManager.unconfigure(zshrcPath: path)
+        }
 
-        let result = try String(contentsOfFile: path, encoding: .utf8)
-        #expect(result.contains("export PATH="))
-        #expect(result.contains("export EDITOR=vim"))
-        #expect(result.contains("alias k=kubectl"))
-        #expect(result.contains("source ~/.secrets"))
-        #expect(!result.contains("# >>> AI KeyChain >>>"))
+        let resultData = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(resultData == originalData)
+        #expect(FileManager.default.fileExists(atPath: backupPath))
+        let backupData = try Data(contentsOf: URL(fileURLWithPath: backupPath))
+        #expect(backupData == originalData)
     }
 
-    @Test("unconfigure backs up original content for a malformed block")
-    func unconfigureBacksUpOriginalContentForMalformedBlock() throws {
+    @Test("unconfigure backup has 0600 permissions")
+    func unconfigureBackupHasPrivatePermissions() throws {
         let path = temporaryZshrcPath()
         let backupPath = path + ".aikeychain.bak"
         defer {
@@ -73,17 +108,45 @@ struct SetupManagerTests {
             try? FileManager.default.removeItem(atPath: backupPath)
         }
         let original = """
-        export PATH="$HOME/bin:$PATH"
         # >>> AI KeyChain >>>
-        export EDITOR=vim
+        source ~/.aikeychain_proxy
+        # <<< AI KeyChain <<<
         """
         try original.write(toFile: path, atomically: true, encoding: .utf8)
 
         try SetupManager.unconfigure(zshrcPath: path)
 
-        #expect(FileManager.default.fileExists(atPath: backupPath))
-        let backup = try String(contentsOfFile: backupPath, encoding: .utf8)
-        #expect(backup == original)
+        let attributes = try FileManager.default.attributesOfItem(atPath: backupPath)
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
+        #expect(permissions == 0o600)
+    }
+
+    @Test("unconfigure recognizes and removes a well-formed CRLF block")
+    func unconfigureRemovesWellFormedCRLFBlock() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        let original = [
+            "export PATH=\"$HOME/bin:$PATH\"",
+            "# >>> AI KeyChain >>>",
+            "source ~/.aikeychain_proxy",
+            "# <<< AI KeyChain <<<",
+            "alias k=kubectl",
+            "",
+        ].joined(separator: "\r\n")
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.unconfigure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(result.contains("export PATH="))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(!result.contains("# >>> AI KeyChain >>>"))
+        #expect(!result.contains("# <<< AI KeyChain <<<"))
+        #expect(!result.contains(".aikeychain_proxy"))
     }
 
     @Test("configure migrates a stale managed block")
@@ -323,6 +386,17 @@ struct SetupManagerTests {
 
     private func temporaryZshrcPath() -> String {
         NSTemporaryDirectory() + "aikeychain_zshrc_test_\(UUID().uuidString)"
+    }
+
+    private func zshSyntaxIsValid(at path: String) throws -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-n", path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
     }
 
     private func writeProxyEnvFile(at path: String, port: UInt16) throws {

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -99,6 +99,37 @@ struct SetupManagerTests {
         #expect(backupData == originalData)
     }
 
+    @Test("unconfigure fails safely for a lone END marker")
+    func unconfigureFailsSafelyForLoneEndMarker() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        let original = """
+        export PATH="$HOME/bin:$PATH"
+        # <<< AI KeyChain <<<
+        export EDITOR=vim
+        alias k=kubectl
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+        let originalData = try Data(contentsOf: URL(fileURLWithPath: path))
+
+        #expect(throws: SetupManager.SetupError.malformedMarkers) {
+            try SetupManager.unconfigure(zshrcPath: path)
+        }
+
+        let resultData = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(resultData == originalData)
+        #expect(FileManager.default.fileExists(atPath: backupPath))
+        let backupData = try Data(contentsOf: URL(fileURLWithPath: backupPath))
+        #expect(backupData == originalData)
+        let attributes = try FileManager.default.attributesOfItem(atPath: backupPath)
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
+        #expect(permissions == 0o600)
+    }
+
     @Test("unconfigure backup has 0600 permissions")
     func unconfigureBackupHasPrivatePermissions() throws {
         let path = temporaryZshrcPath()

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -6,10 +6,94 @@ import Testing
 @Suite("SetupManager Tests", .serialized)
 struct SetupManagerTests {
 
+    @Test("unconfigure removes a well-formed block and preserves user lines")
+    func unconfigureRemovesWellFormedBlockAndPreservesUserLines() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        let original = """
+        export PATH="$HOME/bin:$PATH"
+
+        # >>> AI KeyChain >>>
+        source ~/.aikeychain_proxy
+        # <<< AI KeyChain <<<
+
+        export EDITOR=vim
+        alias k=kubectl
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.unconfigure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(result.contains("export PATH="))
+        #expect(result.contains("export EDITOR=vim"))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(!result.contains("# >>> AI KeyChain >>>"))
+        #expect(!result.contains("# <<< AI KeyChain <<<"))
+        #expect(!result.contains(".aikeychain_proxy"))
+    }
+
+    @Test("unconfigure preserves user lines after a dangling BEGIN")
+    func unconfigurePreservesUserLinesAfterDanglingBegin() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        let original = """
+        export PATH="$HOME/bin:$PATH"
+        # >>> AI KeyChain >>>
+        export EDITOR=vim
+        alias k=kubectl
+        source ~/.secrets
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.unconfigure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(result.contains("export PATH="))
+        #expect(result.contains("export EDITOR=vim"))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(result.contains("source ~/.secrets"))
+        #expect(!result.contains("# >>> AI KeyChain >>>"))
+    }
+
+    @Test("unconfigure backs up original content for a malformed block")
+    func unconfigureBacksUpOriginalContentForMalformedBlock() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        let original = """
+        export PATH="$HOME/bin:$PATH"
+        # >>> AI KeyChain >>>
+        export EDITOR=vim
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.unconfigure(zshrcPath: path)
+
+        #expect(FileManager.default.fileExists(atPath: backupPath))
+        let backup = try String(contentsOfFile: backupPath, encoding: .utf8)
+        #expect(backup == original)
+    }
+
     @Test("configure migrates a stale managed block")
     func configureMigratesStaleManagedBlock() throws {
         let path = temporaryZshrcPath()
-        defer { try? FileManager.default.removeItem(atPath: path) }
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
         let oldContent = """
         export EDITOR=vim
 


### PR DESCRIPTION
Closes #146

> ⚠️ **base = `fix/issue-142-zsh-proxy-probe`（PR #143）**。#146 は #142 が追加した `unconfigure(zshrcPath:)` を対象とするため #143 に積んでいます。**#143 マージ後に base を main へ変更**してください（差分は #146 分のみ表示されます）。

## 背景
gpt-5.6-sol の全体レビューで発見。`SetupManager.unconfigure()` は END マーカー欠落（dangling BEGIN）時に `inBlock` が EOF まで true となり、**BEGIN 以降のユーザー行（PATH/alias/`source ~/.secrets` 等）を全削除**していた（データ損失）。再現確認済み。

## 変更（敵対的レビュー3ラウンドで到達した安全設計）
- **malformed マーカーは非破壊 fail-safe**: dangling BEGIN / lone END / ネスト / END 先行 等を検出したら**ファイルを一切変更せず** `SetupError.malformedMarkers` を throw（部分書換で shell 構文を壊す事故を回避）
- **well-formed は従来どおりブロック削除**（#142 の移行を維持）
- **CRLF 対応**（`.whitespacesAndNewlines` で trim）
- **バックアップを 0600 で退避**（`writeProxyEnvFile` 経由、任意ユーザー秘密を含み得る）
- guard を「BEGIN/END/legacy いずれか」に拡張し END 単独も malformed 契約でカバー

## テスト（swift test 150/150 pass）
- well-formed ブロック削除でユーザー行保持
- dangling BEGIN（現行 nc フック / 単純）→ throw + **byte-identical**（無変更）+ backup
- lone END → throw + 無変更 + backup
- backup が 0600
- CRLF well-formed ブロックの認識・削除
- #142 移行・冪等テストが引き続き green

## レビュー
実装 = Codex (gpt-5.6-sol) / 設計・**敵対的レビュー3R**・検証 = Claude (Fable 5)。R1 で私の初期設計（malformed 部分削除）が壊れた shell 構文を生む HIGH を検出 → 非破壊 throw に再設計 → R2 で END-only/CRLF/0600 → R3 **SHIP AS-IS**。

### スコープ外（follow-up）
- **#148**: configure() が current ブロック存在時に重複/malformed 他ブロックを検証しない（冪等性の穴・**データ損失なし**）

## エビデンス
[📎 issue146-green-summary.log](https://github.com/aieo-product/AIkeychain/blob/evidence/evidence/issue-146/issue146-green-summary.log?raw=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)