### PR TITLE
feat(release): Developer ID 署名 + Apple 公証による正式配布 (v1.8.0)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,5 +1,20 @@
 name: auto-release
 
+# CHANGELOG.md の更新を検知して GitHub Release（リリースノートのみ）を作成する。
+#
+# 配布 DMG はこの workflow では作らない: 出荷物は Developer ID 署名 + Apple 公証が
+# 必須で、証明書と notarytool クレデンシャルはローカルにしかないため
+# （CI への導入は #159）、`scripts/build-release.sh` で生成して Release に添付する。
+# 以前この workflow が生成していた ad-hoc 署名 DMG は、未署名アーティファクトを
+# 「リリース」として公開してしまうため廃止した（#114 / PR #165 レビュー指摘）。
+#
+# 正しいリリース手順（docs/dev/packaging.md 参照）:
+#   1. リリースブランチで scripts/build-release.sh を実行（署名 + 公証 + 検証）
+#   2. `gh release create vX.Y.Z` で公証済み DMG + .sha256 を添付して発行
+#   3. CHANGELOG を含む PR を main へマージ（この workflow は既存 release を検出してスキップ）
+# 手順 2 を忘れてマージした場合はノートのみの release が作られるので、後から
+# `gh release upload vX.Y.Z build/AIKeyChain-vX.Y.Z.dmg{,.sha256}` で添付する。
+
 on:
   push:
     branches:
@@ -12,8 +27,8 @@ permissions:
 
 jobs:
   release:
-    runs-on: macos-14
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
@@ -48,7 +63,7 @@ jobs:
             echo "Release $TAG already exists. Skipping."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Release $TAG not found. Will create."
+            echo "Release $TAG not found. Will create (notes only)."
           fi
 
       - name: Extract CHANGELOG entry
@@ -71,140 +86,22 @@ jobs:
             BODY="Release v${VERSION} (auto-generated — no CHANGELOG entry found)"
           fi
 
-          echo "$BODY" > /tmp/release-body.md
+          {
+            echo "$BODY"
+            echo ""
+            echo "> ⚠️ 配布 DMG は未添付です。\`scripts/build-release.sh\` で公証済み DMG を生成し、"
+            echo "> \`gh release upload ${{ steps.version.outputs.tag }} build/AIKeyChain-v${VERSION}.dmg build/AIKeyChain-v${VERSION}.dmg.sha256\` で添付してください。"
+          } > /tmp/release-body.md
 
-      - name: Build release binary
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          swift build -c release
-
-      - name: Create .app bundle with icon
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          APP="build/AI KeyChain.app/Contents"
-
-          mkdir -p "$APP/MacOS" "$APP/Resources"
-          cp .build/release/AIkeychain "$APP/MacOS/AI KeyChain"
-          cp -R .build/release/AIkeychain_AIkeychain.bundle "$APP/Resources/"
-
-          # Info.plist
-          cat > "$APP/Info.plist" << PLIST
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>CFBundleName</key>
-              <string>AI KeyChain</string>
-              <key>CFBundleDisplayName</key>
-              <string>AI KeyChain</string>
-              <key>CFBundleIdentifier</key>
-              <string>com.aieo.aikeychain</string>
-              <key>CFBundleVersion</key>
-              <string>${VERSION}</string>
-              <key>CFBundleShortVersionString</key>
-              <string>${VERSION}</string>
-              <key>CFBundlePackageType</key>
-              <string>APPL</string>
-              <key>CFBundleExecutable</key>
-              <string>AI KeyChain</string>
-              <key>CFBundleIconFile</key>
-              <string>AppIcon</string>
-              <key>LSMinimumSystemVersion</key>
-              <string>14.0</string>
-              <key>LSUIElement</key>
-              <false/>
-              <key>NSHighResolutionCapable</key>
-              <true/>
-              <key>CFBundleInfoDictionaryVersion</key>
-              <string>6.0</string>
-          </dict>
-          </plist>
-          PLIST
-
-          # .icns 生成
-          SRC="AIkeychain/Resources/Assets.xcassets/AppIcon.appiconset"
-          ICONSET="/tmp/AppIcon.iconset"
-          mkdir -p "$ICONSET"
-          cp "$SRC/icon_16x16.png"     "$ICONSET/icon_16x16.png"
-          cp "$SRC/icon_32x32.png"     "$ICONSET/icon_16x16@2x.png"
-          cp "$SRC/icon_32x32.png"     "$ICONSET/icon_32x32.png"
-          cp "$SRC/icon_64x64.png"     "$ICONSET/icon_32x32@2x.png"
-          cp "$SRC/icon_128x128.png"   "$ICONSET/icon_128x128.png"
-          cp "$SRC/icon_256x256.png"   "$ICONSET/icon_128x128@2x.png"
-          cp "$SRC/icon_256x256.png"   "$ICONSET/icon_256x256.png"
-          cp "$SRC/icon_512x512.png"   "$ICONSET/icon_256x256@2x.png"
-          cp "$SRC/icon_512x512.png"   "$ICONSET/icon_512x512.png"
-          cp "$SRC/icon_1024x1024.png" "$ICONSET/icon_512x512@2x.png"
-          iconutil -c icns "$ICONSET" -o "$APP/Resources/AppIcon.icns"
-
-          # Ad-hoc 署名 (+ Hardened Runtime: defense-in-depth against
-          # DYLD_INSERT_LIBRARIES injection / debugger attach into a process
-          # that holds decrypted secrets in memory. See #114.)
-          codesign --force --deep --options runtime --sign - "build/AI KeyChain.app"
-
-      - name: Verify code signature and Hardened Runtime flag
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          APP="build/AI KeyChain.app"
-
-          # 署名そのものが壊れていないか
-          codesign --verify --deep --strict "$APP"
-
-          # Hardened Runtime フラグが実際に付与されているか検証
-          # (付与に失敗した署名をサイレントに出荷しないためのゲート)
-          if codesign -dvvv "$APP" 2>&1 | grep -qE 'flags=.*runtime'; then
-            echo "Hardened Runtime flag confirmed on $APP"
-          else
-            echo "ERROR: Hardened Runtime flag missing on $APP" >&2
-            codesign -dvvv "$APP" 2>&1 || true
-            exit 1
-          fi
-
-      - name: Install create-dmg
-        if: steps.check.outputs.exists == 'false'
-        run: brew install create-dmg
-
-      - name: Create graphical DMG
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          APP="build/AI KeyChain.app/Contents"
-
-          create-dmg \
-            --volname "AI KeyChain" \
-            --volicon "$APP/Resources/AppIcon.icns" \
-            --window-pos 200 120 \
-            --window-size 660 400 \
-            --icon-size 120 \
-            --icon "AI KeyChain.app" 160 185 \
-            --hide-extension "AI KeyChain.app" \
-            --app-drop-link 500 185 \
-            --no-internet-enable \
-            "build/AIKeyChain-v${VERSION}.dmg" \
-            "build/AI KeyChain.app"
-
-      - name: Compute DMG checksum
-        if: steps.check.outputs.exists == 'false'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          cd build
-          shasum -a 256 "AIKeyChain-v${VERSION}.dmg" > "AIKeyChain-v${VERSION}.dmg.sha256"
-          cat "AIKeyChain-v${VERSION}.dmg.sha256"
-
-      - name: Create GitHub Release
+      - name: Create GitHub Release (notes only)
         if: steps.check.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
 
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes-file /tmp/release-body.md \
-            "build/AIKeyChain-v${VERSION}.dmg#AIKeyChain-v${VERSION}.dmg" \
-            "build/AIKeyChain-v${VERSION}.dmg.sha256#AIKeyChain-v${VERSION}.dmg.sha256"
+            --notes-file /tmp/release-body.md
 
-          echo "Release $TAG created with DMG + checksum attached."
+          echo "Release $TAG created (notes only — attach the notarized DMG via scripts/build-release.sh + gh release upload)."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ All notable changes to AI KeyChain are documented in this file.
 
 ### Changed
 - **README のインストール手順** — 公証済み配布に伴い、`xattr -dr com.apple.quarantine` による Gatekeeper 回避手順を撤廃（EN/JA）。チェックサム検証は完全性チェックとして継続、真正性は署名 + 公証で保証 (#114)
-- **`docs/dev/packaging.md`** — ad-hoc 署名手順を Developer ID + 公証フローに全面更新。正典レシピをローカル `scripts/build-release.sh` に変更（CI の ad-hoc DMG はフォールバック）
+- **`docs/dev/packaging.md`** — ad-hoc 署名手順を Developer ID + 公証フローに全面更新。正典レシピをローカル `scripts/build-release.sh` に変更
+- **auto-release CI** — ad-hoc 署名 DMG の生成・添付を廃止（未署名アーティファクトを「リリース」として公開しないため）。CI はリリースノートのみ作成し、DMG は `scripts/build-release.sh` で生成して添付する。CI での Developer ID 署名は #159
+
+### Upgrade note
+- **v1.7.x 以前からのアップデート時、初回のみ Keychain の承認ダイアログがキーごとに再表示されます**。署名が ad-hoc から Developer ID に変わり、既存 Keychain アイテムの ACL から見て「別のアプリ」になるためです。各ダイアログで「常に許可」を選べば、以後はアプリを更新しても再承認は発生しません（署名 ID が Team `34J49FY7U7` で安定するため）
 
 ## npm `aikeychain@0.5.1` - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to AI KeyChain are documented in this file.
 
+## [1.8.0] - 2026-08-12
+
+### Added
+- **Developer ID 署名 + Apple 公証（Notarization）による正式配布** — 配布 DMG と .app を Developer ID Application 証明書（Team `34J49FY7U7`）+ Hardened Runtime（`--options runtime --timestamp`）で署名し、Apple 公証 + staple 済みで配布。Gatekeeper 警告なしでそのままインストール・起動できる。Hardened Runtime により `DYLD_INSERT_LIBRARIES` 注入やデバッガアタッチからシークレット保持プロセスを防御 (#34, #114)
+- **`scripts/build-release.sh`** — ビルド → .app バンドル → Developer ID 署名 → .app 公証/staple → DMG 作成 → DMG 署名/公証/staple → `spctl` 検証 → SHA-256 生成までを全自動化するリリーススクリプト
+
+### Changed
+- **README のインストール手順** — 公証済み配布に伴い、`xattr -dr com.apple.quarantine` による Gatekeeper 回避手順を撤廃（EN/JA）。チェックサム検証は完全性チェックとして継続、真正性は署名 + 公証で保証 (#114)
+- **`docs/dev/packaging.md`** — ad-hoc 署名手順を Developer ID + 公証フローに全面更新。正典レシピをローカル `scripts/build-release.sh` に変更（CI の ad-hoc DMG はフォールバック）
+
 ## npm `aikeychain@0.5.1` - 2026-07-09
 
 Republish carrying fixes merged to `main` after the `0.5.0` release.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,9 @@ Download the latest release from [Releases](https://github.com/aieo-product/AIke
 
 1. **Verify the download's checksum** — see [Verify your download](#verify-your-download) below.
 2. Open the DMG and drag **AI KeyChain.app** to **Applications**
-3. Run the following command to trust the app (required before first launch):
+3. Launch the app — no extra steps needed.
 
-```bash
-xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
-```
-
-> **Note:** This app is not yet notarized with the Apple Developer Program, so macOS Gatekeeper quarantines it on download (tracking: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)). The command above removes the quarantine attribute so the app can launch without a security warning. **Never run this with `sudo`** — removing a quarantine attribute never requires root, and running it as root only widens the blast radius if the downloaded file were ever tampered with.
+> **Note:** Since v1.8.0, releases are signed with a Developer ID certificate (Team `34J49FY7U7`), notarized by Apple, and stapled, so Gatekeeper accepts the app without any manual `xattr` workaround. If macOS still warns that the app is damaged or from an unidentified developer, you are likely holding a pre-1.8.0 build — download the latest release instead of bypassing Gatekeeper. You can verify the signature with `spctl --assess --type execute -vv "/Applications/AI KeyChain.app"`.
 
 ### Verify your download
 
@@ -75,7 +71,7 @@ shasum -a 256 "AIKeyChain-vX.Y.Z.dmg"
 # compare the printed hash against the value in AIKeyChain-vX.Y.Z.dmg.sha256 from the same release
 ```
 
-> **Note:** The `.sha256` file is hosted in the same GitHub Release as the DMG, so this is a **download-integrity check only** — it catches corrupted downloads or a tampered mirror, but an attacker who can replace the release asset could also replace the checksum. It is **not** a substitute for code signing / notarization (tracking: [#114](https://github.com/aieo-product/AIkeychain/issues/114)).
+> **Note:** The `.sha256` file is hosted in the same GitHub Release as the DMG, so this is a **download-integrity check only** — it catches corrupted downloads or a tampered mirror. Authenticity is guaranteed by the Developer ID signature and Apple notarization (since v1.8.0), which Gatekeeper verifies automatically.
 
 ### Build from Source
 
@@ -251,13 +247,9 @@ AI 開発では多数の API キーを扱います。多くの開発者はこれ
 
 1. **ダウンロードのチェックサムを検証してください**（下記「ダウンロードの検証」参照）。
 2. DMG を開き、**AI KeyChain.app** を **Applications** フォルダにドラッグ
-3. 初回起動前に以下のコマンドを実行してアプリを信頼させてください:
+3. そのまま起動できます — 追加の手順は不要です。
 
-```bash
-xattr -dr com.apple.quarantine "/Applications/AI KeyChain.app"
-```
-
-> **注意:** Apple Developer Program 未登録のため（トラッキング: [#114](https://github.com/aieo-product/AIkeychain/issues/114), [#34](https://github.com/aieo-product/AIkeychain/issues/34)）、macOS Gatekeeper がダウンロード時に quarantine（検疫）属性を付与します。上記コマンドはその検疫属性を削除し、警告なしで起動できるようにします。**`sudo` は絶対に付けないでください** — 検疫属性の削除に root 権限は不要であり、`sudo` を付けると万一ダウンロードしたファイルが改ざんされていた場合の被害が拡大するだけです。
+> **注意:** v1.8.0 以降のリリースは Developer ID 証明書（Team `34J49FY7U7`）で署名し、Apple の公証（Notarization）+ staple 済みのため、Gatekeeper の警告なしでそのまま起動できます。「壊れているため開けません」「開発元を確認できません」と表示される場合は v1.8.0 より前のビルドを使っている可能性が高いので、Gatekeeper を回避せず最新リリースをダウンロードし直してください。署名は `spctl --assess --type execute -vv "/Applications/AI KeyChain.app"` で確認できます。
 
 #### ダウンロードの検証
 
@@ -274,7 +266,7 @@ shasum -a 256 "AIKeyChain-vX.Y.Z.dmg"
 # 出力されたハッシュ値を同リリースの AIKeyChain-vX.Y.Z.dmg.sha256 の値と比較する
 ```
 
-> **注意:** `.sha256` ファイルは DMG と同じ GitHub Release に置かれているため、これは**ダウンロードの完全性チェック**にすぎません（破損したダウンロードやミラーの改ざんは検出できますが、リリース資産を差し替えられる攻撃者はチェックサムも差し替えられます）。コード署名／公証（トラッキング: [#114](https://github.com/aieo-product/AIkeychain/issues/114)）の代替ではありません。
+> **注意:** `.sha256` ファイルは DMG と同じ GitHub Release に置かれているため、これは**ダウンロードの完全性チェック**です（破損したダウンロードやミラーの改ざんを検出）。真正性は v1.8.0 以降の Developer ID 署名 + Apple 公証で保証され、Gatekeeper が自動的に検証します。
 
 #### ソースからビルド
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Download the latest release from [Releases](https://github.com/aieo-product/AIke
 2. Open the DMG and drag **AI KeyChain.app** to **Applications**
 3. Launch the app — no extra steps needed.
 
-> **Note:** Since v1.8.0, releases are signed with a Developer ID certificate (Team `34J49FY7U7`), notarized by Apple, and stapled, so Gatekeeper accepts the app without any manual `xattr` workaround. If macOS still warns that the app is damaged or from an unidentified developer, you are likely holding a pre-1.8.0 build — download the latest release instead of bypassing Gatekeeper. You can verify the signature with `spctl --assess --type execute -vv "/Applications/AI KeyChain.app"`.
+> **Note:** Since v1.8.0, releases are signed with a Developer ID certificate (Team `34J49FY7U7`), notarized by Apple, and stapled, so Gatekeeper accepts the app without any manual `xattr` workaround. If macOS warns that the app is damaged or from an unidentified developer, do **not** bypass Gatekeeper — verify the asset with `spctl --assess --type open --context context:primary-signature -vv AIKeyChain-vX.Y.Z.dmg` (expect `accepted / Notarized Developer ID`) and re-download the latest release.
+>
+> **Upgrading from v1.7.x or earlier:** the signing identity changed from ad-hoc to Developer ID, so macOS asks for Keychain approval once per stored key on first access. Choose **"Always Allow"** — after that, approvals persist across all future updates.
 
 ### Verify your download
 
@@ -71,7 +73,7 @@ shasum -a 256 "AIKeyChain-vX.Y.Z.dmg"
 # compare the printed hash against the value in AIKeyChain-vX.Y.Z.dmg.sha256 from the same release
 ```
 
-> **Note:** The `.sha256` file is hosted in the same GitHub Release as the DMG, so this is a **download-integrity check only** — it catches corrupted downloads or a tampered mirror. Authenticity is guaranteed by the Developer ID signature and Apple notarization (since v1.8.0), which Gatekeeper verifies automatically.
+> **Note:** The `.sha256` file is hosted in the same GitHub Release as the DMG, so this is a **download-integrity check only** — it catches corrupted downloads or a tampered mirror, but an attacker who can replace the release asset could also replace the checksum. Authenticity comes from the Developer ID signature + Apple notarization (v1.8.0+), which Gatekeeper verifies automatically — and which you can check explicitly with `spctl --assess --type open --context context:primary-signature -vv <dmg>`. An asset that fails that check is not an official build, whatever its checksum says.
 
 ### Build from Source
 
@@ -249,7 +251,9 @@ AI 開発では多数の API キーを扱います。多くの開発者はこれ
 2. DMG を開き、**AI KeyChain.app** を **Applications** フォルダにドラッグ
 3. そのまま起動できます — 追加の手順は不要です。
 
-> **注意:** v1.8.0 以降のリリースは Developer ID 証明書（Team `34J49FY7U7`）で署名し、Apple の公証（Notarization）+ staple 済みのため、Gatekeeper の警告なしでそのまま起動できます。「壊れているため開けません」「開発元を確認できません」と表示される場合は v1.8.0 より前のビルドを使っている可能性が高いので、Gatekeeper を回避せず最新リリースをダウンロードし直してください。署名は `spctl --assess --type execute -vv "/Applications/AI KeyChain.app"` で確認できます。
+> **注意:** v1.8.0 以降のリリースは Developer ID 証明書（Team `34J49FY7U7`）で署名し、Apple の公証（Notarization）+ staple 済みのため、Gatekeeper の警告なしでそのまま起動できます。「壊れているため開けません」「開発元を確認できません」と表示された場合は **Gatekeeper を回避せず**、`spctl --assess --type open --context context:primary-signature -vv AIKeyChain-vX.Y.Z.dmg` で資産を検証（`accepted / Notarized Developer ID` が正）した上で最新リリースを取り直してください。
+>
+> **v1.7.x 以前からのアップデート:** 署名が ad-hoc から Developer ID に変わったため、初回アクセス時に保存済みキーごとの Keychain 承認ダイアログが一度だけ表示されます。**「常に許可」**を選べば、以後のアップデートでは再承認は発生しません。
 
 #### ダウンロードの検証
 
@@ -266,7 +270,7 @@ shasum -a 256 "AIKeyChain-vX.Y.Z.dmg"
 # 出力されたハッシュ値を同リリースの AIKeyChain-vX.Y.Z.dmg.sha256 の値と比較する
 ```
 
-> **注意:** `.sha256` ファイルは DMG と同じ GitHub Release に置かれているため、これは**ダウンロードの完全性チェック**です（破損したダウンロードやミラーの改ざんを検出）。真正性は v1.8.0 以降の Developer ID 署名 + Apple 公証で保証され、Gatekeeper が自動的に検証します。
+> **注意:** `.sha256` ファイルは DMG と同じ GitHub Release に置かれているため、これは**ダウンロードの完全性チェック**です（破損やミラー改ざんは検出できますが、リリース資産を差し替えられる攻撃者はチェックサムも差し替えられます）。真正性は v1.8.0 以降の Developer ID 署名 + Apple 公証が担い、Gatekeeper が自動検証します。`spctl --assess --type open --context context:primary-signature -vv <dmg>` で明示的に確認でき、この検証を通らない資産はチェックサムが合っていても公式ビルドではありません。
 
 #### ソースからビルド
 

--- a/docs/dev/packaging.md
+++ b/docs/dev/packaging.md
@@ -28,9 +28,11 @@ VERSION=1.8.0 scripts/build-release.sh  # バージョン明示
 - **notarytool のキーチェーンプロファイル**が登録済みであること（初回のみ）
   ```bash
   xcrun notarytool store-credentials AIKC_NOTARY \
-    --apple-id <Apple ID> --team-id <TEAM_ID> --password <App用パスワード>
+    --apple-id <Apple ID> --team-id <TEAM_ID>
   ```
-  App 用パスワードは https://account.apple.com → サインインとセキュリティ → App 用パスワード で生成。値は Keychain に保存され、ファイルには残らない。
+  App 用パスワードは https://account.apple.com → サインインとセキュリティ → App 用パスワード で生成し、
+  **`--password` は付けずに実行して対話プロンプトで入力する**（argv に渡すとシェル履歴・`ps` に残る）。
+  値は Keychain に保存され、ファイルには残らない。
 
 ## 手順
 
@@ -128,9 +130,20 @@ v1.8.0 以降の出荷物は **Developer ID Application 証明書 + Hardened Run
 ::: warning 正典レシピはローカルの `scripts/build-release.sh`
 公証には Developer ID 証明書と notarytool クレデンシャルが必要なため、
 **出荷 DMG はローカルで `scripts/build-release.sh` により生成する**。
-CI（`.github/workflows/auto-release.yml`）の ad-hoc 署名 DMG はフォールバック
-（署名済みリリースが既に存在する場合はスキップされる）。CI への Developer ID
-署名導入は別 issue でトラッキング。
+CI（`.github/workflows/auto-release.yml`）は**リリースノートのみ**を作成し、
+DMG は一切生成しない（未署名アーティファクトを「リリース」として公開しないため）。
+CI への Developer ID 署名導入は #159 でトラッキング。
+:::
+
+::: danger リリースの順序（必須）
+**公証済み DMG 付きの Release を発行してから、CHANGELOG を含む PR を main にマージする。**
+
+1. リリースブランチで `scripts/build-release.sh` を実行
+2. `gh release create vX.Y.Z --target <ブランチHEAD> ... build/AIKeyChain-vX.Y.Z.dmg build/AIKeyChain-vX.Y.Z.dmg.sha256`
+3. PR をマージ（auto-release は既存 Release を検出してスキップ）
+
+逆順でマージすると auto-release がノートのみの Release を先に作る。その場合は
+`gh release upload vX.Y.Z build/AIKeyChain-vX.Y.Z.dmg{,.sha256}` で後から添付する。
 :::
 
 ```bash
@@ -228,6 +241,13 @@ xcrun stapler validate "build/AIKeyChain-v${VERSION}.dmg"
 shasum -a 256 "build/AIKeyChain-v${VERSION}.dmg" \
   | tee "build/AIKeyChain-v${VERSION}.dmg.sha256"
 ```
+
+::: warning リリースごとの実機起動テスト（必須）
+`spctl` は Gatekeeper 判定しか見ない。**リリースごとに生成 DMG からアプリを実際に
+インストール・起動し、主要機能（キー一覧表示・Proxy モードの upstream TLS 接続）を
+確認すること**。Hardened Runtime + entitlements の組み合わせ不備は起動時にしか
+発現しない。
+:::
 
 ### 10. インストール
 

--- a/docs/dev/packaging.md
+++ b/docs/dev/packaging.md
@@ -1,6 +1,17 @@
 # パッケージング手順
 
-AI KeyChain のビルドからグラフィカル DMG 配布までの手順。
+AI KeyChain のビルドから **Developer ID 署名 + Apple 公証済み** DMG 配布までの手順。
+
+::: tip 全自動スクリプト
+以下の全手順は `scripts/build-release.sh` にまとまっています。前提条件を満たしていれば:
+
+```bash
+scripts/build-release.sh                # project.yml の MARKETING_VERSION でビルド
+VERSION=1.8.0 scripts/build-release.sh  # バージョン明示
+```
+
+以降の節は各ステップの解説です。
+:::
 
 ## 前提条件
 
@@ -8,6 +19,18 @@ AI KeyChain のビルドからグラフィカル DMG 配布までの手順。
 - Swift 5.9+ / Xcode 15+
 - `create-dmg` (`brew install create-dmg`)
 - アプリアイコン PNG が `AIkeychain/Resources/Assets.xcassets/AppIcon.appiconset/` に配置済み
+- **Developer ID Application 証明書**がログインキーチェーンにあること
+  ```bash
+  security find-identity -v -p codesigning
+  # → "Developer ID Application: <NAME> (<TEAM_ID>)" が表示されること
+  ```
+  無い場合: Xcode → Settings → Accounts → チーム選択 → Manage Certificates → 「+」→ Developer ID Application（Account Holder 権限が必要）
+- **notarytool のキーチェーンプロファイル**が登録済みであること（初回のみ）
+  ```bash
+  xcrun notarytool store-credentials AIKC_NOTARY \
+    --apple-id <Apple ID> --team-id <TEAM_ID> --password <App用パスワード>
+  ```
+  App 用パスワードは https://account.apple.com → サインインとセキュリティ → App 用パスワード で生成。値は Keychain に保存され、ファイルには残らない。
 
 ## 手順
 
@@ -95,23 +118,24 @@ cp "$SRC/icon_1024x1024.png" "$ICONSET/icon_512x512@2x.png"
 iconutil -c icns "$ICONSET" -o "$APP_DIR/Resources/AppIcon.icns"
 ```
 
-### 5. Ad-hoc コード署名
+### 5. Developer ID 署名（Hardened Runtime）
 
-Developer ID がない場合の署名（「壊れているため開けません」エラーを防止）。
+v1.8.0 以降の出荷物は **Developer ID Application 証明書 + Hardened Runtime** で署名する。
+`--options runtime` は公証の必須条件であり、`DYLD_INSERT_LIBRARIES` による dylib 注入や
+デコード済みシークレットを保持するプロセスへのデバッガアタッチへの防御にもなる（#114）。
 **Proxy モードの outbound TLS 接続には network entitlements が必須。**
 
-::: warning 正典レシピは CI 側
-実際に出荷されるアーティファクトは **CI（`.github/workflows/auto-release.yml`）が生成する DMG** であり、
-CI の ad-hoc 署名は **network entitlements を付けていない**。この §5 の手動署名（entitlements 付き）は
-ローカル動作確認用であり、出荷物とは署名内容が異なる。**Hardened Runtime の実機起動テストは
-必ず CI 生成物（Release にアップロードされた DMG）に対して行うこと**。
-Proxy モードの upstream TLS 挙動は entitlements の有無で変わるため、手動署名版で
-「動いた／動かない」を CI 生成物の判断材料にしないこと。
+::: warning 正典レシピはローカルの `scripts/build-release.sh`
+公証には Developer ID 証明書と notarytool クレデンシャルが必要なため、
+**出荷 DMG はローカルで `scripts/build-release.sh` により生成する**。
+CI（`.github/workflows/auto-release.yml`）の ad-hoc 署名 DMG はフォールバック
+（署名済みリリースが既に存在する場合はスキップされる）。CI への Developer ID
+署名導入は別 issue でトラッキング。
 :::
 
 ```bash
-# network entitlements を作成（初回のみ）
-cat > /tmp/aikeychain.entitlements << 'ENTITLEMENTS'
+# network entitlements を作成
+cat > build/aikeychain.entitlements << 'ENTITLEMENTS'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -124,11 +148,14 @@ cat > /tmp/aikeychain.entitlements << 'ENTITLEMENTS'
 </plist>
 ENTITLEMENTS
 
-# entitlements 付きで署名 (+ Hardened Runtime: DYLD_INSERT_LIBRARIES 注入や
-# デコード済みシークレットを保持するプロセスへのデバッガアタッチへの防御。#114)
-codesign --force --deep --options runtime --sign - \
-  --entitlements /tmp/aikeychain.entitlements \
+# Developer ID + Hardened Runtime + secure timestamp で署名
+codesign --force --options runtime --timestamp \
+  --entitlements build/aikeychain.entitlements \
+  --sign "Developer ID Application" \
   "build/AI KeyChain.app"
+
+# 検証
+codesign --verify --deep --strict "build/AI KeyChain.app"
 ```
 
 ::: warning entitlements なしの場合
@@ -136,15 +163,23 @@ codesign --force --deep --options runtime --sign - \
 API 呼び出しがタイムアウトします（Standard / Secret Reference モードは影響なし）。
 :::
 
-::: warning Hardened Runtime + Ad-hoc 署名について
-Hardened Runtime の library validation は、Ad-hoc 署名との組み合わせで
-署名されていないサードパーティ dylib の読み込みに影響する可能性がある。
-本アプリはシステムフレームワークと自前の SwiftPM コードのみをリンクしているため
-基本的に問題ないはずだが、**CI では実機起動確認ができないため、リリースごとに
-実機でアプリを起動して動作確認すること**（#114 フォローアップ）。
-:::
+### 6. .app の公証 + staple
 
-### 6. グラフィカル DMG 作成
+DMG から取り出した .app 単体でも（オフライン環境含め）Gatekeeper を通すため、
+.app 自体を公証してチケットを staple する。
+
+```bash
+ditto -c -k --keepParent "build/AI KeyChain.app" "build/AI KeyChain.zip"
+xcrun notarytool submit "build/AI KeyChain.zip" \
+  --keychain-profile AIKC_NOTARY --wait
+xcrun stapler staple "build/AI KeyChain.app"
+rm "build/AI KeyChain.zip"
+```
+
+`--wait` は公証完了までブロックする（通常 1〜5 分）。ステータスが `Invalid` の場合は
+`xcrun notarytool log <submission-id> --keychain-profile AIKC_NOTARY` で理由を確認する。
+
+### 7. グラフィカル DMG 作成
 
 `create-dmg` を使ってアプリアイコン + Applications ドラッグリンク付きのインストーラーを作成。
 
@@ -169,19 +204,46 @@ brew install create-dmg
 ```
 :::
 
-### 7. インストール
+### 8. DMG の署名 + 公証 + staple
 
 ```bash
-# DMG を開く
-open build/AIKeyChain-v${VERSION}.dmg
+codesign --force --timestamp --sign "Developer ID Application" \
+  "build/AIKeyChain-v${VERSION}.dmg"
 
-# AI KeyChain.app を Applications にドラッグ
-
-# Gatekeeper の検疫属性を削除 (署名なしの場合)
-xattr -cr /Applications/AI\ KeyChain.app
+xcrun notarytool submit "build/AIKeyChain-v${VERSION}.dmg" \
+  --keychain-profile AIKC_NOTARY --wait
+xcrun stapler staple "build/AIKeyChain-v${VERSION}.dmg"
 ```
 
+### 9. 検証とチェックサム
+
+```bash
+# Gatekeeper 通過を確認（"accepted" / "Notarized Developer ID" が出ること）
+spctl --assess --type execute -vv "build/AI KeyChain.app"
+spctl --assess --type open --context context:primary-signature -vv \
+  "build/AIKeyChain-v${VERSION}.dmg"
+xcrun stapler validate "build/AIKeyChain-v${VERSION}.dmg"
+
+# リリースに添付する SHA-256 チェックサム
+shasum -a 256 "build/AIKeyChain-v${VERSION}.dmg" \
+  | tee "build/AIKeyChain-v${VERSION}.dmg.sha256"
+```
+
+### 10. インストール
+
+```bash
+# DMG を開く → AI KeyChain.app を Applications にドラッグ
+open build/AIKeyChain-v${VERSION}.dmg
+```
+
+公証 + staple 済みのため、quarantine 属性の手動削除（`xattr`）は**不要**。
+
 ## ワンライナー (全手順)
+
+**`scripts/build-release.sh` を使うこと**（上記手順 1〜9 を全自動化、公証込み）。
+
+<details>
+<summary>旧・ad-hoc 署名ワンライナー（Developer ID 証明書がない環境向け、参考）</summary>
 
 ```bash
 VERSION="1.1.0" && \
@@ -239,6 +301,8 @@ create-dmg \
 echo "Done: build/AIKeyChain-v${VERSION}.dmg"
 ```
 
+</details>
+
 ## トラブルシューティング
 
 | 問題 | 解決策 |
@@ -246,6 +310,7 @@ echo "Done: build/AIKeyChain-v${VERSION}.dmg"
 | 型推論エラー (`unable to type-check`) | 複雑な SwiftUI ビューを `@ViewBuilder` プロパティに分割 |
 | アプリアイコンが表示されない | `.icns` が `Resources/` にあるか確認。`swift build` は xcassets をコンパイルしない |
 | DMG がフォルダ表示になる | `hdiutil` ではなく `create-dmg` を使う |
-| 「壊れているため開けません」 | `xattr -cr /Applications/AI\ KeyChain.app` を実行 |
-| 「信頼されていない開発元」 | システム設定 → プライバシーとセキュリティ → 「このまま開く」 |
+| 「壊れているため開けません」「信頼されていない開発元」 | v1.8.0 以降の公証済み DMG では発生しない。表示されたら旧ビルドの可能性 — 最新リリースを取り直す。ローカルの ad-hoc ビルド検証時のみ `xattr -cr`（`sudo` 不要） |
+| `codesign` が identity を見つけられない | `security find-identity -v -p codesigning` で Developer ID 証明書の有無を確認（前提条件参照） |
+| 公証が `Invalid` になる | `xcrun notarytool log <submission-id> --keychain-profile AIKC_NOTARY` で原因確認。Hardened Runtime（`--options runtime`）と secure timestamp（`--timestamp`）の欠落が典型 |
 | `create-dmg` が見つからない | `brew install create-dmg` |

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aieo.aikeychain
-        MARKETING_VERSION: "1.7.0"
+        MARKETING_VERSION: "1.8.0"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/scripts/akc
+++ b/scripts/akc
@@ -27,7 +27,7 @@ readonly SECURITY_BIN="/usr/bin/security"
 # `VAR=keychain://KEY` 行を捏造して任意の Keychain 値を解決・export させられる。
 readonly ENV_BIN="/usr/bin/env"
 
-VERSION="1.7.0"
+VERSION="1.8.0"
 
 usage() {
     cat <<'USAGE'

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -19,13 +19,38 @@ cd "$(dirname "$0")/.."
 VERSION="${VERSION:-$(sed -n 's/.*MARKETING_VERSION: "\(.*\)"/\1/p' project.yml)}"
 SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-AIKC_NOTARY}"
+# 署名後に実際の TeamIdentifier を照合する（複数の Developer ID 証明書がある環境で
+# 別チームの identity が拾われた成果物を出荷しないためのゲート）
+EXPECTED_TEAM_ID="${EXPECTED_TEAM_ID:-34J49FY7U7}"
+
+# sed が空を返しても set -u では検出できないため明示ガード
+# （project.yml の MARKETING_VERSION がクォート無し等の形式ずれでも起こる）
+if [ -z "$VERSION" ]; then
+    echo "ERROR: VERSION を解決できません。project.yml の MARKETING_VERSION（\"X.Y.Z\" 形式）を確認するか、VERSION=X.Y.Z を指定してください。" >&2
+    exit 1
+fi
 
 APP_NAME="AI KeyChain"
 APP="build/${APP_NAME}.app"
 CONTENTS="$APP/Contents"
 DMG="build/AIKeyChain-v${VERSION}.dmg"
 
-echo "==> Version: $VERSION / Identity: $SIGN_IDENTITY / Profile: $NOTARY_PROFILE"
+echo "==> Version: $VERSION / Identity: $SIGN_IDENTITY / Team: $EXPECTED_TEAM_ID / Profile: $NOTARY_PROFILE"
+
+# notarytool submit --wait は status=Invalid でも exit 0 を返すため、
+# 出力から Accepted を明示検証する。失敗時は log コマンドを案内して止める。
+notarize() {
+    local artifact="$1"
+    local out
+    out=$(xcrun notarytool submit "$artifact" --keychain-profile "$NOTARY_PROFILE" --wait 2>&1 | tee /dev/stderr) || true
+    if ! printf '%s' "$out" | grep -q "status: Accepted"; then
+        local sub_id
+        sub_id=$(printf '%s' "$out" | grep -m1 '  id: ' | awk '{print $2}')
+        echo "ERROR: 公証が Accepted になりませんでした（$artifact）。" >&2
+        echo "  原因確認: xcrun notarytool log ${sub_id:-<submission-id>} --keychain-profile $NOTARY_PROFILE" >&2
+        exit 1
+    fi
+}
 
 # 1. Release ビルド
 swift build -c release
@@ -91,10 +116,16 @@ codesign --force --options runtime --timestamp \
   --sign "$SIGN_IDENTITY" "$APP"
 codesign --verify --deep --strict "$APP"
 
+# 期待した Team の identity で署名されたかを照合
+if ! codesign -dvv "$APP" 2>&1 | grep -q "TeamIdentifier=${EXPECTED_TEAM_ID}"; then
+    echo "ERROR: TeamIdentifier が ${EXPECTED_TEAM_ID} ではありません。SIGN_IDENTITY / キーチェーンの証明書を確認してください。" >&2
+    codesign -dvv "$APP" 2>&1 | grep TeamIdentifier >&2 || true
+    exit 1
+fi
+
 # 6. .app を公証 → staple(DMG から取り出した後もオフラインで Gatekeeper を通すため)
 ditto -c -k --keepParent "$APP" "build/${APP_NAME}.zip"
-xcrun notarytool submit "build/${APP_NAME}.zip" \
-  --keychain-profile "$NOTARY_PROFILE" --wait
+notarize "build/${APP_NAME}.zip"
 xcrun stapler staple "$APP"
 rm "build/${APP_NAME}.zip"
 
@@ -112,7 +143,7 @@ create-dmg \
   "$DMG" "$APP"
 
 codesign --force --timestamp --sign "$SIGN_IDENTITY" "$DMG"
-xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+notarize "$DMG"
 xcrun stapler staple "$DMG"
 
 # 8. 検証

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# AI KeyChain — Developer ID 署名 + 公証済み DMG ビルドスクリプト
+#
+# 前提:
+#   - Developer ID Application 証明書がログインキーチェーンにあること
+#     (security find-identity -v -p codesigning で確認)
+#   - notarytool のキーチェーンプロファイルが登録済みであること
+#     (xcrun notarytool store-credentials <profile> --apple-id ... --team-id ... --password <app用パスワード>)
+#   - create-dmg (brew install create-dmg)
+#
+# 使い方:
+#   scripts/build-release.sh                    # project.yml の MARKETING_VERSION を使用
+#   VERSION=1.8.0 scripts/build-release.sh      # バージョン明示
+#   SIGN_IDENTITY / NOTARY_PROFILE も環境変数で上書き可
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${VERSION:-$(sed -n 's/.*MARKETING_VERSION: "\(.*\)"/\1/p' project.yml)}"
+SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-AIKC_NOTARY}"
+
+APP_NAME="AI KeyChain"
+APP="build/${APP_NAME}.app"
+CONTENTS="$APP/Contents"
+DMG="build/AIKeyChain-v${VERSION}.dmg"
+
+echo "==> Version: $VERSION / Identity: $SIGN_IDENTITY / Profile: $NOTARY_PROFILE"
+
+# 1. Release ビルド
+swift build -c release
+
+# 2. .app バンドル作成
+rm -rf build && mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
+cp .build/release/AIkeychain "$CONTENTS/MacOS/$APP_NAME"
+cp -R .build/release/AIkeychain_AIkeychain.bundle "$CONTENTS/Resources/"
+
+# 3. Info.plist
+cat > "$CONTENTS/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>${APP_NAME}</string>
+    <key>CFBundleDisplayName</key><string>${APP_NAME}</string>
+    <key>CFBundleIdentifier</key><string>com.aieo.aikeychain</string>
+    <key>CFBundleVersion</key><string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleExecutable</key><string>${APP_NAME}</string>
+    <key>CFBundleIconFile</key><string>AppIcon</string>
+    <key>LSMinimumSystemVersion</key><string>14.0</string>
+    <key>LSUIElement</key><false/>
+    <key>NSHighResolutionCapable</key><true/>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+</dict>
+</plist>
+PLIST
+
+# 4. アプリアイコン (.icns) — swift build は xcassets をコンパイルしない
+SRC="AIkeychain/Resources/Assets.xcassets/AppIcon.appiconset"
+ICONSET="build/AppIcon.iconset"
+rm -rf "$ICONSET" && mkdir -p "$ICONSET"
+cp "$SRC/icon_16x16.png"     "$ICONSET/icon_16x16.png"
+cp "$SRC/icon_32x32.png"     "$ICONSET/icon_16x16@2x.png"
+cp "$SRC/icon_32x32.png"     "$ICONSET/icon_32x32.png"
+cp "$SRC/icon_64x64.png"     "$ICONSET/icon_32x32@2x.png"
+cp "$SRC/icon_128x128.png"   "$ICONSET/icon_128x128.png"
+cp "$SRC/icon_256x256.png"   "$ICONSET/icon_128x128@2x.png"
+cp "$SRC/icon_256x256.png"   "$ICONSET/icon_256x256.png"
+cp "$SRC/icon_512x512.png"   "$ICONSET/icon_256x256@2x.png"
+cp "$SRC/icon_512x512.png"   "$ICONSET/icon_512x512.png"
+cp "$SRC/icon_1024x1024.png" "$ICONSET/icon_512x512@2x.png"
+iconutil -c icns "$ICONSET" -o "$CONTENTS/Resources/AppIcon.icns"
+
+# 5. Developer ID 署名 (Hardened Runtime + timestamp)
+#    network entitlements は Proxy モードの outbound TLS / ローカル listener に必須
+cat > build/aikeychain.entitlements << 'ENTITLEMENTS'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.network.client</key><true/>
+    <key>com.apple.security.network.server</key><true/>
+</dict>
+</plist>
+ENTITLEMENTS
+
+codesign --force --options runtime --timestamp \
+  --entitlements build/aikeychain.entitlements \
+  --sign "$SIGN_IDENTITY" "$APP"
+codesign --verify --deep --strict "$APP"
+
+# 6. .app を公証 → staple(DMG から取り出した後もオフラインで Gatekeeper を通すため)
+ditto -c -k --keepParent "$APP" "build/${APP_NAME}.zip"
+xcrun notarytool submit "build/${APP_NAME}.zip" \
+  --keychain-profile "$NOTARY_PROFILE" --wait
+xcrun stapler staple "$APP"
+rm "build/${APP_NAME}.zip"
+
+# 7. グラフィカル DMG 作成 → 署名 → 公証 → staple
+create-dmg \
+  --volname "$APP_NAME" \
+  --volicon "$CONTENTS/Resources/AppIcon.icns" \
+  --window-pos 200 120 \
+  --window-size 660 400 \
+  --icon-size 120 \
+  --icon "${APP_NAME}.app" 160 185 \
+  --hide-extension "${APP_NAME}.app" \
+  --app-drop-link 500 185 \
+  --no-internet-enable \
+  "$DMG" "$APP"
+
+codesign --force --timestamp --sign "$SIGN_IDENTITY" "$DMG"
+xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+xcrun stapler staple "$DMG"
+
+# 8. 検証
+echo "==> Gatekeeper assessment"
+spctl --assess --type execute -vv "$APP"
+spctl --assess --type open --context context:primary-signature -vv "$DMG"
+xcrun stapler validate "$DMG"
+
+# 9. チェックサム公開用
+shasum -a 256 "$DMG" | tee "${DMG}.sha256"
+
+echo "Done: $DMG"


### PR DESCRIPTION
Closes #34, Closes #114

## 変更

- **`scripts/build-release.sh`**: ビルド → .app バンドル → Developer ID 署名（Hardened Runtime + timestamp）→ .app 公証/staple → DMG 作成 → DMG 署名/公証/staple → `spctl` 検証 → SHA-256 生成を全自動化
- **`docs/dev/packaging.md`**: ad-hoc 手順を Developer ID + 公証フローに全面更新（正典レシピをローカルスクリプトに変更、CI は フォールバック → #159）
- **README (EN/JA)**: `xattr` による Gatekeeper 回避手順を撤廃。公証済みのためそのまま起動可能に
- **バージョン 1.8.0**: `project.yml` / `scripts/akc` / CHANGELOG

## 検証（実施済み）

このブランチの状態から `scripts/build-release.sh` を実行し、v1.8.0 DMG を生成:

- .app 公証: **Accepted**（submission `a11a6423-…`）
- DMG 公証: **Accepted**（submission `c41d0a04-…`）+ staple 済み
- `spctl --assess`: .app / DMG とも `accepted — source=Notarized Developer ID (Team 34J49FY7U7)`
- 生成物は Release v1.8.0 に添付

## 備考

- Release v1.8.0 を先に発行済みのため、マージ時の auto-release は既存リリース検出でスキップされる
- CI での Developer ID 署名（Secrets 化）は #159 でトラッキング

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vYEmXxxBRyjwYZoy7u5pq