### PR TITLE
fix(setup): configure() が重複/malformed マーカーブロックを正規化 (#148)

### DIFF
--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -209,6 +209,35 @@ enum SetupManager {
         return MarkerAnalysis(isWellFormed: isWellFormed, blockContents: blocks)
     }
 
+    /// well-formed なマーカーブロックだけを取り除き、ブロック外の行は一切変更せず残す。
+    /// unconfigure と異なりレガシー行（`.aikeychain_proxy` を含む行等）の削除は行わないため、
+    /// マーカー外にあるユーザー自身の設定を巻き添え削除しない（#148 / Codex #1）。
+    /// 呼び出し側は事前に isWellFormed == true を保証すること（malformed は unconfigure に委ねる）。
+    private static func removingMarkerBlocks(from content: String) -> String {
+        let lines = content.components(separatedBy: "\n")
+        var result: [String] = []
+        var inBlock = false
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == markerBegin {
+                inBlock = true
+                continue
+            }
+            if trimmed == markerEnd {
+                inBlock = false
+                continue
+            }
+            if !inBlock {
+                result.append(line)
+            }
+        }
+        var output = result.joined(separator: "\n")
+        while output.contains("\n\n\n") {
+            output = output.replacingOccurrences(of: "\n\n\n", with: "\n\n")
+        }
+        return output
+    }
+
     /// .zshrc にフックを追記（BEGIN/END マーカーで囲む）
     /// レガシー形式が存在する場合は先に削除してからマーカー形式で再追加
     static func configure() throws {
@@ -225,19 +254,29 @@ enum SetupManager {
         let analysis = analyzeMarkers(in: existing)
 
         // べき等: 構造が well-formed かつ「現行と同一のブロックがちょうど 1 つだけ」なら
-        // 何もしない。重複ブロック・古い内容・余分なマーカーは以下で整理し直す（#148）。
-        if analysis.isWellFormed && analysis.blockContents == [zshrcSourceLine] {
+        // 何もしない。CRLF 環境でも本文末尾の \r を無視して比較し、既に整合したブロックを
+        // 不必要に書き換えて末尾へ移動させない（#148 / Codex #3）。
+        let normalizedBlocks = analysis.blockContents.map {
+            $0.replacingOccurrences(of: "\r", with: "")
+        }
+        if analysis.isWellFormed && normalizedBlocks == [zshrcSourceLine] {
             return
         }
 
-        // マーカーが 1 つでも存在すれば unconfigure で一旦整理する。
-        // - well-formed（重複ブロック / 古い内容）→ 全ブロック除去してから 1 つだけ再追加
-        // - malformed（余分/ネストしたマーカー）→ unconfigure が backup + throw（#146 契約）
-        if existing.contains(markerBegin) || existing.contains(markerEnd) {
+        // マーカーの整理。
+        // - well-formed（重複ブロック / 古い内容）→ マーカーブロックだけ除去（ブロック外の
+        //   ユーザー行は保護）してから 1 つだけ再追加する。unconfigure を経由すると
+        //   ブロック外の `.aikeychain_proxy` 参照行まで消えるため使わない（#148 / Codex #1）。
+        // - malformed（余分/ネストしたマーカー）→ unconfigure が backup + throw（#146 契約）。
+        //   analyzeMarkers と unconfigure の well-formedness 判定は同一なので必ず throw する。
+        var content: String
+        if analysis.isWellFormed {
+            content = removingMarkerBlocks(from: existing)
+        } else {
             try unconfigure(zshrcPath: zshrcPath)
+            // 到達しない（malformed なので unconfigure が throw する）。防御的に中断する。
+            throw SetupError.malformedMarkers
         }
-
-        var content = (try? String(contentsOfFile: zshrcPath, encoding: .utf8)) ?? ""
 
         if !content.isEmpty && !content.hasSuffix("\n") {
             content += "\n"

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -212,6 +212,7 @@ enum SetupManager {
     /// well-formed なマーカーブロックだけを取り除き、ブロック外の行は一切変更せず残す。
     /// unconfigure と異なりレガシー行（`.aikeychain_proxy` を含む行等）の削除は行わないため、
     /// マーカー外にあるユーザー自身の設定を巻き添え削除しない（#148 / Codex #1）。
+    /// 空行の圧縮も行わない（heredoc 本文等、ユーザーの意図的な連続空行を壊さない / Codex #A）。
     /// 呼び出し側は事前に isWellFormed == true を保証すること（malformed は unconfigure に委ねる）。
     private static func removingMarkerBlocks(from content: String) -> String {
         let lines = content.components(separatedBy: "\n")
@@ -231,11 +232,15 @@ enum SetupManager {
                 result.append(line)
             }
         }
-        var output = result.joined(separator: "\n")
-        while output.contains("\n\n\n") {
-            output = output.replacingOccurrences(of: "\n\n\n", with: "\n\n")
-        }
-        return output
+        return result.joined(separator: "\n")
+    }
+
+    /// CRLF 環境向けに、各物理行の「行末」の CR だけを取り除いて LF 正規形にする。
+    /// 行の途中に混入した CR は残すため、壊れたブロックを現行ブロックと誤認しない（Codex #B）。
+    private static func normalizingLineEndings(_ s: String) -> String {
+        s.components(separatedBy: "\n")
+            .map { $0.hasSuffix("\r") ? String($0.dropLast()) : $0 }
+            .joined(separator: "\n")
     }
 
     /// .zshrc にフックを追記（BEGIN/END マーカーで囲む）
@@ -256,9 +261,7 @@ enum SetupManager {
         // べき等: 構造が well-formed かつ「現行と同一のブロックがちょうど 1 つだけ」なら
         // 何もしない。CRLF 環境でも本文末尾の \r を無視して比較し、既に整合したブロックを
         // 不必要に書き換えて末尾へ移動させない（#148 / Codex #3）。
-        let normalizedBlocks = analysis.blockContents.map {
-            $0.replacingOccurrences(of: "\r", with: "")
-        }
+        let normalizedBlocks = analysis.blockContents.map(normalizingLineEndings)
         if analysis.isWellFormed && normalizedBlocks == [zshrcSourceLine] {
             return
         }

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -169,6 +169,46 @@ enum SetupManager {
         return content.contains(".aikeychain_proxy") && !content.contains(markerBegin)
     }
 
+    /// マーカー構造の解析結果
+    private struct MarkerAnalysis {
+        /// BEGIN/END がネストなく過不足なく対応しているか（unconfigure と同一判定）
+        let isWellFormed: Bool
+        /// 各ブロックの BEGIN/END 間の内容（各行を "\n" で join、末尾改行なし）
+        let blockContents: [String]
+    }
+
+    /// .zshrc の内容から AI KeyChain マーカーブロックの構造を解析する。
+    /// well-formedness の判定は unconfigure(zshrcPath:) と同一ロジックに揃える
+    /// （isWellFormed == true ならその後 unconfigure が throw しないことを保証する）。
+    private static func analyzeMarkers(in content: String) -> MarkerAnalysis {
+        let lines = content.components(separatedBy: "\n")
+        var isWellFormed = true
+        var blocks: [String] = []
+        var current: [String] = []
+        var inBlock = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == markerBegin {
+                if inBlock { isWellFormed = false }   // ネストした BEGIN
+                inBlock = true
+                current = []
+            } else if trimmed == markerEnd {
+                if !inBlock {
+                    isWellFormed = false              // 対応する BEGIN のない END
+                } else {
+                    blocks.append(current.joined(separator: "\n"))
+                }
+                inBlock = false
+            } else if inBlock {
+                current.append(line)
+            }
+        }
+        if inBlock { isWellFormed = false }           // 閉じられていない BEGIN
+
+        return MarkerAnalysis(isWellFormed: isWellFormed, blockContents: blocks)
+    }
+
     /// .zshrc にフックを追記（BEGIN/END マーカーで囲む）
     /// レガシー形式が存在する場合は先に削除してからマーカー形式で再追加
     static func configure() throws {
@@ -181,13 +221,19 @@ enum SetupManager {
             try unconfigure(zshrcPath: zshrcPath)
         }
 
-        // 現行のマーカー形式が既に存在する場合はスキップ。古い形式は置き換える。
-        if let content = try? String(contentsOfFile: zshrcPath, encoding: .utf8),
-           content.contains(markerBegin) {
-            let currentBlock = "\(markerBegin)\n\(zshrcSourceLine)\n\(markerEnd)"
-            if content.contains(currentBlock) {
-                return
-            }
+        let existing = (try? String(contentsOfFile: zshrcPath, encoding: .utf8)) ?? ""
+        let analysis = analyzeMarkers(in: existing)
+
+        // べき等: 構造が well-formed かつ「現行と同一のブロックがちょうど 1 つだけ」なら
+        // 何もしない。重複ブロック・古い内容・余分なマーカーは以下で整理し直す（#148）。
+        if analysis.isWellFormed && analysis.blockContents == [zshrcSourceLine] {
+            return
+        }
+
+        // マーカーが 1 つでも存在すれば unconfigure で一旦整理する。
+        // - well-formed（重複ブロック / 古い内容）→ 全ブロック除去してから 1 つだけ再追加
+        // - malformed（余分/ネストしたマーカー）→ unconfigure が backup + throw（#146 契約）
+        if existing.contains(markerBegin) || existing.contains(markerEnd) {
             try unconfigure(zshrcPath: zshrcPath)
         }
 

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -344,6 +344,57 @@ struct SetupManagerTests {
         #expect(resultData == originalData)
     }
 
+    @Test("configure preserves user's intentional blank lines (no whitespace collapse)")
+    func configurePreservesIntentionalBlankLines() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        // マーカー未設定の初回 configure。ユーザーが意図的に置いた連続空行
+        // （heredoc 本文等）を圧縮してはならない（Codex #A）。
+        let original = """
+        alpha
+
+
+        beta
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        // 追記前のユーザー内容はそのまま（連続空行が保持される）
+        #expect(result.hasPrefix("alpha\n\n\nbeta"))
+    }
+
+    @Test("configure rewrites a block whose body differs only by an embedded mid-line CR")
+    func configureRewritesBlockWithMidLineCarriageReturn() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        // well-formed だが本文の 1 行に「行中の」CR が混入した壊れたブロック。
+        // 行末 CR ではないので現行 snippet とは別物 → no-op にせず正規化すべき（Codex #B）。
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy")
+        let corruptedSnippet = snippet.replacingOccurrences(
+            of: "~/.aikeychain_proxy", with: "~/.aikeychain_pro\rxy")
+        let corruptedBlock = "# >>> AI KeyChain >>>\n\(corruptedSnippet)\n# <<< AI KeyChain <<<"
+        try corruptedBlock.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        // 壊れたパスは残らず、正しい現行ブロックへ置き換わる
+        #expect(!result.contains("\r"))
+        let cleanBlock = "# >>> AI KeyChain >>>\n\(snippet)\n# <<< AI KeyChain <<<"
+        #expect(result.components(separatedBy: cleanBlock).count - 1 == 1)
+        #expect(try zshSyntaxIsValid(at: path))
+    }
+
     @Test("configure fails safely when a stray marker accompanies the current block")
     func configureFailsSafelyWithStrayMarker() throws {
         let path = temporaryZshrcPath()

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -272,10 +272,76 @@ struct SetupManagerTests {
         #expect(result.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
         #expect(result.components(separatedBy: "# <<< AI KeyChain <<<").count - 1 == 1)
         #expect(result.contains("/usr/bin/nc -z"))
+        // マーカー間本文が現行 snippet と完全一致するブロックがちょうど 1 つ
+        // （「空マーカーペア + マーカー外に残った snippet」等の抜けを防ぐ、Codex #4）。
+        #expect(result.components(separatedBy: block).count - 1 == 1)
         // ユーザー行は保持される
         #expect(result.contains("export EDITOR=vim"))
         #expect(result.contains("alias k=kubectl"))
         #expect(try zshSyntaxIsValid(at: path))
+    }
+
+    @Test("configure preserves user lines mentioning the proxy path when normalizing duplicates")
+    func configurePreservesUserProxyReferenceWhenNormalizing() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        // 重複ブロック + マーカー外にユーザー自身の `.aikeychain_proxy` 参照行。
+        // 正規化のために unconfigure を素通しすると、この行が巻き添え削除される（Codex #1）。
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy")
+        let block = "# >>> AI KeyChain >>>\n\(snippet)\n# <<< AI KeyChain <<<"
+        let userProxyLine = "export SNAPSHOT=\"$HOME/.aikeychain_proxy.backup\""
+        let original = """
+        \(userProxyLine)
+
+        \(block)
+
+        alias k=kubectl
+
+        \(block)
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        // 管理ブロックは 1 つに正規化されるが、ユーザー行は削除されない
+        #expect(result.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
+        #expect(result.contains(userProxyLine))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(try zshSyntaxIsValid(at: path))
+    }
+
+    @Test("configure is a byte-identical no-op for an already-correct CRLF block")
+    func configureIsIdempotentForCRLFCurrentBlock() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        // 既に正しい現行ブロックを持つが CRLF 改行の .zshrc。
+        // 本文の \r を無視して同一と判定できないと、no-op にならずブロックが末尾へ移動する（Codex #3）。
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy")
+        let lf = """
+        export EDITOR=vim
+
+        # >>> AI KeyChain >>>
+        \(snippet)
+        # <<< AI KeyChain <<<
+        """
+        let crlf = lf.replacingOccurrences(of: "\n", with: "\r\n")
+        try crlf.write(toFile: path, atomically: true, encoding: .utf8)
+        let originalData = try Data(contentsOf: URL(fileURLWithPath: path))
+
+        try SetupManager.configure(zshrcPath: path)
+
+        // 既に整合しているので 1 バイトも書き換わらない
+        let resultData = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(resultData == originalData)
     }
 
     @Test("configure fails safely when a stray marker accompanies the current block")
@@ -310,6 +376,9 @@ struct SetupManagerTests {
         #expect(FileManager.default.fileExists(atPath: backupPath))
         let backupData = try Data(contentsOf: URL(fileURLWithPath: backupPath))
         #expect(backupData == originalData)
+        // backup は 0600 で作られる（#146 契約 / Codex #4）
+        let backupPerm = try FileManager.default.attributesOfItem(atPath: backupPath)[.posixPermissions] as? NSNumber
+        #expect(backupPerm?.int16Value == 0o600)
     }
 
     @Test("Config block contains BASE_URL for all supported services")

--- a/Tests/AIkeychainTests/SetupManagerTests.swift
+++ b/Tests/AIkeychainTests/SetupManagerTests.swift
@@ -243,6 +243,75 @@ struct SetupManagerTests {
         #expect(result.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
     }
 
+    @Test("configure normalizes duplicate managed blocks to a single block")
+    func configureNormalizesDuplicateBlocks() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        // 現行と同一の well-formed ブロックが 2 つ存在する（重複）状態。
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy")
+        let block = "# >>> AI KeyChain >>>\n\(snippet)\n# <<< AI KeyChain <<<"
+        let original = """
+        export EDITOR=vim
+
+        \(block)
+
+        alias k=kubectl
+
+        \(block)
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+
+        try SetupManager.configure(zshrcPath: path)
+
+        let result = try String(contentsOfFile: path, encoding: .utf8)
+        // 重複が 1 つに正規化される
+        #expect(result.components(separatedBy: "# >>> AI KeyChain >>>").count - 1 == 1)
+        #expect(result.components(separatedBy: "# <<< AI KeyChain <<<").count - 1 == 1)
+        #expect(result.contains("/usr/bin/nc -z"))
+        // ユーザー行は保持される
+        #expect(result.contains("export EDITOR=vim"))
+        #expect(result.contains("alias k=kubectl"))
+        #expect(try zshSyntaxIsValid(at: path))
+    }
+
+    @Test("configure fails safely when a stray marker accompanies the current block")
+    func configureFailsSafelyWithStrayMarker() throws {
+        let path = temporaryZshrcPath()
+        let backupPath = path + ".aikeychain.bak"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: backupPath)
+        }
+        // 現行ブロックに加え、余分な（ネストした）BEGIN マーカーが混在 = malformed。
+        let snippet = SetupManager.proxySourceSnippet(proxyEnvPath: "~/.aikeychain_proxy")
+        let original = """
+        export EDITOR=vim
+        # >>> AI KeyChain >>>
+        # >>> AI KeyChain >>>
+        \(snippet)
+        # <<< AI KeyChain <<<
+        alias k=kubectl
+        """
+        try original.write(toFile: path, atomically: true, encoding: .utf8)
+        let originalData = try Data(contentsOf: URL(fileURLWithPath: path))
+
+        // malformed は非破壊 throw（unconfigure #146 契約）に委ねる
+        #expect(throws: SetupManager.SetupError.malformedMarkers) {
+            try SetupManager.configure(zshrcPath: path)
+        }
+
+        // 元ファイルは 1 バイトも変更されず、backup が作られる
+        let resultData = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(resultData == originalData)
+        #expect(FileManager.default.fileExists(atPath: backupPath))
+        let backupData = try Data(contentsOf: URL(fileURLWithPath: backupPath))
+        #expect(backupData == originalData)
+    }
+
     @Test("Config block contains BASE_URL for all supported services")
     func configBlockContent() {
         // SetupManager.configure() が書く内容を間接的に検証


### PR DESCRIPTION
## 概要

Closes #148

`SetupManager.configure()` は現行ブロックが `.zshrc` に含まれれば早期 return するため、**現行 + 重複した well-formed ブロック**や**現行 + 余分な malformed マーカー**が残存しても検証・除去しませんでした（データ損失はないが冪等性・整合性の穴）。早期 return 条件を厳格化し、逸脱時は #146 の `unconfigure()` 契約で整理し直すよう修正します。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `AIkeychain/Services/SetupManager.swift` | `analyzeMarkers()` を追加（well-formedness 判定を `unconfigure` と同一ロジックに統一）。`configure()` の早期 return を「構造が well-formed かつ現行と同一のブロックがちょうど1つ」に限定。逸脱時（重複・古い内容・余分マーカー）は `unconfigure()` で整理してから1つだけ再追加。malformed は `SetupError.malformedMarkers`（backup + 非破壊 throw）を尊重。 |
| `Tests/AIkeychainTests/SetupManagerTests.swift` | テスト2件追加：重複ブロック→1つに正規化 / 現行+stray marker→非破壊 throw + backup 生成。 |

## 受入条件

- [x] 現行ブロック + 2つ目のブロックがある場合、`configure()` 後にブロックが1つに正規化される
- [x] 現行ブロック + 余分な malformed マーカーがある場合、安全に検知（backup + throw）される
- [x] 既存の #142 移行・冪等テストが引き続き通る
- [x] 上記を検証するテストを追加

## 動作確認（Red/Green）

**Red**（実装前・現行コード）:
- 重複ブロック → 1つに正規化されず2つ残存（`count-1 → 2 == 1` 失敗）
- 現行+stray marker → throw されず素通り（`an error was expected but none was thrown`）

**Green**（実装後）:
- `swift test --filter SetupManagerTests` → **21/21 passed**（新規2 + #142 移行・冪等維持）
- `swift test`（全体）→ **153/153 passed**

> 📎 エビデンス例外: GUI のない `.zshrc` 編集ロジックのため、Red/Green の swift test ログを代替エビデンスとする（issue のテスト計画に準拠）。

## 関連

- 依存/隣接: #142（configure 移行）、#146/#149（unconfigure malformed 契約）
- gpt-5.6-sol の #146 再レビュー MEDIUM 指摘由来
