### PR TITLE
fix(gui): akc CLI 追加キーを「コマンド追加」カテゴリで発見表示 (#153)

### DIFF
--- a/.agent/logs/workflow-2026-07.jsonl
+++ b/.agent/logs/workflow-2026-07.jsonl
@@ -1,0 +1,1 @@
+{"timestamp": "2026-07-14T12:51:28Z", "command": "issue-implement", "issue": 153, "repo": "aieo-product/AIkeychain", "result": "success", "detail": "GUI が CLI 追加キーを発見表示(.cliAdded カテゴリ)。KeychainService.allAccounts 追加。swift test 160/160。PR #154。"}

--- a/.agent/logs/workflow-2026-07.jsonl
+++ b/.agent/logs/workflow-2026-07.jsonl
@@ -1,1 +1,0 @@
-{"timestamp": "2026-07-14T12:51:28Z", "command": "issue-implement", "issue": 153, "repo": "aieo-product/AIkeychain", "result": "success", "detail": "GUI が CLI 追加キーを発見表示(.cliAdded カテゴリ)。KeychainService.allAccounts 追加。swift test 160/160。PR #154。"}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ CLAUDE.md
 
 # npm pack artifacts
 cli/*.tgz
+
+# ローカルの dev-workflow 作業ファイル（コミットしない）
+.agent/

--- a/AIkeychain/Models/APIKey.swift
+++ b/AIkeychain/Models/APIKey.swift
@@ -70,13 +70,14 @@ struct APIKey: Identifiable, Equatable, Hashable {
     }
 
     var categoryColor: Color {
-        if let service { return service.category.color }
-        if let customKey, let cat = CustomKeyStore.shared.category(for: customKey.categoryId) {
+        // 表示中カテゴリ（override 込みの実効値）から色を解決する。合成キーの元 categoryId
+        // ではなく customCategoryId / builtinCategory を使うことで、発見キーをカスタム/別ビルトイン
+        // カテゴリへ移しても色が gray に落ちない（#153 / Codex #2・#3）。
+        if let customId = customCategoryId, let cat = CustomKeyStore.shared.category(for: customId) {
             return cat.color
         }
-        // ビルトインカテゴリ（発見キーの .cliAdded / stableId でビルトインを指すカスタムキー）
-        // はカスタムカテゴリ検索に載らないため、実効ビルトインカテゴリの色を使う（#153 / Codex #3）。
         if let builtin = builtinCategory { return builtin.color }
+        if let service { return service.category.color }
         return .gray
     }
 

--- a/AIkeychain/Models/APIKey.swift
+++ b/AIkeychain/Models/APIKey.swift
@@ -74,6 +74,9 @@ struct APIKey: Identifiable, Equatable, Hashable {
         if let customKey, let cat = CustomKeyStore.shared.category(for: customKey.categoryId) {
             return cat.color
         }
+        // ビルトインカテゴリ（発見キーの .cliAdded / stableId でビルトインを指すカスタムキー）
+        // はカスタムカテゴリ検索に載らないため、実効ビルトインカテゴリの色を使う（#153 / Codex #3）。
+        if let builtin = builtinCategory { return builtin.color }
         return .gray
     }
 

--- a/AIkeychain/Models/KeyCategory.swift
+++ b/AIkeychain/Models/KeyCategory.swift
@@ -7,6 +7,9 @@ enum KeyCategory: String, CaseIterable, Identifiable {
     case cloud = "Cloud & Infra"
     case communication = "Communication"
     case devTools = "Developer Tools"
+    /// CLI（`akc set`）で追加され、プリセット/カスタムのどちらにも属さないキーの
+    /// 発見用カテゴリ。種別不明のキーをここにまとめて表示する（#153）。
+    case cliAdded = "CLI Added"
 
     var id: String { rawValue }
 
@@ -19,6 +22,7 @@ enum KeyCategory: String, CaseIterable, Identifiable {
         case .cloud: L10n.s(ja: "クラウド & インフラ", en: "Cloud & Infra")
         case .communication: L10n.s(ja: "コミュニケーション", en: "Communication")
         case .devTools: L10n.s(ja: "開発ツール", en: "Developer Tools")
+        case .cliAdded: L10n.s(ja: "コマンド追加", en: "CLI Added")
         }
     }
 
@@ -30,6 +34,7 @@ enum KeyCategory: String, CaseIterable, Identifiable {
         case .cloud: Color(hex: 0x0284C7)
         case .communication: Color(hex: 0x059669)
         case .devTools: Color(hex: 0x6B7280)
+        case .cliAdded: Color(hex: 0x4F46E5)
         }
     }
 
@@ -41,6 +46,7 @@ enum KeyCategory: String, CaseIterable, Identifiable {
         case .cloud: "cloud.fill"
         case .communication: "bubble.left.and.bubble.right.fill"
         case .devTools: "wrench.and.screwdriver.fill"
+        case .cliAdded: "terminal.fill"
         }
     }
 
@@ -53,6 +59,7 @@ enum KeyCategory: String, CaseIterable, Identifiable {
         case .cloud:         UUID(uuidString: "B0000000-0000-0000-0000-000000000004")!
         case .communication: UUID(uuidString: "B0000000-0000-0000-0000-000000000005")!
         case .devTools:      UUID(uuidString: "B0000000-0000-0000-0000-000000000006")!
+        case .cliAdded:      UUID(uuidString: "B0000000-0000-0000-0000-000000000007")!
         }
     }
 

--- a/AIkeychain/Models/KeyCategory.swift
+++ b/AIkeychain/Models/KeyCategory.swift
@@ -67,4 +67,10 @@ enum KeyCategory: String, CaseIterable, Identifiable {
     static func from(stableId: UUID) -> KeyCategory? {
         allCases.first { $0.stableId == stableId }
     }
+
+    /// ユーザーが手動で割り当て可能なカテゴリ。`.cliAdded` は CLI 発見キー専用の
+    /// 自動カテゴリなので、キー追加/オンボーディングの選択肢からは除外する（#153 / Codex #4）。
+    static var assignableCases: [KeyCategory] {
+        allCases.filter { $0 != .cliAdded }
+    }
 }

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -32,6 +32,10 @@ protocol KeychainServiceProtocol {
     func retrieveNoninteractive(for account: String) throws -> String?
     func delete(for account: String) throws
     func exists(for account: String) -> Bool
+    /// AI KeyChain の保存 service (com.aieo.aikeychain) に存在する全アカウント名を列挙する。
+    /// CLI (`akc set`) で追加され GUI 索引に無いキーを発見するために使う (#153)。
+    /// 秘密値は読まない（アカウント名のみ）。
+    func allAccounts() -> [String]
 }
 
 final class KeychainService: KeychainServiceProtocol {
@@ -151,6 +155,21 @@ final class KeychainService: KeychainServiceProtocol {
         let status = SecItemCopyMatching(query as CFDictionary, nil)
         return status == errSecSuccess
     }
+
+    func allAccounts() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            return []
+        }
+        return items.compactMap { $0[kSecAttrAccount as String] as? String }
+    }
 }
 
 // MARK: - Mock for Previews and Tests
@@ -176,5 +195,9 @@ final class MockKeychainService: KeychainServiceProtocol {
 
     func exists(for account: String) -> Bool {
         store[account] != nil
+    }
+
+    func allAccounts() -> [String] {
+        Array(store.keys)
     }
 }

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -126,7 +126,12 @@ final class KeyEditorViewModel {
 
     func save() throws {
         let trimmedValue = tokenValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedEnvVar = envVarName.trimmingCharacters(in: .whitespacesAndNewlines)
+        // 既存キーの編集では環境変数名を変更しない（rename は旧 Keychain 項目の残存・
+        // 無確認上書き・二重表示の原因になるため非対応 / #153 Codex 再指摘#1）。
+        // rename が必要なら削除→新規追加で行う。新規追加時のみ入力値を採用する。
+        let trimmedEnvVar = isEditing
+            ? (editingKey?.envVarName ?? envVarName.trimmingCharacters(in: .whitespacesAndNewlines))
+            : envVarName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedValue.isEmpty, !trimmedEnvVar.isEmpty else { return }
 
         isSaving = true

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -29,6 +29,16 @@ final class KeyEditorViewModel {
         isEditing ? L10n.s(ja: "キーを編集", en: "Edit Key") : L10n.s(ja: "キーを追加", en: "Add Key")
     }
 
+    /// カテゴリピッカーに出すビルトインカテゴリ。通常は `.cliAdded` を除くが、
+    /// 発見キー（現在 .cliAdded）の編集時のみ、現行カテゴリを選択状態として表示できるよう含める。
+    var selectableCategories: [KeyCategory] {
+        var cats = KeyCategory.assignableCases
+        if editingKey?.builtinCategory == .cliAdded {
+            cats.append(.cliAdded)
+        }
+        return cats
+    }
+
     /// 選択中カテゴリの既定アイコン。
     var categoryDefaultIcon: String {
         switch selectedCategorySelection {
@@ -134,12 +144,21 @@ final class KeyEditorViewModel {
                         envVarName: trimmedEnvVar,
                         value: categoryOverrideValue(defaultCategory: service.category))
                     customStore.setIconOverride(envVarName: trimmedEnvVar, icon: iconToStore)
-                } else if let customKey = key.customKey {
-                    // カスタムキーのカテゴリ/アイコン変更
+                } else if let customKey = key.customKey,
+                          customStore.keys.contains(where: { $0.id == customKey.id }) {
+                    // 永続化済みカスタムキーのカテゴリ/アイコン変更
                     var updated = customKey
                     updated.categoryId = resolveCategoryId()
                     updated.icon = iconToStore
                     customStore.updateKey(updated)
+                } else {
+                    // 発見キー（CLI 追加, customStore に無い合成キー）: updateKey は no-op で
+                    // 編集が消えるため、プリセットと同じく envVarName キーの override で分類/アイコンを
+                    // 永続化する。APIKey は再読込後も override を優先解決する（#153 / Codex #1）。
+                    customStore.setCategoryOverride(
+                        envVarName: trimmedEnvVar,
+                        value: categoryOverrideValue(defaultCategory: .cliAdded))
+                    customStore.setIconOverride(envVarName: trimmedEnvVar, icon: iconToStore)
                 }
             } else {
                 // 新規キー

--- a/AIkeychain/ViewModels/KeyListViewModel.swift
+++ b/AIkeychain/ViewModels/KeyListViewModel.swift
@@ -93,6 +93,21 @@ final class KeyListViewModel {
             ))
         }
 
+        // CLI (`akc set`) で追加され、プリセットにもカスタム索引にも無い Keychain キーを
+        // 発見して「コマンド追加」カテゴリに出す（種別不明のためまとめて表示 / #153）。
+        // env 変数名の形（EnvVarName.isValid）のみ採用し、内部用アイテムや
+        // シェル export で壊れる名前は除外する。
+        let known = Set(allKeys.map(\.envVarName))
+        for account in keychainService.allAccounts()
+        where !known.contains(account) && EnvVarName.isValid(account) {
+            let discovered = CustomKey(
+                envVarName: account,
+                displayName: account,
+                categoryId: KeyCategory.cliAdded.stableId
+            )
+            allKeys.append(APIKey(customKey: discovered, isConfigured: true))
+        }
+
         keys = allKeys
     }
 

--- a/AIkeychain/ViewModels/KeyListViewModel.swift
+++ b/AIkeychain/ViewModels/KeyListViewModel.swift
@@ -97,9 +97,11 @@ final class KeyListViewModel {
         // 発見して「コマンド追加」カテゴリに出す（種別不明のためまとめて表示 / #153）。
         // env 変数名の形（EnvVarName.isValid）のみ採用し、内部用アイテムや
         // シェル export で壊れる名前は除外する。
-        let known = Set(allKeys.map(\.envVarName))
+        // known は発見ループ中も更新する。allAccounts() は kSecMatchLimitAll で
+        // 同名アカウントを複数返し得るため、insert の成否で二重追加を防ぐ（Codex #2）。
+        var known = Set(allKeys.map(\.envVarName))
         for account in keychainService.allAccounts()
-        where !known.contains(account) && EnvVarName.isValid(account) {
+        where EnvVarName.isValid(account) && known.insert(account).inserted {
             let discovered = CustomKey(
                 envVarName: account,
                 displayName: account,

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -35,7 +35,7 @@ struct KeyEditorView: View {
                     Text(L10n.s(ja: "カテゴリを選択...", en: "Select a category..."))
                         .foregroundStyle(.secondary)
                         .tag(CategorySelection?.none)
-                    ForEach(KeyCategory.allCases) { cat in
+                    ForEach(viewModel.selectableCategories) { cat in
                         Label(cat.displayName, systemImage: cat.systemImage)
                             .tag(CategorySelection?.some(.builtin(cat)))
                     }

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -52,8 +52,11 @@ struct KeyEditorView: View {
                 }
 
                 // Env var name (required)
+                // 既存キーの編集では rename 非対応（旧項目残存/無確認上書きを防ぐ）。
+                // 名前を変えたい場合は削除→新規追加で行う（#153）。
                 TextField(L10n.s(ja: "環境変数名", en: "Environment Variable"), text: $viewModel.envVarName)
                     .font(AppFonts.code)
+                    .disabled(viewModel.isEditing)
 
                 // Token value (required) — primary input, kept above the optional icon picker.
                 Section {

--- a/AIkeychain/Views/Main/SidebarView.swift
+++ b/AIkeychain/Views/Main/SidebarView.swift
@@ -9,6 +9,14 @@ struct SidebarView: View {
     private var appState: AppState { .shared }
     private var logStore: ProxyLogStore { appState.proxyLogStore }
 
+    /// サイドバーに出すビルトインカテゴリ。`.cliAdded`（コマンド追加）は CLI 発見キーが
+    /// 1 件以上ある時だけ表示し、常時 0/0 の空カテゴリを出さない（#153）。
+    private var visibleCategories: [KeyCategory] {
+        KeyCategory.allCases.filter { category in
+            category != .cliAdded || viewModel.builtinCategoryCount(for: category) > 0
+        }
+    }
+
     var body: some View {
         List(selection: $viewModel.selectedCategory) {
             Section {
@@ -46,7 +54,7 @@ struct SidebarView: View {
             }
 
             Section(L10n.s(ja: "カテゴリ", en: "Categories")) {
-                ForEach(KeyCategory.allCases) { category in
+                ForEach(visibleCategories) { category in
                     NavigationLink(value: CategorySelection.builtin(category)) {
                         Label {
                             HStack {

--- a/AIkeychain/Views/Onboarding/OnboardingView.swift
+++ b/AIkeychain/Views/Onboarding/OnboardingView.swift
@@ -455,7 +455,8 @@ struct RegisterKeysStepView: View {
 
                 // Quick status
                 VStack(spacing: 10) {
-                    ForEach(KeyCategory.allCases) { category in
+                    // 発見用 .cliAdded は CLI キーがある時だけ出す（オンボーディング初期は常に空 / Codex #4）
+                    ForEach(KeyCategory.allCases.filter { $0 != .cliAdded || keyListVM.builtinCategoryCount(for: $0) > 0 }) { category in
                         HStack(spacing: 10) {
                             CategoryIcon(category: category, size: 26)
                             Text(category.rawValue)

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -67,9 +67,10 @@ struct KeyCategoryTests {
         }
     }
 
-    @Test("Category count is 6")
+    @Test("Category count is 7")
     func categoryCount() {
-        #expect(KeyCategory.allCases.count == 6)
+        // 6 プリセットカテゴリ + CLI 発見用 .cliAdded（#153）
+        #expect(KeyCategory.allCases.count == 7)
     }
 }
 

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -150,6 +150,7 @@ final class BlockingKeychainService: KeychainServiceProtocol {
     }
     func delete(for account: String) throws {}
     func exists(for account: String) -> Bool { false }
+    func allAccounts() -> [String] { [] }
 }
 
 /// Keychain double that reports the read needs user interaction.
@@ -161,6 +162,7 @@ final class InteractionRequiredKeychainService: KeychainServiceProtocol {
     }
     func delete(for account: String) throws {}
     func exists(for account: String) -> Bool { false }
+    func allAccounts() -> [String] { [] }
 }
 
 /// Minimal raw-TCP HTTP client for talking to the local proxy in tests.

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -153,6 +153,53 @@ struct KeyListViewModelTests {
         #expect(!vm.keys.contains { $0.envVarName == "has-hyphen" })
     }
 
+    @Test("Editing an existing key does not rename it (no orphaned duplicate)")
+    func editingDoesNotRenameKey() throws {
+        let (vm, mock) = makeSUT()
+        let name = uniqueEnvName()
+        try mock.save(value: "secret", for: name)
+        vm.loadKeys()
+        let discovered = try #require(vm.keys.first { $0.envVarName == name })
+
+        // エディタで環境変数名を書き換えて保存しても、rename は起きない
+        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock)
+        editor.selectedCategorySelection = .builtin(.devTools)
+        editor.envVarName = name + "_RENAMED"
+        try editor.save()
+
+        vm.loadKeys()
+        // 新名は作られず、旧名だけが残る（二重表示・無確認上書きを防ぐ）
+        #expect(!vm.keys.contains { $0.envVarName == name + "_RENAMED" })
+        #expect(vm.keys.contains { $0.envVarName == name })
+        #expect(mock.exists(for: name))
+        #expect(!mock.exists(for: name + "_RENAMED"))
+    }
+
+    @Test("A discovered key moved to a custom category uses that category's color")
+    func discoveredKeyMovedToCustomCategoryUsesItsColor() throws {
+        let (vm, mock) = makeSUT()
+        let name = uniqueEnvName()
+        // テスト用カスタムカテゴリを .shared に用意
+        let cat = CustomCategory(name: "CLI_Test_Cat_\(UUID().uuidString.prefix(6))", colorHex: 0x123456)
+        CustomKeyStore.shared.addCategory(cat)
+        try mock.save(value: "secret", for: name)
+        vm.loadKeys()
+        let discovered = try #require(vm.keys.first { $0.envVarName == name })
+        defer {
+            CustomKeyStore.shared.setCategoryOverride(envVarName: name, value: nil)
+            CustomKeyStore.shared.setIconOverride(envVarName: name, icon: nil)
+            CustomKeyStore.shared.deleteCategory(cat.id)
+        }
+
+        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock)
+        editor.selectedCategorySelection = .custom(cat.id)
+        try editor.save()
+
+        vm.loadKeys()
+        let after = try #require(vm.keys.first { $0.envVarName == name })
+        #expect(after.categoryColor == cat.color)
+    }
+
     @Test("Duplicate accounts from enumeration are surfaced only once")
     func dedupesDuplicateDiscoveredAccounts() {
         let name = "CLI_DUP_" + UUID().uuidString.replacingOccurrences(of: "-", with: "_")

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -70,6 +70,47 @@ struct KeyListViewModelTests {
         #expect(vm.builtinCategoryCount(for: .ai) == aiCount)
     }
 
+    @Test("CLI-added keychain keys are discovered under the CLI Added category")
+    func discoversCliAddedKeys() throws {
+        let (vm, mock) = makeSUT()
+        // プリセットにもカスタムにも無い、CLI (akc set) 由来の Keychain キー。
+        try mock.save(value: "secret", for: "MY_CLI_KEY")
+        vm.loadKeys()
+
+        let discovered = vm.keys.first { $0.envVarName == "MY_CLI_KEY" }
+        #expect(discovered != nil)
+        #expect(discovered?.isConfigured == true)
+        #expect(discovered?.builtinCategory == .cliAdded)
+        // 「コマンド追加」カテゴリでフィルタすると出てくる
+        vm.selectedCategory = .builtin(.cliAdded)
+        #expect(vm.filteredKeys.contains { $0.envVarName == "MY_CLI_KEY" })
+    }
+
+    @Test("A preset key stored via CLI is not duplicated as a discovered key")
+    func presetStoredViaCliIsNotDuplicated() throws {
+        let (vm, mock) = makeSUT()
+        // プリセットの envVarName を CLI で保存しても、発見キーとして二重表示しない。
+        try mock.save(value: "secret", for: "ANTHROPIC_API_KEY")
+        vm.loadKeys()
+
+        let matches = vm.keys.filter { $0.envVarName == "ANTHROPIC_API_KEY" }
+        #expect(matches.count == 1)
+        #expect(matches.first?.service == .some(.anthropic))
+        // .cliAdded ではなくプリセットのカテゴリに属する
+        #expect(matches.first?.builtinCategory != .cliAdded)
+    }
+
+    @Test("Non-env-var-shaped keychain accounts are not surfaced")
+    func invalidNamesNotSurfaced() throws {
+        let (vm, mock) = makeSUT()
+        // env 変数名として無効な名前（先頭数字 / ハイフン）は一覧に出さない。
+        try mock.save(value: "v", for: "9INVALID")
+        try mock.save(value: "v", for: "has-hyphen")
+        vm.loadKeys()
+        #expect(!vm.keys.contains { $0.envVarName == "9INVALID" })
+        #expect(!vm.keys.contains { $0.envVarName == "has-hyphen" })
+    }
+
     @Test("Delete key makes it unconfigured")
     func deleteKey() throws {
         let (vm, mock) = makeSUT()

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import AIkeychain
 
 @Suite("KeyListViewModel Tests")
@@ -70,20 +71,61 @@ struct KeyListViewModelTests {
         #expect(vm.builtinCategoryCount(for: .ai) == aiCount)
     }
 
+    /// CustomKeyStore.shared のグローバル状態と衝突しない、テストごとに一意な env 変数名。
+    /// （APIKey の分類は .shared 参照のため、既存 custom キーと同名だと偽陽性になる — #6 対策）
+    private func uniqueEnvName() -> String {
+        "CLI_TEST_" + UUID().uuidString.replacingOccurrences(of: "-", with: "_")
+    }
+
     @Test("CLI-added keychain keys are discovered under the CLI Added category")
     func discoversCliAddedKeys() throws {
         let (vm, mock) = makeSUT()
+        let name = uniqueEnvName()
         // プリセットにもカスタムにも無い、CLI (akc set) 由来の Keychain キー。
-        try mock.save(value: "secret", for: "MY_CLI_KEY")
+        try mock.save(value: "secret", for: name)
         vm.loadKeys()
 
-        let discovered = vm.keys.first { $0.envVarName == "MY_CLI_KEY" }
+        let discovered = vm.keys.first { $0.envVarName == name }
         #expect(discovered != nil)
         #expect(discovered?.isConfigured == true)
         #expect(discovered?.builtinCategory == .cliAdded)
         // 「コマンド追加」カテゴリでフィルタすると出てくる
         vm.selectedCategory = .builtin(.cliAdded)
-        #expect(vm.filteredKeys.contains { $0.envVarName == "MY_CLI_KEY" })
+        #expect(vm.filteredKeys.contains { $0.envVarName == name })
+    }
+
+    @Test("A discovered key shows the CLI Added category color, not gray")
+    func discoveredKeyUsesCliAddedColor() throws {
+        let (vm, mock) = makeSUT()
+        let name = uniqueEnvName()
+        try mock.save(value: "secret", for: name)
+        vm.loadKeys()
+        let discovered = vm.keys.first { $0.envVarName == name }
+        #expect(discovered?.categoryColor == KeyCategory.cliAdded.color)
+    }
+
+    @Test("Editing a discovered key's category persists across reload (via override)")
+    func editingDiscoveredKeyPersistsCategory() throws {
+        let (vm, mock) = makeSUT()
+        let name = uniqueEnvName()
+        try mock.save(value: "secret", for: name)
+        vm.loadKeys()
+        let discovered = try #require(vm.keys.first { $0.envVarName == name })
+        defer {
+            // .shared に書いた override を後始末する
+            CustomKeyStore.shared.setCategoryOverride(envVarName: name, value: nil)
+            CustomKeyStore.shared.setIconOverride(envVarName: name, icon: nil)
+        }
+
+        // 発見キーをエディタで「開発ツール」に付け替えて保存
+        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock)
+        editor.selectedCategorySelection = .builtin(.devTools)
+        try editor.save()
+
+        // 再読込しても .cliAdded に戻らず devTools を維持する
+        vm.loadKeys()
+        let after = vm.keys.first { $0.envVarName == name }
+        #expect(after?.builtinCategory == .devTools)
     }
 
     @Test("A preset key stored via CLI is not duplicated as a discovered key")
@@ -111,6 +153,14 @@ struct KeyListViewModelTests {
         #expect(!vm.keys.contains { $0.envVarName == "has-hyphen" })
     }
 
+    @Test("Duplicate accounts from enumeration are surfaced only once")
+    func dedupesDuplicateDiscoveredAccounts() {
+        let name = "CLI_DUP_" + UUID().uuidString.replacingOccurrences(of: "-", with: "_")
+        let stub = DupAccountsKeychainService(accounts: [name, name])
+        let vm = KeyListViewModel(keychainService: stub)
+        #expect(vm.keys.filter { $0.envVarName == name }.count == 1)
+    }
+
     @Test("Delete key makes it unconfigured")
     func deleteKey() throws {
         let (vm, mock) = makeSUT()
@@ -122,4 +172,16 @@ struct KeyListViewModelTests {
         try vm.delete(key: githubKey)
         #expect(vm.configuredCount == 0)
     }
+}
+
+/// `allAccounts()` が重複を返す状況を再現するテストダブル（辞書ベースの Mock では作れない）。
+final class DupAccountsKeychainService: KeychainServiceProtocol {
+    private let accounts: [String]
+    init(accounts: [String]) { self.accounts = accounts }
+    func save(value: String, for account: String) throws {}
+    func retrieve(for account: String) throws -> String? { nil }
+    func retrieveNoninteractive(for account: String) throws -> String? { nil }
+    func delete(for account: String) throws {}
+    func exists(for account: String) -> Bool { true }
+    func allAccounts() -> [String] { accounts }
 }


### PR DESCRIPTION
## 概要

Closes #153

`akc set <KEY>`（CLI）で追加したキーが GUI 一覧に表示されない不具合を修正。

### 根本原因
`akc set` は GUI と同じ保存先 `service=com.aieo.aikeychain, account=<KEY>` に値を書く（`cli/src/keychain.js`）。しかし GUI の一覧（`KeyListViewModel.loadKeys`）は **プリセット（`ServiceType`）＋ カスタム（UserDefaults 索引）** だけを反復するため、どちらにも属さない CLI 追加キーは Keychain に値があっても表示されなかった。

### 修正
GUI 側で Keychain を列挙し、未知キーを **「コマンド追加」カテゴリ**で発見表示する。種別・カテゴリ不明なので1つのグループにまとめる。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `AIkeychain/Services/KeychainService.swift` | `allAccounts()` を追加（`com.aieo.aikeychain` の全アカウント名を `SecItemCopyMatching`+`kSecMatchLimitAll` で列挙）。protocol/Mock/テストダブルにも追加。 |
| `AIkeychain/Models/KeyCategory.swift` | ビルトインカテゴリ `.cliAdded`（日本語「コマンド追加」/ 英語「CLI Added」, `terminal.fill`, stableId `...007`）を追加。 |
| `AIkeychain/ViewModels/KeyListViewModel.swift` | `loadKeys()` で、プリセット/カスタムに無く `EnvVarName.isValid` を満たす Keychain アカウントを `.cliAdded` の発見キーとして一覧へ追加。 |
| `AIkeychain/Views/Main/SidebarView.swift` | `.cliAdded` はキーが 1 件以上ある時のみ表示（常時 0/0 を出さない）。 |
| `Tests/…/ViewModelTests.swift` | 発見表示・重複回避・無効名除外の3テスト追加。 |
| `Tests/…/ModelTests.swift` | カテゴリ数 6→7 に更新。 |

## 設計上のポイント

- **重複しない**: プリセット envVarName を CLI 保存しても、既存 envVarName 集合で除外し二重表示しない（テスト `presetStoredViaCliIsNotDuplicated`）。
- **内部アイテムを拾わない**: 共有鍵/署名鍵は別 service（`.sharekey`/`.signkey`）。加えて `EnvVarName.isValid`（`^[A-Za-z_][A-Za-z0-9_]*$`）で env 変数名の形のみ採用（テスト `invalidNamesNotSurfaced`）。
- **横断反映**: `viewModel.keys` は共有・エクスポートの共通ソースのため、発見キーはそれらにも反映される。

## 動作確認（Red/Green）

- **Red**（実装前）: `discoversCliAddedKeys` が失敗（発見キーが一覧に出ない）を再現。
- **Green**（実装後）: `swift test` 全体 **160/160 passed**（新規3件 + カテゴリ数更新含む）。

> 📎 エビデンス例外: GUI ロジック（ヘッドレステスト不可）のため、Red/Green の swift test ログを代替エビデンスとする。ViewModel を Mock 注入で検証。

## 受入条件

- [x] `akc set` した env 変数名のキーが GUI 一覧に「コマンド追加」で表示される
- [x] 既存プリセット/カスタムの表示・分類は不変（重複しない）
- [x] 「コマンド追加」はキー 0 件のときサイドバーに出ない
- [x] 内部用/env 変数名でないアカウントは表示されない
- [x] 検証テストを追加
