### PR TITLE
fix(gui): GUI 値編集による CLI 管理キーの毒化を防止する fail-closed hotfix (v1.8.1)

### DIFF
--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -124,6 +124,10 @@ final class KeychainService: KeychainServiceProtocol {
             var deleteQuery = appQuery
             // 削除がプロンプト/フリーズしないよう UI を明示禁止（旧 ad-hoc 署名などの
             // 別 partition アイテムでも SecurityAgent を起動させず即座に失敗させる）。
+            // deprecation 警告が出るが、推奨代替の LAContext.interactionNotAllowed は
+            // **Keychain の partition/パスワードプロンプトを抑止しない**ことを実測済み
+            // （#177 の E6-1。生体認証系 UI 専用）。よって意図的に kSecUseAuthenticationUIFail
+            // を使う。
             deleteQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
             let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
             switch deleteStatus {

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -8,6 +8,11 @@ enum KeychainError: LocalizedError {
     case invalidData
     case invalidAccount
     case interactionRequired
+    /// The item is owned by `/usr/bin/security` (registered via the `akc` CLI or a
+    /// manual `security add-generic-password`). An in-process edit from the GUI would
+    /// silently poison it — leaving `akc run` unable to read it — so we fail closed
+    /// and tell the user to edit it via the CLI instead. See issue #177.
+    case cliManaged(String)
     case unexpectedStatus(OSStatus)
 
     var errorDescription: String? {
@@ -17,6 +22,7 @@ enum KeychainError: LocalizedError {
         case .invalidData: "Failed to encode/decode the key data."
         case .invalidAccount: "Invalid key name. Use only letters, digits and underscores (must start with a letter or underscore)."
         case .interactionRequired: "Keychain access requires user interaction (consent or unlock), which is unavailable in this context."
+        case .cliManaged(let account): "\(account) is managed by the akc CLI. Change its value from the terminal with: akc set \(account)"
         case .unexpectedStatus(let status): "Keychain error: \(status)"
         }
     }
@@ -67,6 +73,23 @@ final class KeychainService: KeychainServiceProtocol {
         ]
     }
 
+    /// アイテムの存在を **属性のみ** で確認する（値を読まない）。
+    /// 値読み取り (kSecReturnData) は security 所有アイテムで ~7 秒ブロックして
+    /// SecurityAgent を起動する（#177 の実測 E6-1）が、属性照会はプロンプト無しで
+    /// 安全（loadKeys と同じ）。
+    private func itemExists(matching base: [String: Any]) throws -> Bool {
+        var query = base
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnAttributes as String] = true
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess: return true
+        case errSecItemNotFound: return false
+        default: throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
     func save(value: String, for account: String) throws {
         // シンクでの一元検証: どの ingress（手動エディタ / .env インポート /
         // キー共有インポート）経由でも、シェル export に安全な名前だけを Keychain に
@@ -79,42 +102,38 @@ final class KeychainService: KeychainServiceProtocol {
             throw KeychainError.invalidData
         }
 
-        // Try to update first
-        let query = baseQuery(for: account)
-        let attributes: [String: Any] = [
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-        ]
+        // #177: 既存アイテムへの in-process SecItemUpdate は、そのアイテムが
+        // /usr/bin/security 所有（`akc set` / 手動 security 登録）の場合、**無音で成功
+        // するのに所有権を毒化し、以後 `akc run` がヘッドレスで読めなくなる**（実測 E6-4）。
+        // よって update を使わず、SecItemDelete を「プロンプトを出さない所有権プローブ」
+        // として使う: 削除に失敗（-25244 等）= security 所有 → in-process 編集は毒化する
+        // ので **アイテムを変更せず fail-closed**（`akc set` で編集するよう案内）。
+        // 削除成功 = GUI 所有 → 新しい値で再作成する。
+        let appQuery = baseQuery(for: account)
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-
-        if updateStatus == errSecItemNotFound {
-            // GUI スキームに無く manual スキームにだけ存在するキーは、manual 側を
-            // その場で更新する（CLI の setKey と同じ）。GUI 側へ新規追加してしまうと
-            // 旧値を持つ manual アイテムが残り、manual を直接読む既存の .zshrc 行や
-            // スクリプトがローテート前の値を使い続ける (#163 レビュー指摘)。
-            if EnvVarName.isManualSchemeCandidate(account) {
-                let manualStatus = SecItemUpdate(manualQuery(for: account) as CFDictionary,
-                                                 attributes as CFDictionary)
-                if manualStatus == errSecSuccess {
-                    return
-                }
-                guard manualStatus == errSecItemNotFound else {
-                    throw KeychainError.unexpectedStatus(manualStatus)
-                }
+        if try itemExists(matching: appQuery) {
+            let deleteStatus = SecItemDelete(appQuery as CFDictionary)
+            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                // -25244（GUI からは削除できない = security 所有）を含む全ての失敗で
+                // 毒化を避けるため fail-closed。アイテムは未変更（削除に失敗している）。
+                throw KeychainError.cliManaged(account)
             }
+        } else if EnvVarName.isManualSchemeCandidate(account),
+                  try itemExists(matching: manualQuery(for: account)) {
+            // manual スキーム (service=<KEY>) のキーは実運用上ほぼ security 所有
+            // （手動 security 登録 / `akc set` の manual 更新）。in-process 編集は毒化する
+            // ため、削除を試みず fail-closed（#163 の manual in-place 更新を置き換える）。
+            throw KeychainError.cliManaged(account)
+        }
 
-            // どちらにも無い新規キーは GUI スキームに追加
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        // 新規キー、または GUI 所有アイテムの削除成功後 → GUI スキームに追加
+        var addQuery = appQuery
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-            guard addStatus == errSecSuccess else {
-                throw KeychainError.unexpectedStatus(addStatus)
-            }
-        } else if updateStatus != errSecSuccess {
-            throw KeychainError.unexpectedStatus(updateStatus)
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(addStatus)
         }
     }
 
@@ -252,14 +271,22 @@ final class MockKeychainService: KeychainServiceProtocol {
     var store: [String: String] = [:]
     /// manual スキーム (service=<キー名>) 相当のアイテム (#160)
     var manualStore: [String: String] = [:]
+    /// `/usr/bin/security` 所有（`akc set` / 手動登録）を模すアカウント。実装では
+    /// in-process SecItemDelete が -25244 で失敗するケース。save() は fail-closed する (#177)。
+    var securityOwnedAccounts: Set<String> = []
 
     func save(value: String, for account: String) throws {
-        // 実装と同じ意味論: manual にだけ存在するキーは manual 側を in-place 更新
-        if store[account] == nil, manualStore[account] != nil {
-            manualStore[account] = value
-        } else {
-            store[account] = value
+        // #177: 実装と同じ fail-closed 契約。
+        // (1) security 所有アイテム（app スキームだが CLI/手動作成）→ in-process 編集は
+        //     毒化するため cliManaged で拒否。
+        // (2) manual スキームにのみ存在するキーも実運用上 security 所有 → 拒否。
+        if securityOwnedAccounts.contains(account) {
+            throw KeychainError.cliManaged(account)
         }
+        if store[account] == nil, manualStore[account] != nil {
+            throw KeychainError.cliManaged(account)
+        }
+        store[account] = value
     }
 
     func retrieve(for account: String) throws -> String? {

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -73,16 +73,14 @@ final class KeychainService: KeychainServiceProtocol {
         ]
     }
 
-    /// アイテムの存在を **属性のみ** で確認する（値を読まない）。
+    /// アイテムの存在を **値を読まずに** 確認する（データも属性も返さない）。
     /// 値読み取り (kSecReturnData) は security 所有アイテムで ~7 秒ブロックして
-    /// SecurityAgent を起動する（#177 の実測 E6-1）が、属性照会はプロンプト無しで
-    /// 安全（loadKeys と同じ）。
+    /// SecurityAgent を起動する（#177 の実測 E6-1）が、存在照会はプロンプト無しで
+    /// 安全（exists(for:) と同じ）。
     private func itemExists(matching base: [String: Any]) throws -> Bool {
         var query = base
         query[kSecMatchLimit as String] = kSecMatchLimitOne
-        query[kSecReturnAttributes as String] = true
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
         switch status {
         case errSecSuccess: return true
         case errSecItemNotFound: return false
@@ -105,18 +103,38 @@ final class KeychainService: KeychainServiceProtocol {
         // #177: 既存アイテムへの in-process SecItemUpdate は、そのアイテムが
         // /usr/bin/security 所有（`akc set` / 手動 security 登録）の場合、**無音で成功
         // するのに所有権を毒化し、以後 `akc run` がヘッドレスで読めなくなる**（実測 E6-4）。
-        // よって update を使わず、SecItemDelete を「プロンプトを出さない所有権プローブ」
-        // として使う: 削除に失敗（-25244 等）= security 所有 → in-process 編集は毒化する
-        // ので **アイテムを変更せず fail-closed**（`akc set` で編集するよう案内）。
-        // 削除成功 = GUI 所有 → 新しい値で再作成する。
+        // よって update を使わず、SecItemDelete を「所有権プローブ」として使う:
+        // 削除に失敗（-25244 = security 所有、または UIFail による -25308 = 要対話）なら
+        // in-process 編集は毒化する／できないので **アイテムを変更せず fail-closed**
+        // （`akc set` で編集するよう案内）。削除成功 = GUI 所有 → 新しい値で再作成する。
+        //
+        // 既知の限界（いずれも恒久対応は #167 の v2 namespace / security 経路書込）:
+        //  1. delete→add は原子的でない。GUI 所有アイテムで delete 成功直後に add が
+        //     （キーチェーンのロック等で）失敗すると旧値を失う窓がある。add を 1 回
+        //     リトライして緩和し、それでも失敗したら旧値の消失を隠さず throw する。
+        //  2. `security add -A`（allow-all-apps ACL）で作られたキーは GUI からの
+        //     SecItemDelete が成功してしまい、GUI 所有として再作成され所有権が再毒化
+        //     し得る（akc set のデフォルト ACL では発生しない稀ケース）。
+        //  3. save() はメインスレッドで呼ばれる。SecItemDelete は E6-3 で security 所有
+        //     アイテムに対し即座に -25244（プロンプト無し）を返すことを実測済みで、
+        //     さらに下記 UIFail で対話を明示禁止するため UI フリーズは起きない。
         let appQuery = baseQuery(for: account)
 
         if try itemExists(matching: appQuery) {
-            let deleteStatus = SecItemDelete(appQuery as CFDictionary)
-            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
-                // -25244（GUI からは削除できない = security 所有）を含む全ての失敗で
-                // 毒化を避けるため fail-closed。アイテムは未変更（削除に失敗している）。
+            var deleteQuery = appQuery
+            // 削除がプロンプト/フリーズしないよう UI を明示禁止（旧 ad-hoc 署名などの
+            // 別 partition アイテムでも SecurityAgent を起動させず即座に失敗させる）。
+            deleteQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
+            let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
+            switch deleteStatus {
+            case errSecSuccess, errSecItemNotFound:
+                break // GUI 所有 → 下で再作成
+            case errSecInteractionNotAllowed, errSecAuthFailed, -25244:
+                // security 所有 / 要対話 = in-process 編集不可 → 毒化させず fail-closed。
                 throw KeychainError.cliManaged(account)
+            default:
+                // ロック等の想定外失敗も、アイテムは未変更なので安全側に倒す。
+                throw KeychainError.unexpectedStatus(deleteStatus)
             }
         } else if EnvVarName.isManualSchemeCandidate(account),
                   try itemExists(matching: manualQuery(for: account)) {
@@ -131,7 +149,11 @@ final class KeychainService: KeychainServiceProtocol {
         addQuery[kSecValueData as String] = data
         addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        var addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        if addStatus != errSecSuccess {
+            // delete 後の add 失敗（旧値消失の窓）を緩和するため 1 回だけ再試行。
+            addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        }
         guard addStatus == errSecSuccess else {
             throw KeychainError.unexpectedStatus(addStatus)
         }

--- a/AIkeychain/Views/EnvImportView.swift
+++ b/AIkeychain/Views/EnvImportView.swift
@@ -393,11 +393,12 @@ struct EnvImportView: View {
             Spacer()
 
             if let result = importResult {
-                Image(systemName: result.failed == 0 ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                let clean = result.failed == 0 && result.cliManaged.isEmpty
+                Image(systemName: clean ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
                     .font(.system(size: 48))
-                    .foregroundStyle(result.failed == 0 ? AppColors.configured : .orange)
+                    .foregroundStyle(clean ? AppColors.configured : .orange)
 
-                Text(result.failed == 0 ? "Import Complete!" : "Partially Imported")
+                Text(clean ? "Import Complete!" : "Partially Imported")
                     .font(.system(size: 18, weight: .semibold))
 
                 VStack(spacing: 8) {
@@ -416,6 +417,12 @@ struct EnvImportView: View {
                     if result.failed > 0 {
                         ResultRow(icon: "xmark.circle.fill", color: .red,
                                   text: "\(result.failed) keys failed")
+                    }
+                    if !result.cliManaged.isEmpty {
+                        ResultRow(icon: "terminal.fill", color: .orange,
+                                  text: L10n.s(
+                                    ja: "\(result.cliManaged.count) 件は akc CLI 管理のため未更新。ターミナルで更新してください: akc set \(result.cliManaged.joined(separator: " / akc set "))",
+                                    en: "\(result.cliManaged.count) key(s) are managed by the akc CLI and were not updated. Update them in a terminal: akc set \(result.cliManaged.joined(separator: " / akc set "))"))
                     }
                 }
                 .padding(.horizontal, 40)
@@ -448,6 +455,7 @@ struct EnvImportView: View {
         var failed = 0
         var removedFromZshrc = 0
         var savedKeys: [String] = []
+        var cliManagedKeys: [String] = []
 
         for entry in selected {
             let account = entry.matchedService?.envVarName ?? entry.key
@@ -455,6 +463,11 @@ struct EnvImportView: View {
                 try KeychainService.shared.save(value: entry.value, for: account)
                 saved += 1
                 savedKeys.append(account)
+            } catch KeychainError.cliManaged {
+                // #177: このキーは akc CLI 管理（security 所有）。GUI から上書きすると
+                // 毒化するため save() が fail-closed した。古い値のまま黙って放置せず、
+                // 「akc set で更新して」と明示する。
+                cliManagedKeys.append(account)
             } catch {
                 failed += 1
             }
@@ -471,7 +484,8 @@ struct EnvImportView: View {
         }
 
         let skipped = parsedEntries.count - selected.count
-        importResult = ImportResult(saved: saved, skipped: skipped, failed: failed, removedFromZshrc: removedFromZshrc)
+        importResult = ImportResult(saved: saved, skipped: skipped, failed: failed,
+                                    removedFromZshrc: removedFromZshrc, cliManaged: cliManagedKeys)
     }
 
     private func isAIKey(_ key: String) -> Bool {
@@ -593,6 +607,9 @@ private struct ImportResult {
     let skipped: Int
     let failed: Int
     let removedFromZshrc: Int
+    /// #177: akc CLI 管理（security 所有）で GUI から上書きできなかったキー。
+    /// 古い値のまま残るため `akc set <KEY>` での更新を案内する。
+    var cliManaged: [String] = []
 }
 
 struct EnvEntry: Identifiable {

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -541,6 +541,8 @@ private struct ReceiveTab: View {
     @State private var importCount = 0
     /// #177: 受信キーのうちローカルが akc CLI 管理で上書きできなかった件数。
     @State private var cliManagedCount = 0
+    /// #177: cliManaged 以外の理由（keychain ロック等）で保存できなかった件数。
+    @State private var failedCount = 0
     @State private var errorMessage: String?
     // 復号時に envVarName で重複排除（先勝ち）した表示用エントリ（finding 10）と、
     // その時点で一度だけ Keychain を引いて数えた上書き件数（finding 11）。
@@ -872,6 +874,16 @@ private struct ReceiveTab: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 24)
             }
+            if failedCount > 0 {
+                Label(L10n.s(
+                    ja: "\(failedCount) 件は保存に失敗しました（Keychain のロック等）。もう一度お試しください。",
+                    en: "\(failedCount) key(s) failed to save (e.g. a locked Keychain). Please try again."),
+                      systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
 
             Button {
                 NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Applications/Utilities/Keychain Access.app"))
@@ -937,6 +949,7 @@ private struct ReceiveTab: View {
         }
         var count = 0
         var cliManaged: [String] = []
+        var failed: [String] = []
         for entry in entries {
             // 外部由来の .aikeychain ファイルの envVarName は信頼できない。
             // シェル export に不正な名前はスキップする（KeychainService.save 側でも
@@ -950,12 +963,14 @@ private struct ReceiveTab: View {
                 // GUI から上書きすると毒化するため fail-closed。黙って捨てず件数を surface。
                 cliManaged.append(entry.envVarName)
             } catch {
-                // その他の失敗も黙って捨てない
-                cliManaged.append(entry.envVarName)
+                // その他の失敗（keychain ロック等）は cliManaged と混同せず別集計。
+                // 「akc set で更新」の誤案内で本当の失敗を隠さないため（codex 指摘）。
+                failed.append(entry.envVarName)
             }
         }
         importCount = count
         cliManagedCount = cliManaged.count
+        failedCount = failed.count
         imported = true
         onImport() // キーリストを更新
     }

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -539,6 +539,8 @@ private struct ReceiveTab: View {
     @State private var overwriteConfirmed = false          // 既存上書きの明示承諾
     @State private var imported = false
     @State private var importCount = 0
+    /// #177: 受信キーのうちローカルが akc CLI 管理で上書きできなかった件数。
+    @State private var cliManagedCount = 0
     @State private var errorMessage: String?
     // 復号時に envVarName で重複排除（先勝ち）した表示用エントリ（finding 10）と、
     // その時点で一度だけ Keychain を引いて数えた上書き件数（finding 11）。
@@ -859,6 +861,17 @@ private struct ReceiveTab: View {
             Text(L10n.s(ja: "Keychain に保存されました", en: "Saved to Keychain"))
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
+            if cliManagedCount > 0 {
+                // #177: akc CLI 管理キーは GUI から上書きできない（毒化防止）
+                Label(L10n.s(
+                    ja: "\(cliManagedCount) 件は akc CLI 管理のため未更新です。ターミナルで `akc set <KEY>` で更新してください。",
+                    en: "\(cliManagedCount) key(s) are managed by the akc CLI and were not updated. Update them with `akc set <KEY>` in a terminal."),
+                      systemImage: "terminal.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
 
             Button {
                 NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Applications/Utilities/Keychain Access.app"))
@@ -923,16 +936,26 @@ private struct ReceiveTab: View {
             tofu.confirm(fp)
         }
         var count = 0
+        var cliManaged: [String] = []
         for entry in entries {
             // 外部由来の .aikeychain ファイルの envVarName は信頼できない。
             // シェル export に不正な名前はスキップする（KeychainService.save 側でも
             // 弾かれるが、ここで明示的に skip して意図を明確化 / #116）。
             guard EnvVarName.isValid(entry.envVarName) else { continue }
-            if let _ = try? KeychainService.shared.save(value: entry.value, for: entry.envVarName) {
+            do {
+                try KeychainService.shared.save(value: entry.value, for: entry.envVarName)
                 count += 1
+            } catch KeychainError.cliManaged {
+                // #177: 受信キーと同名のローカルキーが akc CLI 管理（security 所有）。
+                // GUI から上書きすると毒化するため fail-closed。黙って捨てず件数を surface。
+                cliManaged.append(entry.envVarName)
+            } catch {
+                // その他の失敗も黙って捨てない
+                cliManaged.append(entry.envVarName)
             }
         }
         importCount = count
+        cliManagedCount = cliManaged.count
         imported = true
         onImport() // キーリストを更新
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to AI KeyChain are documented in this file.
 
+## [1.8.1] - 2026-08-13
+
+### Fixed
+- **GUI 値編集による CLI 管理キーの毒化を防止（データ整合性）** — `akc set` または手動 `security add-generic-password` で登録した `/usr/bin/security` 所有キーの値を GUI で編集すると、in-process `SecItemUpdate` が**無音で成功しつつ所有権を破壊し、以後 `akc run` がヘッドレスでそのキーを読めなくなる**（プロンプト待ちでハング）実機確認済みの不具合を修正。GUI は該当キーの in-process 上書きをやめ、`SecItemDelete` を「プロンプトを出さない所有権プローブ」に用いて、CLI 管理キーは**値を変更せず fail-closed** し「`akc set <KEY>` で更新してください」と案内する。GUI 所有キーは従来どおり編集可能 (#177)
+- **.env インポート / キー共有インポートでの取りこぼしを可視化** — 上記により CLI 管理キーはインポート時に上書きされないため、「N 件は akc CLI 管理のため未更新（`akc set` で更新）」を結果画面に明示。古い/失効済みの値がサイレントに残る問題を解消 (#177)
+
 ## [1.8.0] - 2026-08-12
 
 ### Added

--- a/Tests/AIkeychainTests/KeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/KeychainServiceTests.swift
@@ -49,4 +49,37 @@ struct KeychainServiceTests {
         let result = try service.retrieve(for: "KEY")
         #expect(result == "new")
     }
+
+    // MARK: - #177: 毒化防止（fail-closed）
+
+    @Test("Editing a CLI/security-owned key fails closed instead of poisoning (#177)")
+    func securityOwnedEditFailsClosed() throws {
+        let service = MockKeychainService()
+        // `akc set` 等で作られ security 所有になっているキーを模す。
+        service.store["OPENAI_API_KEY"] = "sk-original"
+        service.securityOwnedAccounts.insert("OPENAI_API_KEY")
+
+        #expect(throws: KeychainError.self) {
+            try service.save(value: "sk-overwritten", for: "OPENAI_API_KEY")
+        }
+        // 値は未変更（in-process 編集による毒化が起きない）
+        #expect(service.store["OPENAI_API_KEY"] == "sk-original")
+    }
+
+    @Test("cliManaged error tells the user to use `akc set <KEY>` (#177)")
+    func cliManagedErrorMessage() {
+        let message = KeychainError.cliManaged("OPENAI_API_KEY").errorDescription ?? ""
+        #expect(message.contains("akc set OPENAI_API_KEY"))
+    }
+
+    @Test("A brand-new key and a GUI-owned key still save normally (#177 no regression)")
+    func newAndGuiOwnedStillSave() throws {
+        let service = MockKeychainService()
+        // 新規
+        try service.save(value: "v1", for: "GITHUB_TOKEN")
+        #expect(try service.retrieve(for: "GITHUB_TOKEN") == "v1")
+        // GUI 所有（securityOwned でない）→ 上書き可
+        try service.save(value: "v2", for: "GITHUB_TOKEN")
+        #expect(try service.retrieve(for: "GITHUB_TOKEN") == "v2")
+    }
 }

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -174,18 +174,20 @@ struct KeyListViewModelTests {
         #expect(discovered?.storage == .manual)
     }
 
-    @Test("Saving a manual-only key updates the manual item in place (no GUI shadow copy)")
-    func savingManualKeyUpdatesInPlace() throws {
+    @Test("Editing a manual-only (CLI-managed) key fails closed instead of poisoning (#177)")
+    func savingManualKeyFailsClosed() throws {
         let (vm, mock) = makeSUT()
         let name = uniqueEnvName()
         mock.manualStore[name] = "old-value"
         vm.loadKeys()
-        let discovered = vm.keys.first { $0.envVarName == name }
+        let discovered = try #require(vm.keys.first { $0.envVarName == name })
 
-        try vm.save(value: "new-value", for: discovered!)
-
-        // manual 側が更新され、GUI 側に影のコピーが増えない (#163 レビュー指摘)
-        #expect(mock.manualStore[name] == "new-value")
+        // in-process 編集は security 所有 manual アイテムを毒化するため拒否される。
+        #expect(throws: KeychainError.self) {
+            try vm.save(value: "new-value", for: discovered)
+        }
+        // 値は未変更（毒化も GUI 影コピーも起きない）
+        #expect(mock.manualStore[name] == "old-value")
         #expect(mock.store[name] == nil)
     }
 

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aieo.aikeychain
-        MARKETING_VERSION: "1.8.0"
+        MARKETING_VERSION: "1.8.1"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/scripts/akc
+++ b/scripts/akc
@@ -27,7 +27,7 @@ readonly SECURITY_BIN="/usr/bin/security"
 # `VAR=keychain://KEY` 行を捏造して任意の Keychain 値を解決・export させられる。
 readonly ENV_BIN="/usr/bin/env"
 
-VERSION="1.8.0"
+VERSION="1.8.1"
 
 usage() {
     cat <<'USAGE'

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -116,10 +116,14 @@ codesign --force --options runtime --timestamp \
   --sign "$SIGN_IDENTITY" "$APP"
 codesign --verify --deep --strict "$APP"
 
-# 期待した Team の identity で署名されたかを照合
-if ! codesign -dvv "$APP" 2>&1 | grep -q "TeamIdentifier=${EXPECTED_TEAM_ID}"; then
-    echo "ERROR: TeamIdentifier が ${EXPECTED_TEAM_ID} ではありません。SIGN_IDENTITY / キーチェーンの証明書を確認してください。" >&2
-    codesign -dvv "$APP" 2>&1 | grep TeamIdentifier >&2 || true
+# 期待した Team の identity で署名されたかを照合。
+# 注: `codesign -dvv | grep -q` を直接パイプすると、grep -q がマッチ即座に終了して
+# codesign が SIGPIPE(141) で落ち、pipefail がパイプライン全体を失敗扱いにするため
+# 正しい署名でも誤検知する。先に変数へ捕捉してから照合する。
+CODESIGN_INFO=$(codesign -dvv "$APP" 2>&1)
+ACTUAL_TEAM=$(printf '%s\n' "$CODESIGN_INFO" | sed -n 's/^TeamIdentifier=//p')
+if [ "$ACTUAL_TEAM" != "$EXPECTED_TEAM_ID" ]; then
+    echo "ERROR: TeamIdentifier が ${EXPECTED_TEAM_ID} ではありません（実際: '${ACTUAL_TEAM}'）。SIGN_IDENTITY / キーチェーンの証明書を確認してください。" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Closes #177

## 概要
`akc set` / 手動 `security add-generic-password` で登録した `/usr/bin/security` 所有キーの値を GUI で編集すると、in-process `SecItemUpdate` が**無音で成功しつつ所有権を破壊し、以後 `akc run` がそのキーをヘッドレスで読めなくなる**（実機確認済みの出荷中バグ）。GUI を fail-closed 化して毒化を防ぐ。

## 実測根拠（DevID 実署名・macOS 26.2）
- in-proc `SecItemUpdate`（security 所有）→ 無音成功 **かつ毒化**（以後 `security -w` が rc=124 ハング）
- in-proc `SecItemDelete`（security 所有）→ **-25244 で即失敗**（プロンプト/ハング無し・アイテム未変更）
- 属性のみ照会・GUI 所有アイテムの読み書き削除は無音

## 変更
- `KeychainService.save()`: in-proc `SecItemUpdate` を廃止。既存アイテムは `SecItemDelete`（`kSecUseAuthenticationUIFail` 付き）を所有権プローブに使い、削除失敗（-25244 / authFailed / interactionNotAllowed）= security 所有 → **値を変更せず `cliManaged` で fail-closed**（`akc set <KEY>` を案内）。削除成功 = GUI 所有 → 新値で再作成。manual スキームキーも fail-closed。
- `EnvImportView` / `ShareKeysView`: `cliManaged` を握り潰さず「N 件は akc CLI 管理のため未更新」を UI に明示（stale 値のサイレント放置を解消）。cliManaged と一般失敗を別集計。
- `KeychainError.cliManaged` 追加、Mock に fail-closed 契約、回帰テスト。

## 二段階レビュー
- **codex(solultra)**: 実装生成 + 差分レビュー2ラウンド。P1（delete の UIFail・データ喪失窓・エラー分類・ShareKeys の誤集計）を反映。
- **Fable(15エージェント workflow)**: P1（caller の握り潰し = stale 値サイレント放置）を反映。
- 既知の限界（delete→add 非原子性は1回リトライで緩和・allow-all-apps ACL エッジ）は恒久対応を #167 の v2 namespace 再設計に明記。

## テスト
`swift test`: **175 全パス**（新規: security 所有/manual の編集拒否・値不変・新規/GUI 所有は正常・エラー文言）。

## スコープ外（既存・別対応）
エディタの値 prefill が security 所有キーで ~7秒ハングする件は既存問題で #167(C7)。本 hotfix はデータ破壊（毒化）の防止に限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vYEmXxxBRyjwYZoy7u5pq