### PR TITLE
test(gui): 発見キーテストの CustomKeyStore.shared 並列競合を解消

### DIFF
--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;
@@ -681,7 +681,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Republish carrying fixes merged to `main` after the `0.5.0` release.
 - **CLI mask leak** — `cli/src/keychain.js` `maskValue` printed `****** (N chars)`, leaking the secret's character count. Now emits a fixed-length `********` mask, matching the `scripts/akc` behavior fixed earlier under #115/#123 (#136)
 - **Manual key-retrieval guidance** — `akc init` template, MCP `usage_guide`, and README taught only the `security find-generic-password -s "ENV_VAR_NAME" -w` form, which returns exit 44 for keys stored via the AI KeyChain GUI (`service=com.aieo.aikeychain`) and falsely suggested the key was missing. `akc get <KEY>` is now the primary recommendation everywhere; both `security` lookup forms are documented with an explicit warning that exit 44 on the bare form is not proof of "unregistered" (#137, #138)
 
+## [1.7.0] - 2026-07-16
+
+### Added
+- **CLI で追加したキーの GUI 表示** — `akc set`（CLI）で追加したキーは GUI と同じ Keychain（`service=com.aieo.aikeychain`）に保存されるが、GUI 一覧はプリセット + カスタム索引しか反復せず表示されなかった。GUI 起動時に Keychain を列挙し、プリセット/カスタムのどちらにも属さないキーを新カテゴリ「コマンド追加」(`CLI Added`) で発見表示する。分類/アイコンの編集は override で永続化し、内部用（共有鍵/署名鍵）や env 変数名でないアカウントは除外する (#153)
+
+### Fixed
+- **`SetupManager.configure()` のマーカーブロック正規化** — 現行ブロックが存在すると早期 return するため、重複した well-formed ブロックや余分な malformed マーカーが残存しても検証・除去されなかった（冪等性・整合性の穴）。早期 return を「well-formed かつ現行と同一ブロックがちょうど 1 つ」に厳格化し、逸脱時は `unconfigure()` 契約（well-formed は全除去して再追加 / malformed は 0600 backup + throw）で整理し直す。ブロック外のユーザー行や連続空行、CRLF 改行を保持する (#148)
+
+### Docs
+- **設計書のキー解決フロー最新化** — `docs/design/architecture.md` を現行実装に同期。External CLI を npm CLI(`aikeychain`/`akc`) + MCP server + Bash 同等に更新、Secret Reference の 2 段ルックアップ(#91)を図に反映、AI エージェント経由(MCP + `akc run`)のデータフローを新設 (#156)
+
 ## [1.6.1] - 2026-05-13
 
 ### Fixed

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -77,6 +77,16 @@ struct KeyListViewModelTests {
         "CLI_TEST_" + UUID().uuidString.replacingOccurrences(of: "-", with: "_")
     }
 
+    /// 分離した UserDefaults スイートで CustomKeyStore を作る。テストが
+    /// グローバルな `CustomKeyStore.shared`（`.standard`）を書き換えないための土台。
+    /// swift-testing は既定で並列実行するため、`.shared` を書くテストは他テストの
+    /// `.shared` 読取と競合してクラッシュし得る（ModelTests と同じ隔離パターンに揃える）。
+    private func isolatedStore() -> (CustomKeyStore, UserDefaults, String) {
+        let suite = "test-keylist-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        return (CustomKeyStore(defaults: defaults), defaults, suite)
+    }
+
     @Test("CLI-added keychain keys are discovered under the CLI Added category")
     func discoversCliAddedKeys() throws {
         let (vm, mock) = makeSUT()
@@ -104,28 +114,24 @@ struct KeyListViewModelTests {
         #expect(discovered?.categoryColor == KeyCategory.cliAdded.color)
     }
 
-    @Test("Editing a discovered key's category persists across reload (via override)")
+    @Test("Editing a discovered key's category is persisted as an override")
     func editingDiscoveredKeyPersistsCategory() throws {
-        let (vm, mock) = makeSUT()
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let mock = MockKeychainService()
         let name = uniqueEnvName()
         try mock.save(value: "secret", for: name)
-        vm.loadKeys()
+        let vm = KeyListViewModel(keychainService: mock, customStore: store)
         let discovered = try #require(vm.keys.first { $0.envVarName == name })
-        defer {
-            // .shared に書いた override を後始末する
-            CustomKeyStore.shared.setCategoryOverride(envVarName: name, value: nil)
-            CustomKeyStore.shared.setIconOverride(envVarName: name, icon: nil)
-        }
 
         // 発見キーをエディタで「開発ツール」に付け替えて保存
-        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock)
+        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock, customStore: store)
         editor.selectedCategorySelection = .builtin(.devTools)
         try editor.save()
 
-        // 再読込しても .cliAdded に戻らず devTools を維持する
-        vm.loadKeys()
-        let after = vm.keys.first { $0.envVarName == name }
-        #expect(after?.builtinCategory == .devTools)
+        // 発見キー（customStore に無い合成キー）の分類変更は override として永続化される。
+        // → 再読込後も APIKey.builtinCategory が override を優先解決し devTools を維持する。
+        #expect(store.overriddenCategory(for: name) == .builtin(.devTools))
     }
 
     @Test("A preset key stored via CLI is not duplicated as a discovered key")
@@ -155,14 +161,16 @@ struct KeyListViewModelTests {
 
     @Test("Editing an existing key does not rename it (no orphaned duplicate)")
     func editingDoesNotRenameKey() throws {
-        let (vm, mock) = makeSUT()
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let mock = MockKeychainService()
         let name = uniqueEnvName()
         try mock.save(value: "secret", for: name)
-        vm.loadKeys()
+        let vm = KeyListViewModel(keychainService: mock, customStore: store)
         let discovered = try #require(vm.keys.first { $0.envVarName == name })
 
         // エディタで環境変数名を書き換えて保存しても、rename は起きない
-        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock)
+        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock, customStore: store)
         editor.selectedCategorySelection = .builtin(.devTools)
         editor.envVarName = name + "_RENAMED"
         try editor.save()
@@ -175,29 +183,26 @@ struct KeyListViewModelTests {
         #expect(!mock.exists(for: name + "_RENAMED"))
     }
 
-    @Test("A discovered key moved to a custom category uses that category's color")
-    func discoveredKeyMovedToCustomCategoryUsesItsColor() throws {
-        let (vm, mock) = makeSUT()
+    @Test("Editing a discovered key into a custom category persists the override")
+    func editingDiscoveredKeyPersistsCustomCategory() throws {
+        let (store, defaults, suite) = isolatedStore()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let mock = MockKeychainService()
         let name = uniqueEnvName()
-        // テスト用カスタムカテゴリを .shared に用意
-        let cat = CustomCategory(name: "CLI_Test_Cat_\(UUID().uuidString.prefix(6))", colorHex: 0x123456)
-        CustomKeyStore.shared.addCategory(cat)
+        let cat = CustomCategory(name: "CLI_Test_Cat", colorHex: 0x123456)
+        store.addCategory(cat)
         try mock.save(value: "secret", for: name)
-        vm.loadKeys()
+        let vm = KeyListViewModel(keychainService: mock, customStore: store)
         let discovered = try #require(vm.keys.first { $0.envVarName == name })
-        defer {
-            CustomKeyStore.shared.setCategoryOverride(envVarName: name, value: nil)
-            CustomKeyStore.shared.setIconOverride(envVarName: name, icon: nil)
-            CustomKeyStore.shared.deleteCategory(cat.id)
-        }
 
-        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock)
+        let editor = KeyEditorViewModel(editingKey: discovered, keychainService: mock, customStore: store)
         editor.selectedCategorySelection = .custom(cat.id)
         try editor.save()
 
-        vm.loadKeys()
-        let after = try #require(vm.keys.first { $0.envVarName == name })
-        #expect(after.categoryColor == cat.color)
+        // 発見キーをカスタムカテゴリへ移動 → override として永続化される（categoryColor は
+        // この customCategoryId 経由で当該カテゴリ色を解決する。色解決自体は
+        // discoveredKeyUsesCliAddedColor でも担保）。
+        #expect(store.overriddenCategory(for: name) == .custom(cat.id))
     }
 
     @Test("Duplicate accounts from enumeration are surfaced only once")

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aieo.aikeychain
-        MARKETING_VERSION: "1.6.1"
+        MARKETING_VERSION: "1.7.0"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/scripts/akc
+++ b/scripts/akc
@@ -27,7 +27,7 @@ readonly SECURITY_BIN="/usr/bin/security"
 # `VAR=keychain://KEY` 行を捏造して任意の Keychain 値を解決・export させられる。
 readonly ENV_BIN="/usr/bin/env"
 
-VERSION="1.6.1"
+VERSION="1.7.0"
 
 usage() {
     cat <<'USAGE'


### PR DESCRIPTION
## 概要

#153 で追加した発見キーの override テストが並列実行下で **クラッシュ(signal 6 / NSInvalidArgumentException)** する問題を修正する。**テスト専用の変更**（アプリ本体は無変更）。

## 原因

swift-testing は既定で並列実行。追加テストがグローバル `CustomKeyStore.shared`（`.standard` UserDefaults）を `setCategoryOverride`/`addCategory` で**書き換え**、他テストの `.shared` 読取（`APIKey.categoryColor`/`builtinCategory` 解決）と競合 → 内部辞書が破損し `-[NSIndirectTaggedPointerString objectForKey:]` でクラッシュ。タイミング依存でフルスイート時のみ発現（PR #154 の CI や単独実行では通過していた）。

## 修正

既存 `ModelTests` と同じ `isolatedStore()`（分離 UserDefaults スイート）パターンを `KeyListViewModelTests` に導入し、`save`/`addCategory` を呼ぶテストは分離 `CustomKeyStore` を `KeyListViewModel`/`KeyEditorViewModel` に注入。**`.shared` への書き込みを撤廃**し、全テストで `.shared` を読み取り専用にして競合を解消。永続化の検証は注入ストアの `overriddenCategory` で行う。

## 動作確認

- フルスイート `swift test` を **3 回連続実行 → 165/165 passed**（クラッシュ再現せず）
- アプリ本体（production コード）は無変更 → 配布済み v1.7.0 dmg に影響なし

## 補足
テスト隔離の根本（`APIKey` が `CustomKeyStore.shared` を直接参照）は別途リファクタ余地あり（本 PR は競合の実害を除去）。