### PR TITLE
feat(cli): akc set 新規作成時に GUI アプリを Keychain ACL の信頼リストへ追加 (-T)

### DIFF
--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -136,8 +136,13 @@ export async function setKey(name, value, { manual = false } = {}) {
   }
   const service = manual ? name : GUI_SERVICE;
   const hex = Buffer.from(value, 'utf8').toString('hex');
+  // -T: 作成時に GUI アプリと security CLI を Keychain ACL の信頼リストへ登録する
+  // (issue #162)。これが無いと GUI からの読み取りがアイテムごとに承認ダイアログを
+  // 出す。-T は作成時のみ有効で、-U による既存アイテム更新では ACL は変わらない。
+  // パスのアプリが存在しない環境でも add 自体は成功する。
   const r = await securityInteractive(
-    `add-generic-password -U -s "${service}" -a "${name}" -X ${hex}`
+    `add-generic-password -U -s "${service}" -a "${name}" ` +
+      `-T "/Applications/AI KeyChain.app" -T "/usr/bin/security" -X ${hex}`
   );
   if (!r.ok) {
     // `security -i` stderr could in principle echo the command line (which

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -6,7 +6,7 @@ import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { mkdtemp, writeFile, chmod, access } from 'node:fs/promises';
+import { mkdtemp, writeFile, chmod, access, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -28,6 +28,7 @@ if [ "$cmd" = "-i" ]; then
   read -r line
   case "$line" in
     add-generic-password*-a\\ \\"NEW_KEY\\"*-X\\ *)
+      printf '%s' "$line" > "$state_dir/line-NEW_KEY"
       printf '%s' "\${line##* }" | xxd -r -p > "$state_dir/state-NEW_KEY"
       exit 0 ;;
     add-generic-password*-a\\ \\"ECHO_KEY\\"*-X\\ *)
@@ -235,6 +236,23 @@ test('set stores a piped value via security -i stdin, never argv', async () => {
   assert.equal(r.code, 0);
   assert.match(r.stdout, /✅ Saved NEW_KEY/);
   assert.doesNotMatch(r.stdout, /piped-secret/);
+});
+
+test('set pre-trusts the GUI app and security CLI in the item ACL (-T, issue #162)', async () => {
+  // stub が記録した -i コマンドラインを検証する。
+  // -T が無いと GUI からの読み取りがアイテムごとに承認ダイアログを出す。
+  const r = await pExecFile(
+    'bash',
+    ['-c', `echo "trust-check" | ${process.execPath} ${AKC} set NEW_KEY`],
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
+  ).then(
+    (r) => ({ code: 0, ...r }),
+    (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
+  );
+  assert.equal(r.code, 0);
+  const line = await readFile(join(stubDir, 'line-NEW_KEY'), 'utf8');
+  assert.match(line, /-T "\/Applications\/AI KeyChain\.app"/);
+  assert.match(line, /-T "\/usr\/bin\/security"/);
 });
 
 test('set failure stderr never leaks the value, even when security echoes the command', async () => {


### PR DESCRIPTION
Closes #162

## 変更

`akc set`（npm CLI / MCP `set_secret` も同経路）の `security add-generic-password` に `-T "/Applications/AI KeyChain.app" -T "/usr/bin/security"` を付与。CLI で新規作成したキーを GUI（キー共有エクスポート等）が読む際の、アイテム単位の承認ダイアログを根本から無くす。

- `-T` は**作成時のみ**有効。`-U` 更新では既存アイテムの ACL は変わらない（既存キーは初回アクセス時に「常に許可」で個別移行）
- GUI アプリ未インストール環境でも add は成功する（パスは信頼リストに載るだけ）
- macOS の partition list により署名済みアプリからのアクセスで引き続き確認が出るケースは v1.8.0（Developer ID 署名版）実機で要検証 → 結果次第で `set-generic-password-partition-list` 対応を追補

## テスト

- `node --test test/cli.test.js`: **17/17 パス**(新規: stub が記録した `-i` コマンドラインに `-T` 2 件が含まれることを検証)
- `test/mcp.test.js` のタイムアウトはクリーンな main でも再現する既知の環境問題で、本変更とは無関係

## 備考

マージ後は npm 再 publish が必要(`aikeychain@0.5.2`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vYEmXxxBRyjwYZoy7u5pq