### PR TITLE
chore: bump version to 1.7.0 (#148 / #153)

### DIFF
--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;
@@ -681,7 +681,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Republish carrying fixes merged to `main` after the `0.5.0` release.
 - **CLI mask leak** — `cli/src/keychain.js` `maskValue` printed `****** (N chars)`, leaking the secret's character count. Now emits a fixed-length `********` mask, matching the `scripts/akc` behavior fixed earlier under #115/#123 (#136)
 - **Manual key-retrieval guidance** — `akc init` template, MCP `usage_guide`, and README taught only the `security find-generic-password -s "ENV_VAR_NAME" -w` form, which returns exit 44 for keys stored via the AI KeyChain GUI (`service=com.aieo.aikeychain`) and falsely suggested the key was missing. `akc get <KEY>` is now the primary recommendation everywhere; both `security` lookup forms are documented with an explicit warning that exit 44 on the bare form is not proof of "unregistered" (#137, #138)
 
+## [1.7.0] - 2026-07-16
+
+### Added
+- **CLI で追加したキーの GUI 表示** — `akc set`（CLI）で追加したキーは GUI と同じ Keychain（`service=com.aieo.aikeychain`）に保存されるが、GUI 一覧はプリセット + カスタム索引しか反復せず表示されなかった。GUI 起動時に Keychain を列挙し、プリセット/カスタムのどちらにも属さないキーを新カテゴリ「コマンド追加」(`CLI Added`) で発見表示する。分類/アイコンの編集は override で永続化し、内部用（共有鍵/署名鍵）や env 変数名でないアカウントは除外する (#153)
+
+### Fixed
+- **`SetupManager.configure()` のマーカーブロック正規化** — 現行ブロックが存在すると早期 return するため、重複した well-formed ブロックや余分な malformed マーカーが残存しても検証・除去されなかった（冪等性・整合性の穴）。早期 return を「well-formed かつ現行と同一ブロックがちょうど 1 つ」に厳格化し、逸脱時は `unconfigure()` 契約（well-formed は全除去して再追加 / malformed は 0600 backup + throw）で整理し直す。ブロック外のユーザー行や連続空行、CRLF 改行を保持する (#148)
+
+### Docs
+- **設計書のキー解決フロー最新化** — `docs/design/architecture.md` を現行実装に同期。External CLI を npm CLI(`aikeychain`/`akc`) + MCP server + Bash 同等に更新、Secret Reference の 2 段ルックアップ(#91)を図に反映、AI エージェント経由(MCP + `akc run`)のデータフローを新設 (#156)
+
 ## [1.6.1] - 2026-05-13
 
 ### Fixed

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aieo.aikeychain
-        MARKETING_VERSION: "1.6.1"
+        MARKETING_VERSION: "1.7.0"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/scripts/akc
+++ b/scripts/akc
@@ -27,7 +27,7 @@ readonly SECURITY_BIN="/usr/bin/security"
 # `VAR=keychain://KEY` 行を捏造して任意の Keychain 値を解決・export させられる。
 readonly ENV_BIN="/usr/bin/env"
 
-VERSION="1.6.1"
+VERSION="1.7.0"
 
 usage() {
     cat <<'USAGE'


### PR DESCRIPTION
## 概要

#148(configure マーカーブロック正規化) と #153(CLI 追加キーの GUI 発見表示・新機能) をまとめた **v1.7.0** リリース。新機能を含むため semver で minor バンプ。

## 変更
| ファイル | 変更 |
|---|---|
| `project.yml` / `AIkeychain.xcodeproj` | MARKETING_VERSION 1.6.1 → 1.7.0 |
| `scripts/akc` | VERSION 1.6.1 → 1.7.0 |
| `CHANGELOG.md` | [1.7.0] 追記 (#148 / #153 / #156) |

## 目的
既存ユーザーの**アップグレード検証**用に、旧バージョンより新しい 1.7.0 ビルドを配布可能にする。npm CLI(`aikeychain`)は本リリースで変更が無いため 0.5.1 のまま据え置き。

## 動作確認
- [ ] `swift build -c release` が通る
- [ ] 全テスト green（バンプはビルド設定のみでロジック非変更）