### PR TITLE
fix(security): 2段ルックアップを fail-closed に（not-found 以外で manual へ落とさない） (#147)

### DIFF
--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -1,7 +1,7 @@
 // Thin wrapper around the macOS `security` CLI.
 // Lookup order matches scripts/akc (issue #91):
 //   1. service="com.aieo.aikeychain" account="<KEY>"  (AI KeyChain GUI store)
-//   2. service="<KEY>" with NO account               (manually-registered keys)
+//   2. service="<KEY>" with NO account               (only when GUI exits 44/not-found)
 // Manual keys are looked up by service only because their `acct` attribute is
 // not consistent ($USER or the service name) — pinning -a can grab a stale
 // duplicate entry and return an invalid value.
@@ -72,16 +72,16 @@ function stripTrailingNewline(s) {
 
 /** Resolve a key to its secret value, or null if not found. */
 export async function resolveKey(name) {
-  let r = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
-  if (r.ok) {
-    const value = stripTrailingNewline(r.stdout);
-    if (value) return value;
-  } else if (r.code !== 44) {
-    return null;
+  const gui = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
+  if (gui.ok) {
+    const value = stripTrailingNewline(gui.stdout);
+    return value || null;
   }
-  r = await security(['find-generic-password', '-s', name, '-w']);
-  if (r.ok) {
-    const value = stripTrailingNewline(r.stdout);
+  if (gui.code !== 44) return null;
+
+  const manual = await security(['find-generic-password', '-s', name, '-w']);
+  if (manual.ok) {
+    const value = stripTrailingNewline(manual.stdout);
     if (value) return value;
   }
   return null;

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -55,9 +55,14 @@ async function security(args) {
     const { stdout, stderr } = await pExecFile(SECURITY_BIN, args, {
       maxBuffer: 16 * 1024 * 1024,
     });
-    return { ok: true, stdout, stderr };
+    return { ok: true, code: 0, stdout, stderr };
   } catch (err) {
-    return { ok: false, stdout: err.stdout ?? '', stderr: err.stderr ?? String(err) };
+    return {
+      ok: false,
+      code: err.code ?? null,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? String(err),
+    };
   }
 }
 
@@ -71,6 +76,8 @@ export async function resolveKey(name) {
   if (r.ok) {
     const value = stripTrailingNewline(r.stdout);
     if (value) return value;
+  } else if (r.code !== 44) {
+    return null;
   }
   r = await security(['find-generic-password', '-s', name, '-w']);
   if (r.ok) {

--- a/cli/test/resolve-keychain-bash.test.js
+++ b/cli/test/resolve-keychain-bash.test.js
@@ -30,6 +30,7 @@ if [ "$svc" = "com.aieo.aikeychain" ]; then
     gui_51) exit 51 ;;
     gui_empty) exit 0 ;;
     gui_44_manual) exit 44 ;;
+    gui_44_manual_empty) exit 44 ;;
     manual_output_error) exit 44 ;;
     gui_value) printf '%s\\n' gui-value; exit 0 ;;
   esac
@@ -38,6 +39,7 @@ fi
 printf '%s\\n' manual >> "$CALLS_PATH"
 case "$SCENARIO" in
   gui_44_manual) printf '%s\\n' manual-value; exit 0 ;;
+  gui_44_manual_empty) exit 0 ;;
   manual_output_error) printf '%s\\n' rejected-value; exit 52 ;;
   *) printf '%s\\n' manual-must-not-be-used; exit 0 ;;
 esac
@@ -113,7 +115,14 @@ test('scripts/akc resolve_keychain fails closed on successful empty GUI value', 
 
 test('scripts/akc resolve_keychain falls back to manual only on GUI exit 44', async () => {
   await assertScenario('gui_44_manual', {
-    result: { status: 0, stdout: 'manual-value\n', stderr: '' },
+    result: { status: 0, stdout: 'manual-value', stderr: '' },
+    calls: 'gui\nmanual\n',
+  });
+});
+
+test('scripts/akc resolve_keychain returns nonzero on GUI exit 44 and successful empty manual value', async () => {
+  await assertScenario('gui_44_manual_empty', {
+    result: { status: 1, stdout: '', stderr: '' },
     calls: 'gui\nmanual\n',
   });
 });

--- a/cli/test/resolve-keychain-bash.test.js
+++ b/cli/test/resolve-keychain-bash.test.js
@@ -1,0 +1,140 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tempDir;
+let harnessPath;
+let cmdHarnessPath;
+let securityPath;
+let envPath;
+let callsPath;
+
+const SECURITY_STUB = `#!/bin/bash
+svc=""; acct=""
+shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s) svc="$2"; shift 2 ;;
+    -a) acct="$2"; shift 2 ;;
+    -w) shift ;;
+    *) shift ;;
+  esac
+done
+
+if [ "$svc" = "com.aieo.aikeychain" ]; then
+  printf '%s\\n' gui >> "$CALLS_PATH"
+  case "$SCENARIO" in
+    gui_51) exit 51 ;;
+    gui_empty) exit 0 ;;
+    gui_44_manual) exit 44 ;;
+    manual_output_error) exit 44 ;;
+    gui_value) printf '%s\\n' gui-value; exit 0 ;;
+  esac
+fi
+
+printf '%s\\n' manual >> "$CALLS_PATH"
+case "$SCENARIO" in
+  gui_44_manual) printf '%s\\n' manual-value; exit 0 ;;
+  manual_output_error) printf '%s\\n' rejected-value; exit 52 ;;
+  *) printf '%s\\n' manual-must-not-be-used; exit 0 ;;
+esac
+`;
+
+const ENV_STUB = `#!/bin/bash
+printf '%s\\n' 'TEST_REF=keychain://TEST_KEY'
+`;
+
+before(async () => {
+  const script = await readFile(new URL('../../scripts/akc', import.meta.url), 'utf8');
+  const start = script.indexOf('resolve_keychain() {');
+  const end = script.indexOf('\n}\n\nmask_value()', start);
+  assert.notEqual(start, -1, 'resolve_keychain function start must exist');
+  assert.notEqual(end, -1, 'resolve_keychain function end must exist');
+  const resolver = script.slice(start, end + 2);
+  const functionsEnd = script.indexOf('\n\n# Main dispatch', start);
+  assert.notEqual(functionsEnd, -1, 'cmd_run function end must exist');
+  const functions = script.slice(start, functionsEnd);
+
+  tempDir = await mkdtemp(join(tmpdir(), 'akc-bash-resolver-'));
+  harnessPath = join(tempDir, 'harness.sh');
+  cmdHarnessPath = join(tempDir, 'cmd-harness.sh');
+  securityPath = join(tempDir, 'security');
+  envPath = join(tempDir, 'env');
+  callsPath = join(tempDir, 'calls');
+  await writeFile(
+    harnessPath,
+    `#!/bin/bash\nset -uo pipefail\nSECURITY_BIN="$1"\nCALLS_PATH="$2"\nSCENARIO="$3"\nexport CALLS_PATH SCENARIO\n${resolver}\nresolve_keychain TEST_KEY\n`
+  );
+  await writeFile(
+    cmdHarnessPath,
+    `#!/bin/bash\nset -euo pipefail\nSECURITY_BIN="$1"\nCALLS_PATH="$2"\nSCENARIO="$3"\nENV_BIN="$4"\nexport CALLS_PATH SCENARIO\n${functions}\ncmd_run --dry-run\n`
+  );
+  await writeFile(securityPath, SECURITY_STUB);
+  await writeFile(envPath, ENV_STUB);
+  await chmod(harnessPath, 0o755);
+  await chmod(cmdHarnessPath, 0o755);
+  await chmod(securityPath, 0o755);
+  await chmod(envPath, 0o755);
+});
+
+after(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function runResolver(scenario) {
+  const result = spawnSync('/bin/bash', [harnessPath, securityPath, callsPath, scenario], {
+    encoding: 'utf8',
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+async function assertScenario(scenario, expected) {
+  await writeFile(callsPath, '');
+  assert.deepEqual(runResolver(scenario), expected.result);
+  assert.equal(await readFile(callsPath, 'utf8'), expected.calls);
+}
+
+test('scripts/akc resolve_keychain fails closed on GUI exit 51', async () => {
+  await assertScenario('gui_51', {
+    result: { status: 51, stdout: '', stderr: '' },
+    calls: 'gui\n',
+  });
+});
+
+test('scripts/akc resolve_keychain fails closed on successful empty GUI value', async () => {
+  await assertScenario('gui_empty', {
+    result: { status: 1, stdout: '', stderr: '' },
+    calls: 'gui\n',
+  });
+});
+
+test('scripts/akc resolve_keychain falls back to manual only on GUI exit 44', async () => {
+  await assertScenario('gui_44_manual', {
+    result: { status: 0, stdout: 'manual-value\n', stderr: '' },
+    calls: 'gui\nmanual\n',
+  });
+});
+
+test('scripts/akc resolve_keychain returns a nonempty GUI value without manual fallback', async () => {
+  await assertScenario('gui_value', {
+    result: { status: 0, stdout: 'gui-value', stderr: '' },
+    calls: 'gui\n',
+  });
+});
+
+test('scripts/akc cmd_run rejects nonempty resolver output when its exit status is nonzero', async () => {
+  await writeFile(callsPath, '');
+  const result = spawnSync(
+    '/bin/bash',
+    [cmdHarnessPath, securityPath, callsPath, 'manual_output_error', envPath],
+    { encoding: 'utf8' }
+  );
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Resolved: 0, Failed: 1/);
+  assert.doesNotMatch(result.stdout, /rejected-value/);
+  assert.match(result.stderr, /TEST_REF .* not found in Keychain/);
+  assert.equal(await readFile(callsPath, 'utf8'), 'gui\nmanual\n');
+});

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -1,4 +1,4 @@
-import { after, before, test } from 'node:test';
+import { after, before, beforeEach, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -25,6 +25,7 @@ printf '%s|%s\\n' "$svc" "$acct" >> "$stub_dir/calls"
 if [ "$svc" = "com.aieo.aikeychain" ]; then
   case "$acct" in
     ERROR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
+    EMPTY_KEY) exit 0 ;;
     MISSING_KEY) exit 44 ;;
     GUI_KEY) printf '%s\\n' "gui-value"; exit 0 ;;
   esac
@@ -32,6 +33,7 @@ fi
 
 case "$svc" in
   ERROR_KEY) printf '%s\\n' "attacker-manual-value"; exit 0 ;;
+  EMPTY_KEY) printf '%s\\n' "manual-must-not-be-used"; exit 0 ;;
   MISSING_KEY) printf '%s\\n' "manual-value"; exit 0 ;;
 esac
 exit 44
@@ -47,6 +49,10 @@ before(async () => {
   ({ resolveKey } = await import('../src/keychain.js'));
 });
 
+beforeEach(async () => {
+  await writeFile(callsPath, '');
+});
+
 after(async () => {
   delete process.env.AIKEYCHAIN_SECURITY_BIN;
   await rm(stubDir, { recursive: true, force: true });
@@ -60,6 +66,12 @@ test('resolveKey fails closed on a non-44 GUI lookup error (#147)', async () => 
 
 test('resolveKey falls back to manual storage when GUI lookup exits 44', async () => {
   assert.equal(await resolveKey('MISSING_KEY'), 'manual-value');
+});
+
+test('resolveKey treats an empty successful GUI value as authoritative failure', async () => {
+  assert.equal(await resolveKey('EMPTY_KEY'), null);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain|EMPTY_KEY\n');
 });
 
 test('resolveKey returns the GUI storage value without manual fallback', async () => {

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -27,6 +27,7 @@ if [ "$svc" = "com.aieo.aikeychain" ]; then
     ERROR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
     EMPTY_KEY) exit 0 ;;
     MISSING_KEY) exit 44 ;;
+    MANUAL_EMPTY_KEY) exit 44 ;;
     GUI_KEY) printf '%s\\n' "gui-value"; exit 0 ;;
   esac
 fi
@@ -35,6 +36,7 @@ case "$svc" in
   ERROR_KEY) printf '%s\\n' "attacker-manual-value"; exit 0 ;;
   EMPTY_KEY) printf '%s\\n' "manual-must-not-be-used"; exit 0 ;;
   MISSING_KEY) printf '%s\\n' "manual-value"; exit 0 ;;
+  MANUAL_EMPTY_KEY) exit 0 ;;
 esac
 exit 44
 `;
@@ -66,6 +68,10 @@ test('resolveKey fails closed on a non-44 GUI lookup error (#147)', async () => 
 
 test('resolveKey falls back to manual storage when GUI lookup exits 44', async () => {
   assert.equal(await resolveKey('MISSING_KEY'), 'manual-value');
+});
+
+test('resolveKey returns null when GUI lookup exits 44 and manual value is empty', async () => {
+  assert.equal(await resolveKey('MANUAL_EMPTY_KEY'), null);
 });
 
 test('resolveKey treats an empty successful GUI value as authoritative failure', async () => {

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -1,0 +1,67 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let resolveKey;
+let stubDir;
+let callsPath;
+
+const STUB = `#!/bin/bash
+stub_dir="$(cd "$(dirname "$0")" && pwd)"
+svc=""; acct=""
+shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s) svc="$2"; shift 2 ;;
+    -a) acct="$2"; shift 2 ;;
+    -w) shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s|%s\\n' "$svc" "$acct" >> "$stub_dir/calls"
+
+if [ "$svc" = "com.aieo.aikeychain" ]; then
+  case "$acct" in
+    ERROR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
+    MISSING_KEY) exit 44 ;;
+    GUI_KEY) printf '%s\\n' "gui-value"; exit 0 ;;
+  esac
+fi
+
+case "$svc" in
+  ERROR_KEY) printf '%s\\n' "attacker-manual-value"; exit 0 ;;
+  MISSING_KEY) printf '%s\\n' "manual-value"; exit 0 ;;
+esac
+exit 44
+`;
+
+before(async () => {
+  stubDir = await mkdtemp(join(tmpdir(), 'akc-resolve-keychain-'));
+  const stubPath = join(stubDir, 'security');
+  callsPath = join(stubDir, 'calls');
+  await writeFile(stubPath, STUB);
+  await chmod(stubPath, 0o755);
+  process.env.AIKEYCHAIN_SECURITY_BIN = stubPath;
+  ({ resolveKey } = await import('../src/keychain.js'));
+});
+
+after(async () => {
+  delete process.env.AIKEYCHAIN_SECURITY_BIN;
+  await rm(stubDir, { recursive: true, force: true });
+});
+
+test('resolveKey fails closed on a non-44 GUI lookup error (#147)', async () => {
+  assert.equal(await resolveKey('ERROR_KEY'), null);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain|ERROR_KEY\n');
+});
+
+test('resolveKey falls back to manual storage when GUI lookup exits 44', async () => {
+  assert.equal(await resolveKey('MISSING_KEY'), 'manual-value');
+});
+
+test('resolveKey returns the GUI storage value without manual fallback', async () => {
+  assert.equal(await resolveKey('GUI_KEY'), 'gui-value');
+});

--- a/scripts/akc
+++ b/scripts/akc
@@ -56,9 +56,14 @@ USAGE
 resolve_keychain() {
     local key_name="$1"
     local value
+    local rc
 
-    value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null) \
-        && [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+    if value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null); then
+        [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+    else
+        rc=$?
+        [ "$rc" -eq 44 ] || return "$rc"
+    fi
 
     # 手動登録キーのフォールバック。-a はあえて指定しない: acct の値が
     # エントリごとに一定しないため、service 名のみで引く方が安定する (issue #91)

--- a/scripts/akc
+++ b/scripts/akc
@@ -68,7 +68,8 @@ resolve_keychain() {
 
     # 手動登録キーのフォールバック。-a はあえて指定しない: acct の値が
     # エントリごとに一定しないため、service 名のみで引く方が安定する (issue #91)
-    "$SECURITY_BIN" find-generic-password -s "$key_name" -w 2>/dev/null
+    value=$("$SECURITY_BIN" find-generic-password -s "$key_name" -w 2>/dev/null) && [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+    return 1
 }
 
 mask_value() {

--- a/scripts/akc
+++ b/scripts/akc
@@ -12,7 +12,7 @@
 #
 # Lookup order:
 #   1. service="com.aieo.aikeychain" account="<KEY_NAME>"  (AI KeyChain GUI store)
-#   2. service="<KEY_NAME>"  (manually-registered keys; account 非指定)
+#   2. service="<KEY_NAME>"  (GUI が exit 44/not-found の場合のみ; account 非指定)
 #      -a は付けない: 手動登録キーは acct の値が一定しないため、
 #      service 名のみで引く方が安定する (issue #91)
 
@@ -60,6 +60,7 @@ resolve_keychain() {
 
     if value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null); then
         [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+        return 1
     else
         rc=$?
         [ "$rc" -eq 44 ] || return "$rc"
@@ -122,10 +123,14 @@ cmd_run() {
                     *[!A-Za-z0-9_]* | "" | [0-9]* ) continue ;;
                 esac
                 local key_name="${var_value#keychain://}"
-                local resolved
-                resolved=$(resolve_keychain "$key_name") || true
+                local resolved rk_rc
+                if resolved=$(resolve_keychain "$key_name"); then
+                    rk_rc=0
+                else
+                    rk_rc=$?
+                fi
 
-                if [ -n "$resolved" ]; then
+                if [ "$rk_rc" -eq 0 ] && [ -n "$resolved" ]; then
                     resolved_count=$((resolved_count + 1))
                     if $dry_run; then
                         local masked


### PR DESCRIPTION
Closes #147

## 背景
gpt-5.6-sol の全体レビューで発見。CLI/bash の 2段キーチェーンルックアップが、GUI ストアのルックアップが **not-found(exit 44) 以外のエラー**（キーチェーンロック / ACL 拒否 / キャンセル / 実行失敗）でも manual ストアへ fallback していた。valid な GUI キーが読めない状況で攻撃者が仕込んだ / 古い manual 同名キーがあると、黙って誤った値を注入し得た（same-uid 脅威モデル・#117 と同じ前提）。**再現確認済み**（GUI exit 51 + manual 値 → 攻撃者値が返る）。

## 変更（fail-closed モデル）
「**GUI ストアが応答(exit 0)したらその答えが権威（値 or 空→失敗）。manual への fallback は GUI が not-found(exit 44) の時だけ。他エラーは fail-closed（null）**」

- `cli/src/keychain.js`: `security()` が exit code を返すよう拡張。`resolveKey` を上記モデルに
- `scripts/akc` `resolve_keychain()`: 同じモデルを bash で実装（GUI 空→return1、rc!=44→即return、manual 空→return1）。CLI と揃えドリフト防止（レビュー #24）
- `scripts/akc` `cmd_run`: resolver の rc を捕捉し **rc==0 かつ非空**の時だけ resolved 扱い

## テスト（cli 70/70 pass）
JS/bash 両方に committed テスト。6ケースで挙動一致を検証:

| Case | resolveKey | resolve_keychain |
|---|---|---|
| GUI value | value | value, rc0 |
| GUI success-empty | null | empty, rc1 |
| GUI non-44 error | null | rc(元) |
| GUI 44 + manual value | value | value, rc0 |
| GUI 44 + manual empty | null | empty, rc1 |
| GUI 44 + manual not-found | null | empty, rc1 |

## レビュー
実装 = Codex (gpt-5.6-sol) / 設計・**敵対的レビュー3R**・検証 = Claude (Fable 5)。R1 で success-empty の fallback(HIGH) + bash caller の rc 破棄(MEDIUM) → R2 で JS/bash manual-empty パリティ(LOW) → **SHIP AS-IS**（fail-open 経路なし確認）。

### スコープ外（follow-up）
- `keyExists()`（`akc check` / MCP）は値を返さない存在確認のため本 PR では不変。GUI エラー時に「manual に在る」と報告し得るが**事実として正しく値漏洩なし**（UX 整合のみ、別途検討）

## エビデンス
[📎 issue147-green-summary.log](https://github.com/aieo-product/AIkeychain/blob/evidence/evidence/issue-147/issue147-green-summary.log?raw=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)