### PR TITLE
feat(core): SecurityCLIKeychainService — managed namespace + subprocess 単一経路 (C2 #169)

### DIFF
--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -58,7 +58,9 @@
 		E6EF4BDCA836753730368031 /* AIkeychainApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FBF226CDBB7B16615DB078 /* AIkeychainApp.swift */; };
 		E805C8A422ADCA7B2042DE29 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BBC08B62D864042131E96C /* AppState.swift */; };
 		E963094220E71C64DEA96121 /* FingerprintTOFUStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8C7190C24537528AD2B987 /* FingerprintTOFUStore.swift */; };
+		F0BB7FFD1936E579F9D65861 /* SecurityCLIKeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B529E3962BE2F851B2297B /* SecurityCLIKeychainServiceTests.swift */; };
 		F1FCE802F6B8CD69C82050FD /* CategoryIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5564B99419540E50E1276D79 /* CategoryIcon.swift */; };
+		F600C34E56EF17E276B8E5B8 /* SecurityCLIKeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D2DFA56DC4FD7D699EC36 /* SecurityCLIKeychainService.swift */; };
 		F620D2BC08B405183D3732AB /* AppAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D3DCA2727A4F0E3B73623 /* AppAnimations.swift */; };
 		F76438E441201123E08CCBA2 /* KeyListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2999D8FAA2B2AA1066D5B7 /* KeyListView.swift */; };
 /* End PBXBuildFile section */
@@ -114,6 +116,7 @@
 		86254B995FB20769DA53656A /* KeyListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyListViewModel.swift; sourceTree = "<group>"; };
 		8BAA59605A0988605BDA9071 /* APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKey.swift; sourceTree = "<group>"; };
 		92065103580C94C2BB99FB48 /* CustomKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomKeyStore.swift; sourceTree = "<group>"; };
+		956D2DFA56DC4FD7D699EC36 /* SecurityCLIKeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityCLIKeychainService.swift; sourceTree = "<group>"; };
 		99B69E8B22FA2C8C00A6DF9A /* AppLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguage.swift; sourceTree = "<group>"; };
 		9C17D41EA989227C3858DBEE /* AIkeychain.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AIkeychain.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5AE0FFA12A5A654B81D2DBA /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -123,6 +126,7 @@
 		B76CC5D338AC4C682B18BBA6 /* ProxyRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyRoute.swift; sourceTree = "<group>"; };
 		BBB424D42EDE63D9E03A86DD /* ProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyTests.swift; sourceTree = "<group>"; };
 		CFEC2C4A62A257212BEE4D95 /* SetupManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupManagerTests.swift; sourceTree = "<group>"; };
+		D6B529E3962BE2F851B2297B /* SecurityCLIKeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityCLIKeychainServiceTests.swift; sourceTree = "<group>"; };
 		DDE2E88F59640366B8EE60C8 /* ProxyServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyServer.swift; sourceTree = "<group>"; };
 		E18270833BDFFEACBE8F6B44 /* KeyShareServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyShareServiceTests.swift; sourceTree = "<group>"; };
 		E18E322C52277BDBD022D701 /* SecretHygiene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretHygiene.swift; sourceTree = "<group>"; };
@@ -158,6 +162,7 @@
 				0F4D6C9DC84B322FB385ACE3 /* ModelTests.swift */,
 				BBB424D42EDE63D9E03A86DD /* ProxyTests.swift */,
 				1EDF5F4F543FDCFEAE87669B /* SecretRefTests.swift */,
+				D6B529E3962BE2F851B2297B /* SecurityCLIKeychainServiceTests.swift */,
 				CFEC2C4A62A257212BEE4D95 /* SetupManagerTests.swift */,
 				F69D54AA42B1FDEBB2AD036B /* ViewModelTests.swift */,
 			);
@@ -319,6 +324,7 @@
 				7DF81328B72F2A8A703BEFF2 /* L10n.swift */,
 				DDE2E88F59640366B8EE60C8 /* ProxyServer.swift */,
 				E18E322C52277BDBD022D701 /* SecretHygiene.swift */,
+				956D2DFA56DC4FD7D699EC36 /* SecurityCLIKeychainService.swift */,
 				524109D967A855636B5BECB8 /* SetupManager.swift */,
 				728E72380D1F60902EF105B2 /* ZshrcExporter.swift */,
 			);
@@ -449,6 +455,7 @@
 				1FBDB678ABCDB9503FE0DCEA /* ProxyServer.swift in Sources */,
 				C4C7726A2BDC408D034DC23A /* RecoveryView.swift in Sources */,
 				ADD892CA115969AC2CF3C169 /* SecretHygiene.swift in Sources */,
+				F600C34E56EF17E276B8E5B8 /* SecurityCLIKeychainService.swift in Sources */,
 				47D0324B8366C625BD452CE3 /* ServiceIcon.swift in Sources */,
 				6857A9D9465864324DC7F284 /* ServiceType.swift in Sources */,
 				E60B2BDDB0E9793C2CC58C5C /* SetupManager.swift in Sources */,
@@ -469,6 +476,7 @@
 				CC6B7823B5DCA500A9A20A4D /* ModelTests.swift in Sources */,
 				434F7D7FEE37A6CDED3AD084 /* ProxyTests.swift in Sources */,
 				4013BBEA241CC555169FCF65 /* SecretRefTests.swift in Sources */,
+				F0BB7FFD1936E579F9D65861 /* SecurityCLIKeychainServiceTests.swift in Sources */,
 				63BB58A5661CD588F35B64D7 /* SetupManagerTests.swift in Sources */,
 				30C8DB25105498065C1AF8F5 /* ViewModelTests.swift in Sources */,
 			);
@@ -583,7 +591,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;
@@ -681,7 +689,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;

--- a/AIkeychain/Services/ProxyServer.swift
+++ b/AIkeychain/Services/ProxyServer.swift
@@ -47,7 +47,7 @@ final class ProxyServer {
     /// 差し替えてストリーミング/フレーミングを検証できるようにする。
     private let makeUpstream: (_ host: String) -> NWConnection
 
-    init(keychainService: KeychainServiceProtocol = KeychainService.shared,
+    init(keychainService: KeychainServiceProtocol = SecurityCLIKeychainService.shared,
          keychainTimeout: TimeInterval = 3,
          upstreamTimeout: TimeInterval = 30,
          keychainCooldown: TimeInterval = 10,

--- a/AIkeychain/Services/SecurityCLIKeychainService.swift
+++ b/AIkeychain/Services/SecurityCLIKeychainService.swift
@@ -1,0 +1,330 @@
+import Foundation
+import Security
+
+/// `/usr/bin/security` を単一の作成/更新アイデンティティとする Keychain アクセス層 (#167/#169)。
+///
+/// ## なぜ subprocess か（実測根拠は #168 の E6/S6/S7'/S5）
+/// macOS のヘッドレス読み取りは「復号 trusted-app リスト」かつ「PartitionID リスト」の
+/// 2 重ゲートで、既定では**作成したプロセスだけ**が両方を満たす。GUI が in-process で
+/// 書いたキーは `akc run`（= security CLI）から読めず、逆も然り。よって:
+/// - **書き込みは必ず子プロセス `/usr/bin/security`**（作成者 = security → akc がヘッドレスで読める。S6 で LaunchServices 起動アプリの子でも成立を実証）
+/// - **値の読み取りも subprocess**（security 所有アイテムの in-process 読みは ~7 秒ブロック + SecurityAgent 起動 — E6-1）
+/// - **一覧・存在確認だけは in-process の属性照会**（値を読まなければ所有者に関係なく無音）
+///
+/// ## managed namespace
+/// 書き込み先 service は `com.aieo.aikeychain.managed` に固定。「managed の下のキー =
+/// security が作成」という不変条件により、所有者判別（マーカー等）そのものを不要にする。
+/// 旧 service（com.aieo.aikeychain / manual スキーム）へは一切書かない。
+///
+/// ## セキュリティ規約（#94/#117 踏襲）
+/// - security は**絶対パス**で起動（PATH ハイジャック防止）
+/// - 値は `security -i` の stdin + hex で渡す（argv / 環境変数に露出させない）
+/// - stderr はエラー整形時に hex/値を redact
+final class SecurityCLIKeychainService: KeychainServiceProtocol {
+    static let shared = SecurityCLIKeychainService()
+
+    /// managed namespace（#167 オーナー決定）。旧 com.aieo.aikeychain とは別名にすることで
+    /// 復元/同期/旧アプリ由来の GUI 所有アイテムが混入しても不変条件が壊れない。
+    static let managedService = "com.aieo.aikeychain.managed"
+
+    private let securityBin = "/usr/bin/security"
+    /// subprocess 読み取りの上限。プロンプト待ち等でブロックした子はこれで kill する。
+    /// Proxy の外側タイムアウト(3s)より短くし、permit を先に返せるようにする。
+    var readTimeout: TimeInterval = 2.5
+    var writeTimeout: TimeInterval = 10
+
+    /// テスト専用: stub security への差し替え口。#117 の絶対パス主義を守るため、
+    /// 環境変数ではなくコード（@testable）からのみ変更できる internal プロパティにする。
+    var securityBinOverrideForTesting: String?
+
+    private var effectiveSecurityBin: String { securityBinOverrideForTesting ?? securityBin }
+
+    // MARK: - 直列化・coalescing・quarantine (#169 Proxy ハードニング)
+
+    private let stateLock = NSLock()
+    /// key → 実行中の読み取り。同一キーへの並行読みを 1 本の subprocess に束ねる
+    /// （Proxy への同時リクエストで security を多重 spawn しない）。
+    private var inflightReads: [String: ReadTask] = [:]
+    /// timeout-kill が発生したキーの隔離。TTL まで即時 interactionRequired を返し、
+    /// ダイアログ/spawn の連発を防ぐ。成功した save で解除される。
+    private var quarantinedUntil: [String: Date] = [:]
+    private let quarantineTTL: TimeInterval = 60
+
+    private final class ReadTask {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<String?, Error>?
+    }
+
+    // MARK: - KeychainServiceProtocol
+
+    func save(value: String, for account: String) throws {
+        guard EnvVarName.isValid(account) else {
+            throw KeychainError.invalidAccount
+        }
+        // CLI (cli/src/keychain.js) と同じ制約: 制御文字は `find -w` の読み戻しを
+        // hex 出力に化けさせラウンドトリップを壊すため保存前に拒否する。
+        // （複数行値の許容は C7 #174 で読み書き両側の規約を揃えてから）
+        guard value.range(of: "[\\x00-\\x1f\\x7f]", options: .regularExpression) == nil else {
+            throw KeychainError.invalidData
+        }
+        guard !value.isEmpty else { throw KeychainError.invalidData }
+
+        let hex = value.data(using: .utf8)!.map { String(format: "%02x", $0) }.joined()
+        // -U: 既存アイテムの更新。security 所有アイテムへの -U は所有権・headless
+        // 読み取りを保つことを実測済み（#168 S7'）。
+        let command = "add-generic-password -U -s \"\(Self.managedService)\" -a \"\(account)\" -X \(hex)\n"
+        let result = runSecurity(arguments: ["-i"], stdin: command, timeout: writeTimeout)
+        guard case .exited(let status, _, let stderr) = result, status == 0 else {
+            throw KeychainError.unexpectedStatus(errSecIO).annotated(redact(resultDescription(result, stderr: true)))
+        }
+        _ = stderr
+
+        // 書き込みの読み戻し検証（CLI の setKey と同じ: -U は不整合状態でも成功を
+        // 報告し得るため、実際に保存された値を確認する）
+        guard let readBack = try retrieve(for: account), readBack == value else {
+            throw KeychainError.invalidData
+        }
+
+        // 成功した書き込みは quarantine を解除する
+        stateLock.lock()
+        quarantinedUntil[account] = nil
+        stateLock.unlock()
+    }
+
+    func retrieve(for account: String) throws -> String? {
+        try subprocessRead(account: account, timeout: writeTimeout)
+    }
+
+    func retrieveNoninteractive(for account: String) throws -> String? {
+        // Proxy 経路: quarantine 済みキーは spawn せず即時失敗（fail fast）
+        stateLock.lock()
+        if let until = quarantinedUntil[account], until > Date() {
+            stateLock.unlock()
+            throw KeychainError.interactionRequired
+        }
+        // 同一キーの読みが実行中ならそれに相乗りする（coalescing）
+        if let existing = inflightReads[account] {
+            stateLock.unlock()
+            existing.semaphore.wait()
+            existing.semaphore.signal() // 後続の待ち手にも伝播
+            switch existing.result {
+            case .success(let v): return v
+            case .failure(let e): throw e
+            case nil: throw KeychainError.interactionRequired
+            }
+        }
+        let task = ReadTask()
+        inflightReads[account] = task
+        stateLock.unlock()
+
+        defer {
+            stateLock.lock()
+            inflightReads[account] = nil
+            stateLock.unlock()
+            task.semaphore.signal()
+        }
+
+        do {
+            let value = try subprocessRead(account: account, timeout: readTimeout)
+            task.result = .success(value)
+            return value
+        } catch {
+            if case KeychainError.interactionRequired = error {
+                // timeout-kill（プロンプト待ち相当）→ 隔離してダイアログ/spawn 連発を防ぐ
+                stateLock.lock()
+                quarantinedUntil[account] = Date().addingTimeInterval(quarantineTTL)
+                stateLock.unlock()
+            }
+            task.result = .failure(error)
+            throw error
+        }
+    }
+
+    func delete(for account: String) throws {
+        let result = runSecurity(
+            arguments: ["delete-generic-password", "-s", Self.managedService, "-a", account],
+            stdin: nil, timeout: writeTimeout)
+        switch result {
+        case .exited(0, _, _):
+            return
+        case .exited(44, _, _):
+            return // not found は冪等成功扱い（従来の delete と同じ意味論）
+        case .exited(let status, _, _):
+            throw KeychainError.unexpectedStatus(OSStatus(status))
+        case .timedOut:
+            throw KeychainError.interactionRequired
+        case .failedToLaunch:
+            throw KeychainError.unexpectedStatus(errSecIO)
+        }
+    }
+
+    func exists(for account: String) -> Bool {
+        // 属性のみの in-process 照会（値を読まない = 所有者に関係なく無音）
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.managedService,
+            kSecAttrAccount as String: account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+    }
+
+    func allAccounts() -> [String] {
+        // managed namespace の列挙（in-process 属性照会・無音）
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.managedService,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            return []
+        }
+        var seen = Set<String>()
+        return items.compactMap { item -> String? in
+            guard let acct = item[kSecAttrAccount as String] as? String,
+                  seen.insert(acct).inserted else { return nil }
+            return acct
+        }
+    }
+
+    func manualServices() -> [String] {
+        // managed namespace 移行に伴い manual スキームの発見は廃止 (#167)。
+        // 旧キーは移行アシスタント (C5 #172) の専用導線でのみ扱う。
+        []
+    }
+
+    // MARK: - subprocess 基盤
+
+    private enum RunResult {
+        case exited(Int32, stdout: Data, stderr: Data)
+        case timedOut
+        case failedToLaunch
+    }
+
+    private func subprocessRead(account: String, timeout: TimeInterval) throws -> String? {
+        let result = runSecurity(
+            arguments: ["find-generic-password", "-s", Self.managedService, "-a", account, "-w"],
+            stdin: nil, timeout: timeout)
+        switch result {
+        case .exited(0, let stdout, _):
+            var text = String(data: stdout, encoding: .utf8) ?? ""
+            if text.hasSuffix("\n") { text.removeLast() }
+            // security -w は非 ASCII 値を hex で出力する。保存側（save/akc set）は
+            // hex 入力なので、偶数長 hex + UTF-8 復号可能なら復号を試す。
+            // ASCII のみの実値が hex 文字だけで構成されるケースは save 側の
+            // read-back 検証で弾かれるため実害は限定的（CLI と同じ扱い）。
+            if let decoded = Self.decodeHexIfLikely(text) { text = decoded }
+            return text
+        case .exited(44, _, _):
+            return nil
+        case .exited(let status, _, _):
+            throw KeychainError.unexpectedStatus(OSStatus(status))
+        case .timedOut:
+            // プロンプト待ち等でブロック → kill 済み。呼び出し側の意味論は「要対話」。
+            throw KeychainError.interactionRequired
+        case .failedToLaunch:
+            throw KeychainError.unexpectedStatus(errSecIO)
+        }
+    }
+
+    /// security を絶対パスで起動し、timeout で**プロセスグループごと** SIGKILL する。
+    /// S5 実測: kill 後のセッションはモーダルブロックされず、ゾンビも残らない。
+    private func runSecurity(arguments: [String], stdin: String?, timeout: TimeInterval) -> RunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: effectiveSecurityBin)
+        process.arguments = arguments
+        // 環境は最小化（PATH 固定・DYLD_* 等を渡さない）
+        process.environment = ["PATH": "/usr/bin:/bin"]
+
+        let stdoutPipe = Pipe(), stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
+
+        do { try process.run() } catch { return .failedToLaunch }
+
+        if let stdin {
+            stdinPipe.fileHandleForWriting.write(stdin.data(using: .utf8)!)
+        }
+        stdinPipe.fileHandleForWriting.closeFile()
+
+        // 出力はバックグラウンドで吸い上げる（パイプ詰まりで子が固まらないように）
+        var stdoutData = Data(), stderrData = Data()
+        let ioGroup = DispatchGroup()
+        ioGroup.enter()
+        DispatchQueue.global().async {
+            stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            ioGroup.leave()
+        }
+        ioGroup.enter()
+        DispatchQueue.global().async {
+            stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            ioGroup.leave()
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning && Date() < deadline {
+            usleep(20_000) // 20ms
+        }
+
+        if process.isRunning {
+            // プロセスグループごと SIGKILL（security が子を持つ場合も回収）
+            kill(-process.processIdentifier, SIGKILL)
+            process.terminate()
+            kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit() // reap（ゾンビ防止, S5 実測どおり）
+            _ = ioGroup.wait(timeout: .now() + 1)
+            return .timedOut
+        }
+
+        process.waitUntilExit()
+        _ = ioGroup.wait(timeout: .now() + 2)
+        return .exited(process.terminationStatus, stdout: stdoutData, stderr: stderrData)
+    }
+
+    /// 偶数長の hex 文字列で、かつ UTF-8 として復号できる場合のみ復号して返す。
+    static func decodeHexIfLikely(_ text: String) -> String? {
+        guard !text.isEmpty, text.count % 2 == 0,
+              text.range(of: "^[0-9a-fA-F]+$", options: .regularExpression) != nil else { return nil }
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(text.count / 2)
+        var index = text.startIndex
+        while index < text.endIndex {
+            let next = text.index(index, offsetBy: 2)
+            guard let byte = UInt8(text[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        return String(bytes: bytes, encoding: .utf8)
+    }
+
+    private func resultDescription(_ result: RunResult, stderr: Bool) -> String {
+        switch result {
+        case .exited(let status, _, let err):
+            let msg = stderr ? (String(data: err, encoding: .utf8) ?? "") : ""
+            return "security exited \(status): \(msg)"
+        case .timedOut: return "security timed out"
+        case .failedToLaunch: return "security failed to launch"
+        }
+    }
+
+    /// stderr に混入し得る hex 値（= シークレット）を redact する（#94 系）
+    private func redact(_ message: String) -> String {
+        message.replacingOccurrences(of: "-X [0-9a-fA-F]+", with: "-X <redacted>",
+                                     options: .regularExpression)
+    }
+}
+
+private extension KeychainError {
+    /// 追加コンテキストは debug ログ用途。ユーザー向け文言は KeychainError 側の定義を使う。
+    func annotated(_ context: String) -> KeychainError {
+        #if DEBUG
+        NSLog("[SecurityCLIKeychainService] %@", context)
+        #endif
+        return self
+    }
+}

--- a/AIkeychain/Services/SecurityCLIKeychainService.swift
+++ b/AIkeychain/Services/SecurityCLIKeychainService.swift
@@ -27,6 +27,12 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     /// 復元/同期/旧アプリ由来の GUI 所有アイテムが混入しても不変条件が壊れない。
     static let managedService = "com.aieo.aikeychain.managed"
 
+    /// 旧 GUI ストアの service 名（読み取り fallback / 削除時の掃除にのみ使う）。
+    static let legacyGUIService = "com.aieo.aikeychain"
+
+    /// 値の最大長。stdin 一括書き込みのパイプバッファ束縛（save() 参照）。
+    static let maxValueLength = 8192
+
     private let securityBin = "/usr/bin/security"
     /// subprocess 読み取りの上限。プロンプト待ち等でブロックした子はこれで kill する。
     /// Proxy の外側タイムアウト(3s)より短くし、permit を先に返せるようにする。
@@ -67,6 +73,13 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         // 代わりに保存側で printable ASCII のみに制限し、読み出しが常に raw に
         // なることを保証する。非 ASCII/複数行の対応は C7 #174 で規約を決めてから。
         guard value.range(of: "^[\\x20-\\x7e]+$", options: .regularExpression) != nil else {
+            throw KeychainError.invalidData
+        }
+        // 長さ上限: hex 展開後も `security -i` への stdin 一括書き込みがパイプ
+        // バッファ (64KB) 内に収まることを保証する（超えると「親は write で、子は
+        // 出力でブロック」のデッドロックが timeout の外で起き得る — #179 二段レビュー）。
+        // CLI (cli/src/keychain.js) と同じ値。
+        guard value.count <= Self.maxValueLength else {
             throw KeychainError.invalidData
         }
 
@@ -142,12 +155,42 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     }
 
     func delete(for account: String) throws {
-        let result = runSecurity(
-            arguments: ["delete-generic-password", "-s", Self.managedService, "-a", account],
-            stdin: nil, timeout: writeTimeout)
-        switch result {
+        // 掃除の順序が要（#179 二段レビュー B3）: fallback ストア（manual → 旧 GUI）を
+        // **先に**消し、権威コピー（managed）を最後に消す。逆順で legacy 掃除が失敗すると
+        // 「削除成功と報告したのに `akc get` の fallback が古い値を解決し続ける」状態になる。
+        // fallback 掃除が失敗した場合は managed に触らず throw する — キーは無傷のまま
+        // 解決可能で、ユーザーには削除失敗が見える（half-deleted 状態を作らない）。
+
+        if EnvVarName.isManualSchemeCandidate(account) {
+            // manual スキームは厳格名（大文字スネーク）のみ対象（#163 と同じガード —
+            // 他アプリの小文字/ドット付き service 名アイテムを巻き添えにしない）。
+            // `delete-generic-password -s NAME` は最初に一致した 1 件しか消さないため、
+            // 重複エントリ（#100）が残らないよう 44 (not found) まで繰り返す。
+            var remaining = 10 // 暴走防止の上限（実キーチェーンで重複が 10 超は想定外）
+            while remaining > 0 {
+                remaining -= 1
+                switch runSecurity(arguments: ["delete-generic-password", "-s", account],
+                                   stdin: nil, timeout: writeTimeout) {
+                case .exited(0, _, _):
+                    continue
+                case .exited(44, _, _):
+                    remaining = 0
+                case .exited(let status, _, _):
+                    throw KeychainError.unexpectedStatus(OSStatus(status))
+                case .timedOut:
+                    throw KeychainError.interactionRequired
+                case .failedToLaunch:
+                    throw KeychainError.unexpectedStatus(errSecIO)
+                }
+            }
+        }
+
+        // 旧 GUI ストアの同名コピー。旧 GUI 所有はプロンプトになり得るが、削除は
+        // headed 前提の操作なので許容（timeout なら throw し、managed は無傷）。
+        switch runSecurity(arguments: ["delete-generic-password", "-s", Self.legacyGUIService, "-a", account],
+                           stdin: nil, timeout: writeTimeout) {
         case .exited(0, _, _), .exited(44, _, _):
-            break // 44 (not found) は冪等成功扱い（従来の delete と同じ意味論）
+            break
         case .exited(let status, _, _):
             throw KeychainError.unexpectedStatus(OSStatus(status))
         case .timedOut:
@@ -156,19 +199,17 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
             throw KeychainError.unexpectedStatus(errSecIO)
         }
 
-        // 旧 namespace（GUI store / manual スキーム）の同名コピーも best-effort で
-        // 掃除する。残すと `akc get/run` の legacy fallback が「削除したはずのキー」を
-        // 解決し続ける（#179 レビュー CONFIRMED）。akc set 由来の legacy は security
-        // 所有なので無音で消える。旧 GUI 所有はプロンプトになり得るため headed 前提の
-        // 削除操作でのみ発生し、timeout で kill されても本体（managed）は削除済み。
-        var legacyDeletes = [["delete-generic-password", "-s", "com.aieo.aikeychain", "-a", account]]
-        if EnvVarName.isManualSchemeCandidate(account) {
-            // manual スキームは厳格名（大文字スネーク）のみ対象（#163 と同じガード —
-            // 他アプリの小文字 service 名アイテムを巻き添えにしない）
-            legacyDeletes.append(["delete-generic-password", "-s", account])
-        }
-        for legacy in legacyDeletes {
-            _ = runSecurity(arguments: legacy, stdin: nil, timeout: writeTimeout)
+        // 最後に権威コピー（managed）。44 は冪等成功扱い（従来の delete と同じ意味論）。
+        switch runSecurity(arguments: ["delete-generic-password", "-s", Self.managedService, "-a", account],
+                           stdin: nil, timeout: writeTimeout) {
+        case .exited(0, _, _), .exited(44, _, _):
+            break
+        case .exited(let status, _, _):
+            throw KeychainError.unexpectedStatus(OSStatus(status))
+        case .timedOut:
+            throw KeychainError.interactionRequired
+        case .failedToLaunch:
+            throw KeychainError.unexpectedStatus(errSecIO)
         }
     }
 
@@ -205,9 +246,32 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     }
 
     func manualServices() -> [String] {
-        // managed namespace 移行に伴い manual スキームの発見は廃止 (#167)。
-        // 旧キーは移行アシスタント (C5 #172) の専用導線でのみ扱う。
-        []
+        // manual スキーム (service=<キー名>) の発見。値は読まない属性列挙なので
+        // 所有者に関係なく無音（旧 KeychainService と同じ実装 / #160）。
+        // #167 では最終的に manual スキーム自体を廃止するが、その置き換えは
+        // C5 (#172) 移行アシスタント / C7 (#174) の担当。C2 で列挙まで止めると
+        // (a) 既存 manual キーが GUI から突然消える、(b) delete() は manual コピーを
+        // 掃除するのに KeyEditorViewModel.deletesManualEntryToo の巻き添え警告が
+        // 恒久 false になり無警告削除が走る（#179 二段レビュー B4）。
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            return []
+        }
+        var seen = Set<String>()
+        return items.compactMap { item -> String? in
+            guard let svc = item[kSecAttrService as String] as? String,
+                  svc != Self.managedService,
+                  svc != Self.legacyGUIService,
+                  EnvVarName.isManualSchemeCandidate(svc),
+                  seen.insert(svc).inserted else { return nil }
+            return svc
+        }
     }
 
     // MARK: - subprocess 基盤
@@ -256,26 +320,40 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         let stdinPipe = Pipe()
         process.standardInput = stdinPipe
 
-        do { try process.run() } catch { return .failedToLaunch }
-
-        if let stdin {
-            stdinPipe.fileHandleForWriting.write(stdin.data(using: .utf8)!)
+        do {
+            try process.run()
+        } catch {
+            // 一時的な資源枯渇 (fork EAGAIN 等) は 1 回だけ短い待機後に再試行する
+            usleep(50_000)
+            do { try process.run() } catch { return .failedToLaunch }
         }
-        stdinPipe.fileHandleForWriting.closeFile()
 
-        // 出力はバックグラウンドで吸い上げる（パイプ詰まりで子が固まらないように）
+        // 出力の吸い上げは **stdin 書き込みより先に** 開始する（パイプ詰まりで
+        // 「親は write・子は出力」の相互ブロックを作らない — #179 二段レビュー S4）。
+        // バッファはロック越しにのみ触り、timeout 帰還後にクロージャが走っても
+        // 呼び出し元とデータ競合しないようにする。
+        let ioLock = NSLock()
         var stdoutData = Data(), stderrData = Data()
         let ioGroup = DispatchGroup()
         ioGroup.enter()
         DispatchQueue.global().async {
-            stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            ioLock.lock(); stdoutData = data; ioLock.unlock()
             ioGroup.leave()
         }
         ioGroup.enter()
         DispatchQueue.global().async {
-            stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            ioLock.lock(); stderrData = data; ioLock.unlock()
             ioGroup.leave()
         }
+
+        // stdin は同期書き込みでよい: save() が値長を maxValueLength に制限するため
+        // コマンド全体が hex 展開後もパイプバッファ (64KB) に収まり、ブロックしない。
+        if let stdin {
+            stdinPipe.fileHandleForWriting.write(stdin.data(using: .utf8)!)
+        }
+        stdinPipe.fileHandleForWriting.closeFile()
 
         let deadline = Date().addingTimeInterval(timeout)
         while process.isRunning && Date() < deadline {
@@ -289,12 +367,21 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
             kill(process.processIdentifier, SIGKILL)
             process.waitUntilExit() // reap（ゾンビ防止, S5 実測どおり）
             _ = ioGroup.wait(timeout: .now() + 1)
-            return .timedOut
+            return .timedOut // バッファには触らない（読み手がまだ走っていても安全）
         }
 
         process.waitUntilExit()
-        _ = ioGroup.wait(timeout: .now() + 2)
-        return .exited(process.terminationStatus, stdout: stdoutData, stderr: stderrData)
+        // 排出待ちは subprocess 本体と同等の猶予を与える。短すぎると正常終了した
+        // 読み取りを（GCD スレッドが混雑しているだけで）timeout 扱いに誤変換する
+        guard ioGroup.wait(timeout: .now() + max(2, timeout)) == .success else {
+            // 子孫プロセスが pipe を握り続けて出力が閉じない異常系。不完全な出力を
+            // 「成功した読み取り値」として返さない（値の取り違えを防ぐ）。
+            return .timedOut
+        }
+        ioLock.lock()
+        let out = stdoutData, err = stderrData
+        ioLock.unlock()
+        return .exited(process.terminationStatus, stdout: out, stderr: err)
     }
 
     private func resultDescription(_ result: RunResult, stderr: Bool) -> String {

--- a/AIkeychain/Services/SecurityCLIKeychainService.swift
+++ b/AIkeychain/Services/SecurityCLIKeychainService.swift
@@ -61,13 +61,14 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         guard EnvVarName.isValid(account) else {
             throw KeychainError.invalidAccount
         }
-        // CLI (cli/src/keychain.js) と同じ制約: 制御文字は `find -w` の読み戻しを
-        // hex 出力に化けさせラウンドトリップを壊すため保存前に拒否する。
-        // （複数行値の許容は C7 #174 で読み書き両側の規約を揃えてから）
-        guard value.range(of: "[\\x00-\\x1f\\x7f]", options: .regularExpression) == nil else {
+        // `security find -w` は値に非 ASCII/制御文字が含まれると hex を出力する。
+        // 「hex らしき出力を復号する」推測は all-hex の正規シークレット
+        // （例 "4142..."）を破壊するため行わない（#179 レビュー CONFIRMED）。
+        // 代わりに保存側で printable ASCII のみに制限し、読み出しが常に raw に
+        // なることを保証する。非 ASCII/複数行の対応は C7 #174 で規約を決めてから。
+        guard value.range(of: "^[\\x20-\\x7e]+$", options: .regularExpression) != nil else {
             throw KeychainError.invalidData
         }
-        guard !value.isEmpty else { throw KeychainError.invalidData }
 
         let hex = value.data(using: .utf8)!.map { String(format: "%02x", $0) }.joined()
         // -U: 既存アイテムの更新。security 所有アイテムへの -U は所有権・headless
@@ -145,16 +146,29 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
             arguments: ["delete-generic-password", "-s", Self.managedService, "-a", account],
             stdin: nil, timeout: writeTimeout)
         switch result {
-        case .exited(0, _, _):
-            return
-        case .exited(44, _, _):
-            return // not found は冪等成功扱い（従来の delete と同じ意味論）
+        case .exited(0, _, _), .exited(44, _, _):
+            break // 44 (not found) は冪等成功扱い（従来の delete と同じ意味論）
         case .exited(let status, _, _):
             throw KeychainError.unexpectedStatus(OSStatus(status))
         case .timedOut:
             throw KeychainError.interactionRequired
         case .failedToLaunch:
             throw KeychainError.unexpectedStatus(errSecIO)
+        }
+
+        // 旧 namespace（GUI store / manual スキーム）の同名コピーも best-effort で
+        // 掃除する。残すと `akc get/run` の legacy fallback が「削除したはずのキー」を
+        // 解決し続ける（#179 レビュー CONFIRMED）。akc set 由来の legacy は security
+        // 所有なので無音で消える。旧 GUI 所有はプロンプトになり得るため headed 前提の
+        // 削除操作でのみ発生し、timeout で kill されても本体（managed）は削除済み。
+        var legacyDeletes = [["delete-generic-password", "-s", "com.aieo.aikeychain", "-a", account]]
+        if EnvVarName.isManualSchemeCandidate(account) {
+            // manual スキームは厳格名（大文字スネーク）のみ対象（#163 と同じガード —
+            // 他アプリの小文字 service 名アイテムを巻き添えにしない）
+            legacyDeletes.append(["delete-generic-password", "-s", account])
+        }
+        for legacy in legacyDeletes {
+            _ = runSecurity(arguments: legacy, stdin: nil, timeout: writeTimeout)
         }
     }
 
@@ -212,11 +226,8 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         case .exited(0, let stdout, _):
             var text = String(data: stdout, encoding: .utf8) ?? ""
             if text.hasSuffix("\n") { text.removeLast() }
-            // security -w は非 ASCII 値を hex で出力する。保存側（save/akc set）は
-            // hex 入力なので、偶数長 hex + UTF-8 復号可能なら復号を試す。
-            // ASCII のみの実値が hex 文字だけで構成されるケースは save 側の
-            // read-back 検証で弾かれるため実害は限定的（CLI と同じ扱い）。
-            if let decoded = Self.decodeHexIfLikely(text) { text = decoded }
+            // 保存側が printable ASCII のみを許容するため、-w の出力は常に raw。
+            // hex 推測復号は all-hex の正規値を破壊するので行わない（#179 レビュー）。
             return text
         case .exited(44, _, _):
             return nil
@@ -284,22 +295,6 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         process.waitUntilExit()
         _ = ioGroup.wait(timeout: .now() + 2)
         return .exited(process.terminationStatus, stdout: stdoutData, stderr: stderrData)
-    }
-
-    /// 偶数長の hex 文字列で、かつ UTF-8 として復号できる場合のみ復号して返す。
-    static func decodeHexIfLikely(_ text: String) -> String? {
-        guard !text.isEmpty, text.count % 2 == 0,
-              text.range(of: "^[0-9a-fA-F]+$", options: .regularExpression) != nil else { return nil }
-        var bytes = [UInt8]()
-        bytes.reserveCapacity(text.count / 2)
-        var index = text.startIndex
-        while index < text.endIndex {
-            let next = text.index(index, offsetBy: 2)
-            guard let byte = UInt8(text[index..<next], radix: 16) else { return nil }
-            bytes.append(byte)
-            index = next
-        }
-        return String(bytes: bytes, encoding: .utf8)
     }
 
     private func resultDescription(_ result: RunResult, stderr: Bool) -> String {

--- a/AIkeychain/Services/ZshrcExporter.swift
+++ b/AIkeychain/Services/ZshrcExporter.swift
@@ -9,12 +9,18 @@ enum ExportFormat: String, CaseIterable, Identifiable {
 }
 
 struct ZshrcExporter {
-    static func export(keys: [APIKey], format: ExportFormat) -> String {
+    /// - Parameter managedExists: managed namespace (com.aieo.aikeychain.managed) に
+    ///   キーが存在するかの判定。既定は実 Keychain への属性照会（値は読まないため
+    ///   承認 UI は出ない）。テストからは差し替える。
+    static func export(keys: [APIKey], format: ExportFormat,
+                       managedExists: (String) -> Bool = {
+                           SecurityCLIKeychainService.shared.exists(for: $0)
+                       }) -> String {
         let configured = keys.filter(\.isConfigured)
 
         switch format {
         case .zshrc:
-            return generateZshrc(keys: configured)
+            return generateZshrc(keys: configured, managedExists: managedExists)
         case .secretRef:
             return generateSecretRef(keys: configured)
         case .env:
@@ -22,7 +28,7 @@ struct ZshrcExporter {
         }
     }
 
-    private static func generateZshrc(keys: [APIKey]) -> String {
+    private static func generateZshrc(keys: [APIKey], managedExists: (String) -> Bool) -> String {
         var lines: [String] = [
             "# AI KeyChain - Generated exports",
             "# Tokens are stored in macOS Keychain (not plaintext)",
@@ -43,7 +49,12 @@ struct ZshrcExporter {
                 // シェル側の `||` フォールバックは使わない — 承認拒否や一時エラーでも
                 // 別スキームの古い/無関係な値へ静かに落ちてしまうため。
                 // -a "$USER" は acct のずれ/重複で古い値を掴む恐れがあるため使わない。
+                // .app キーは export 時点の実在場所で判定する: GUI の新規保存は
+                // managed namespace (#167/#169) へ行くため、旧 service 固定のままだと
+                // 保存直後のキーが新しいシェルで空になる（#179 二段レビュー B1）。
                 switch key.storage {
+                case .app where managedExists(key.envVarName):
+                    lines.append("export \(key.envVarName)=$(/usr/bin/security find-generic-password -s \"\(SecurityCLIKeychainService.managedService)\" -a \"\(key.envVarName)\" -w)")
                 case .app:
                     lines.append("export \(key.envVarName)=$(/usr/bin/security find-generic-password -s \"com.aieo.aikeychain\" -a \"\(key.envVarName)\" -w)")
                 case .manual:

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -85,7 +85,7 @@ final class KeyEditorViewModel {
     }
 
     init(editingKey: APIKey? = nil,
-         keychainService: KeychainServiceProtocol = KeychainService.shared,
+         keychainService: KeychainServiceProtocol = SecurityCLIKeychainService.shared,
          customStore: CustomKeyStore = .shared) {
         self.editingKey = editingKey
         self.keychainService = keychainService

--- a/AIkeychain/ViewModels/KeyListViewModel.swift
+++ b/AIkeychain/ViewModels/KeyListViewModel.swift
@@ -21,7 +21,7 @@ final class KeyListViewModel {
     private let keychainService: KeychainServiceProtocol
     private let customStore: CustomKeyStore
 
-    init(keychainService: KeychainServiceProtocol = KeychainService.shared,
+    init(keychainService: KeychainServiceProtocol = SecurityCLIKeychainService.shared,
          customStore: CustomKeyStore = .shared) {
         self.keychainService = keychainService
         self.customStore = customStore

--- a/AIkeychain/Views/EnvImportView.swift
+++ b/AIkeychain/Views/EnvImportView.swift
@@ -328,7 +328,7 @@ struct EnvImportView: View {
 
                             Spacer()
 
-                            if KeychainService.shared.exists(for: entry.matchedService?.envVarName ?? entry.key) {
+                            if SecurityCLIKeychainService.shared.exists(for: entry.matchedService?.envVarName ?? entry.key) {
                                 Label("Overwrite", systemImage: "exclamationmark.triangle")
                                     .font(.system(size: 10))
                                     .foregroundStyle(.orange)
@@ -460,7 +460,7 @@ struct EnvImportView: View {
         for entry in selected {
             let account = entry.matchedService?.envVarName ?? entry.key
             do {
-                try KeychainService.shared.save(value: entry.value, for: account)
+                try SecurityCLIKeychainService.shared.save(value: entry.value, for: account)
                 saved += 1
                 savedKeys.append(account)
             } catch KeychainError.cliManaged {
@@ -575,7 +575,7 @@ private struct EnvEntryRow: View {
 
             Spacer()
 
-            if KeychainService.shared.exists(for: entry.matchedService?.envVarName ?? entry.key) {
+            if SecurityCLIKeychainService.shared.exists(for: entry.matchedService?.envVarName ?? entry.key) {
                 Text("Exists")
                     .font(.system(size: 9))
                     .foregroundStyle(.orange)

--- a/AIkeychain/Views/EnvImportView.swift
+++ b/AIkeychain/Views/EnvImportView.swift
@@ -365,7 +365,7 @@ struct EnvImportView: View {
                 .background(Color.orange.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Label(L10n.s(ja: "保存先: macOS Keychain (com.aieo.aikeychain)", en: "Destination: macOS Keychain (com.aieo.aikeychain)"), systemImage: "lock.shield")
+                    Label(L10n.s(ja: "保存先: macOS Keychain (com.aieo.aikeychain.managed)", en: "Destination: macOS Keychain (com.aieo.aikeychain.managed)"), systemImage: "lock.shield")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
 
@@ -393,7 +393,7 @@ struct EnvImportView: View {
             Spacer()
 
             if let result = importResult {
-                let clean = result.failed == 0 && result.cliManaged.isEmpty
+                let clean = result.failed == 0 && result.unsupported.isEmpty
                 Image(systemName: clean ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
                     .font(.system(size: 48))
                     .foregroundStyle(clean ? AppColors.configured : .orange)
@@ -418,11 +418,11 @@ struct EnvImportView: View {
                         ResultRow(icon: "xmark.circle.fill", color: .red,
                                   text: "\(result.failed) keys failed")
                     }
-                    if !result.cliManaged.isEmpty {
-                        ResultRow(icon: "terminal.fill", color: .orange,
+                    if !result.unsupported.isEmpty {
+                        ResultRow(icon: "textformat.abc.dottedunderline", color: .orange,
                                   text: L10n.s(
-                                    ja: "\(result.cliManaged.count) 件は akc CLI 管理のため未更新。ターミナルで更新してください: akc set \(result.cliManaged.joined(separator: " / akc set "))",
-                                    en: "\(result.cliManaged.count) key(s) are managed by the akc CLI and were not updated. Update them in a terminal: akc set \(result.cliManaged.joined(separator: " / akc set "))"))
+                                    ja: "\(result.unsupported.count) 件は未対応の値形式（非 ASCII / 複数行 / 8KB 超）のため保存されませんでした: \(result.unsupported.joined(separator: ", "))",
+                                    en: "\(result.unsupported.count) key(s) were not saved because the value format is not supported yet (non-ASCII / multi-line / over 8KB): \(result.unsupported.joined(separator: ", "))"))
                     }
                 }
                 .padding(.horizontal, 40)
@@ -455,7 +455,7 @@ struct EnvImportView: View {
         var failed = 0
         var removedFromZshrc = 0
         var savedKeys: [String] = []
-        var cliManagedKeys: [String] = []
+        var unsupportedKeys: [String] = []
 
         for entry in selected {
             let account = entry.matchedService?.envVarName ?? entry.key
@@ -463,11 +463,12 @@ struct EnvImportView: View {
                 try SecurityCLIKeychainService.shared.save(value: entry.value, for: account)
                 saved += 1
                 savedKeys.append(account)
-            } catch KeychainError.cliManaged {
-                // #177: このキーは akc CLI 管理（security 所有）。GUI から上書きすると
-                // 毒化するため save() が fail-closed した。古い値のまま黙って放置せず、
-                // 「akc set で更新して」と明示する。
-                cliManagedKeys.append(account)
+            } catch KeychainError.invalidData {
+                // 値形式が未対応（非 ASCII / 複数行 / 8KB 超 — .env に多い複数行 PEM 鍵
+                // 等）。一般の failed に混ぜず理由付きで別掲する（#179 二段レビュー N1）。
+                // ※ 旧 KeychainService の cliManaged fail-closed (#177) は、書き込みが
+                // security subprocess 単一経路になったことで構造的に不要になった。
+                unsupportedKeys.append(account)
             } catch {
                 failed += 1
             }
@@ -485,7 +486,7 @@ struct EnvImportView: View {
 
         let skipped = parsedEntries.count - selected.count
         importResult = ImportResult(saved: saved, skipped: skipped, failed: failed,
-                                    removedFromZshrc: removedFromZshrc, cliManaged: cliManagedKeys)
+                                    removedFromZshrc: removedFromZshrc, unsupported: unsupportedKeys)
     }
 
     private func isAIKey(_ key: String) -> Bool {
@@ -607,9 +608,10 @@ private struct ImportResult {
     let skipped: Int
     let failed: Int
     let removedFromZshrc: Int
-    /// #177: akc CLI 管理（security 所有）で GUI から上書きできなかったキー。
-    /// 古い値のまま残るため `akc set <KEY>` での更新を案内する。
-    var cliManaged: [String] = []
+    /// 値の形式が未対応（非 ASCII / 複数行 / 8KB 超 — 複数行 PEM 鍵など）で保存
+    /// できなかったキー。C7 (#174) のエンコーディング規約が入るまでの制約。
+    /// 一般の failed に混ぜると理由が見えないため別掲する（#179 二段レビュー N1/D-Q1）。
+    var unsupported: [String] = []
 }
 
 struct EnvEntry: Identifiable {

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -540,8 +540,8 @@ private struct ReceiveTab: View {
     @State private var imported = false
     @State private var importCount = 0
     /// #177: 受信キーのうちローカルが akc CLI 管理で上書きできなかった件数。
-    @State private var cliManagedCount = 0
-    /// #177: cliManaged 以外の理由（keychain ロック等）で保存できなかった件数。
+    @State private var unsupportedCount = 0
+    /// 値形式以外の理由（keychain ロック等）で保存できなかった件数。
     @State private var failedCount = 0
     @State private var errorMessage: String?
     // 復号時に envVarName で重複排除（先勝ち）した表示用エントリ（finding 10）と、
@@ -863,12 +863,12 @@ private struct ReceiveTab: View {
             Text(L10n.s(ja: "Keychain に保存されました", en: "Saved to Keychain"))
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
-            if cliManagedCount > 0 {
-                // #177: akc CLI 管理キーは GUI から上書きできない（毒化防止）
+            if unsupportedCount > 0 {
+                // 値形式が未対応（非 ASCII / 複数行 / 8KB 超）。C7 (#174) までの制約
                 Label(L10n.s(
-                    ja: "\(cliManagedCount) 件は akc CLI 管理のため未更新です。ターミナルで `akc set <KEY>` で更新してください。",
-                    en: "\(cliManagedCount) key(s) are managed by the akc CLI and were not updated. Update them with `akc set <KEY>` in a terminal."),
-                      systemImage: "terminal.fill")
+                    ja: "\(unsupportedCount) 件は未対応の値形式（非 ASCII / 複数行 / 8KB 超）のため保存されませんでした。",
+                    en: "\(unsupportedCount) key(s) were not saved because the value format is not supported yet (non-ASCII / multi-line / over 8KB)."),
+                      systemImage: "textformat.abc.dottedunderline")
                     .font(.system(size: 11))
                     .foregroundStyle(.orange)
                     .multilineTextAlignment(.center)
@@ -948,7 +948,7 @@ private struct ReceiveTab: View {
             tofu.confirm(fp)
         }
         var count = 0
-        var cliManaged: [String] = []
+        var unsupported: [String] = []
         var failed: [String] = []
         for entry in entries {
             // 外部由来の .aikeychain ファイルの envVarName は信頼できない。
@@ -958,18 +958,19 @@ private struct ReceiveTab: View {
             do {
                 try SecurityCLIKeychainService.shared.save(value: entry.value, for: entry.envVarName)
                 count += 1
-            } catch KeychainError.cliManaged {
-                // #177: 受信キーと同名のローカルキーが akc CLI 管理（security 所有）。
-                // GUI から上書きすると毒化するため fail-closed。黙って捨てず件数を surface。
-                cliManaged.append(entry.envVarName)
+            } catch KeychainError.invalidData {
+                // 値形式が未対応（非 ASCII / 複数行 / 8KB 超）。share フォーマット自体は
+                // UTF-8 を運べるため、受信側の制約として理由付きで surface する
+                // （#179 二段レビュー N1/D-Q1。C7 #174 のエンコーディング規約で解消予定）。
+                unsupported.append(entry.envVarName)
             } catch {
-                // その他の失敗（keychain ロック等）は cliManaged と混同せず別集計。
-                // 「akc set で更新」の誤案内で本当の失敗を隠さないため（codex 指摘）。
+                // その他の失敗（keychain ロック等）は理由別に別集計。
+                // 誤案内で本当の失敗を隠さないため（codex 指摘）。
                 failed.append(entry.envVarName)
             }
         }
         importCount = count
-        cliManagedCount = cliManaged.count
+        unsupportedCount = unsupported.count
         failedCount = failed.count
         imported = true
         onImport() // キーリストを更新

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -469,7 +469,7 @@ private struct SendTab: View {
             var failed: [String] = []
             for key in configuredKeys {
                 do {
-                    if let value = try KeychainService.shared.retrieve(for: key.envVarName),
+                    if let value = try SecurityCLIKeychainService.shared.retrieve(for: key.envVarName),
                        !value.isEmpty {
                         values[key.envVarName] = value
                     }
@@ -922,7 +922,7 @@ private struct ReceiveTab: View {
                 let deduped = decrypted.entries.filter { seen.insert($0.envVarName).inserted }
                 // 上書き対象は decrypt 時に一度だけ Keychain を引いて確定（毎描画で
                 // 引かない / finding 11）。
-                let owNames = Set(deduped.map(\.envVarName).filter { KeychainService.shared.exists(for: $0) })
+                let owNames = Set(deduped.map(\.envVarName).filter { SecurityCLIKeychainService.shared.exists(for: $0) })
                 entries = deduped
                 overwriteNames = owNames
                 share = decrypted
@@ -956,7 +956,7 @@ private struct ReceiveTab: View {
             // 弾かれるが、ここで明示的に skip して意図を明確化 / #116）。
             guard EnvVarName.isValid(entry.envVarName) else { continue }
             do {
-                try KeychainService.shared.save(value: entry.value, for: entry.envVarName)
+                try SecurityCLIKeychainService.shared.save(value: entry.value, for: entry.envVarName)
                 count += 1
             } catch KeychainError.cliManaged {
                 // #177: 受信キーと同名のローカルキーが akc CLI 管理（security 所有）。

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -3,6 +3,21 @@ import Network
 import Testing
 @testable import AIkeychain
 
+/// テスト用ポートの重複しない払い出し。以前の `UInt16.random(in:)` は並列 suite 間で
+/// 誕生日衝突し、別テストのサーバへ接続して 404/トークン不一致になる flake があった。
+enum TestPorts {
+    private static let lock = NSLock()
+    // プロセス起動毎にベースをずらし、前回実行の TIME_WAIT ソケットとの衝突も避ける
+    private static var current: UInt16 = UInt16.random(in: 19000...24000)
+
+    static func next() -> UInt16 {
+        lock.lock()
+        defer { lock.unlock() }
+        current += 1
+        return current
+    }
+}
+
 @Suite("ProxyRoute Tests")
 struct ProxyRouteTests {
 
@@ -211,7 +226,7 @@ enum TestHTTPClient {
 struct ProxyHangRegressionTests {
 
     /// Pick a high port unlikely to collide.
-    private func testPort() -> UInt16 { UInt16.random(in: 19000...19900) }
+    private func testPort() -> UInt16 { TestPorts.next() }
 
     @Test("A blocked keychain read does NOT wedge other requests")
     func blockedReadDoesNotWedgeOthers() throws {
@@ -442,20 +457,21 @@ final class RawClient {
 
 @Suite("Proxy HTTP Streaming & Framing Tests (issue #98)")
 struct ProxyStreamingTests {
-    private func port() -> UInt16 { UInt16.random(in: 20000...20900) }
+    private func port() -> UInt16 { TestPorts.next() }
 
     @Test("Upstream response is streamed to the client, not buffered until completion")
     func responseIsStreamed() throws {
         let upstreamPort = port()
         let proxyPort = port()
-        // Upstream sends headers + first SSE event immediately, then waits 1.5s
+        // Upstream sends headers + first SSE event immediately, then waits 4s
         // before the second event and close. A buffering proxy would deliver
-        // nothing until ~1.5s; a streaming proxy delivers event 1 right away.
+        // nothing until ~4s; a streaming proxy delivers event 1 right away.
+        // (ギャップと観測窓は並列テストの CPU 混雑でも誤判定しない幅を取る)
         let upstream = try FakeUpstream(port: upstreamPort) { conn, queue in
             conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { _, _, _, _ in
                 let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\ndata: 1\n\n"
                 conn.send(content: Data(head.utf8), completion: .contentProcessed { _ in
-                    queue.asyncAfter(deadline: .now() + 1.5) {
+                    queue.asyncAfter(deadline: .now() + 4.0) {
                         conn.send(content: Data("data: 2\n\n".utf8), completion: .contentProcessed { _ in
                             conn.cancel()
                         })
@@ -477,20 +493,29 @@ struct ProxyStreamingTests {
         defer { client.disconnect() }
         client.send("GET /v1/models HTTP/1.1\r\nHost: api.anthropic.com\r\n\(ProxyServer.tokenHeaderName): \(server.sessionToken)\r\n\r\n")
 
-        // Within 0.8s (well before the upstream's 1.5s gap), we must already have
-        // the status line and the first event — proof of streaming.
-        let early = client.recv(timeout: 0.8)
+        // Well before the upstream's 4s gap, we must already have the status
+        // line and the first event — proof of streaming. Loop small recvs until
+        // the first event arrives: a single recv returns one TCP segment's worth
+        // and can miss data under parallel-test CPU load (flake observed on
+        // unmodified code too). The 3s deadline still cannot observe "data: 2",
+        // which is sent no earlier than 4s after the head.
+        var early = Data()
+        let earlyDeadline = Date().addingTimeInterval(3.0)
+        while Date() < earlyDeadline {
+            early.append(client.recv(timeout: 0.2))
+            if (String(data: early, encoding: .utf8) ?? "").contains("data: 1") { break }
+        }
         let earlyStr = String(data: early, encoding: .utf8) ?? ""
         #expect(earlyStr.contains("200"))
         #expect(earlyStr.contains("data: 1"))
         #expect(!earlyStr.contains("data: 2")) // second event hasn't been sent yet
 
-        // Drain the rest.
+        // Drain the rest (2 個目のイベントは head 送信の 4s 後 — 混雑を見込んで待つ).
         var rest = Data()
-        for _ in 0..<5 {
-            let chunk = client.recv(timeout: 2)
-            if chunk.isEmpty { break }
-            rest.append(chunk)
+        let drainDeadline = Date().addingTimeInterval(10)
+        while Date() < drainDeadline {
+            rest.append(client.recv(timeout: 2))
+            if (String(data: rest, encoding: .utf8) ?? "").contains("data: 2") { break }
         }
         #expect((String(data: rest, encoding: .utf8) ?? "").contains("data: 2"))
     }

--- a/Tests/AIkeychainTests/SecretRefTests.swift
+++ b/Tests/AIkeychainTests/SecretRefTests.swift
@@ -28,7 +28,8 @@ struct ZshrcExporterSecretRefTests {
     @Test("Standard format includes service name comments")
     func standardComments() {
         let keys = [makeKey(service: .github)]
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc)
+        // managed に未移行のキー（旧 GUI store に実在）を模す
+        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in false })
         #expect(output.contains("# [AI KeyChain]"))
         #expect(output.contains("/usr/bin/security find-generic-password"))
         // 生成される .zshrc 行が GUI 保存形式 (service=com.aieo.aikeychain, account=KEY) に
@@ -42,6 +43,19 @@ struct ZshrcExporterSecretRefTests {
         #expect(!output.contains("||"))
     }
 
+    @Test("Standard format emits the managed lookup for keys living in the managed namespace")
+    func standardManagedScheme() {
+        // GUI の新規保存は managed namespace (#167/#169) に行く。旧 service 固定の
+        // export だと保存直後のキーが新しいシェルで空になる（#179 二段レビュー B1）。
+        let keys = [makeKey(service: .github)]
+        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in true })
+        #expect(output.contains(
+            "export GITHUB_TOKEN=$(/usr/bin/security find-generic-password -s \"com.aieo.aikeychain.managed\" -a \"GITHUB_TOKEN\" -w)"
+        ))
+        #expect(!output.contains("-s \"com.aieo.aikeychain\" -a \"GITHUB_TOKEN\""))
+        #expect(!output.contains("||"))
+    }
+
     @Test("Standard format emits the manual-scheme lookup for manual-scheme keys")
     func standardManualScheme() {
         // manual スキーム (service=KEY_NAME) のキーは、そのスキームに厳密一致する
@@ -49,7 +63,7 @@ struct ZshrcExporterSecretRefTests {
         let custom = CustomKey(envVarName: "MANUAL_ONLY_KEY", displayName: "MANUAL_ONLY_KEY",
                                categoryId: KeyCategory.cliAdded.stableId)
         let keys = [APIKey(customKey: custom, isConfigured: true, storage: .manual)]
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc)
+        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in false })
         #expect(output.contains(
             "export MANUAL_ONLY_KEY=$(/usr/bin/security find-generic-password -s \"MANUAL_ONLY_KEY\" -w)"
         ))
@@ -62,7 +76,7 @@ struct ZshrcExporterSecretRefTests {
             makeKey(service: .github),
             makeKey(service: .openAI),
         ]
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc)
+        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in false })
         let lookupLines = output.split(separator: "\n").filter {
             $0.contains("find-generic-password")
         }

--- a/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
@@ -1,0 +1,175 @@
+import Testing
+import Foundation
+@testable import AIkeychain
+
+/// SecurityCLIKeychainService のテスト。実 Keychain には触れず、`security` を模す
+/// スタブスクリプト（npm CLI の cli/test と同じ発想）に差し替えて検証する。
+@Suite("SecurityCLIKeychainService Tests (stub security)")
+struct SecurityCLIKeychainServiceTests {
+
+    /// テストごとに独立した state ディレクトリを持つ stub security を作る。
+    private func makeStub() throws -> (service: SecurityCLIKeychainService, stateDir: URL) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("akc-stub-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let stub = dir.appendingPathComponent("security")
+        let script = """
+        #!/bin/bash
+        dir="$(cd "$(dirname "$0")" && pwd)/state"
+        mkdir -p "$dir"
+        if [ "$1" = "-i" ]; then
+          read -r line
+          acct=$(printf '%s' "$line" | sed -n 's/.*-a "\\([^"]*\\)".*/\\1/p')
+          hex=$(printf '%s' "$line" | sed -n 's/.*-X \\([0-9a-fA-F]*\\).*/\\1/p')
+          [ -n "$acct" ] && [ -n "$hex" ] || exit 1
+          printf '%s' "$hex" | xxd -r -p > "$dir/$acct"
+          exit 0
+        fi
+        cmd="$1"; shift
+        svc=""; acct=""; w=false
+        while [ $# -gt 0 ]; do case "$1" in
+          -s) svc="$2"; shift 2 ;;
+          -a) acct="$2"; shift 2 ;;
+          -w) w=true; shift ;;
+          *) shift ;;
+        esac; done
+        case "$cmd" in
+        find-generic-password)
+          echo "find $acct" >> "$dir/calls.log"
+          case "$acct" in
+            HANG_KEY) sleep 60 ;;
+            SLOW_KEY) sleep 0.5 ;;
+          esac
+          if [ -f "$dir/$acct" ]; then cat "$dir/$acct"; echo; exit 0; else exit 44; fi ;;
+        delete-generic-password)
+          if [ -f "$dir/$acct" ]; then rm "$dir/$acct"; exit 0; else exit 44; fi ;;
+        esac
+        exit 1
+        """
+        try script.write(to: stub, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stub.path)
+        let service = SecurityCLIKeychainService()
+        service.securityBinOverrideForTesting = stub.path
+        return (service, dir.appendingPathComponent("state"))
+    }
+
+    private func findCalls(_ stateDir: URL) -> Int {
+        (try? String(contentsOf: stateDir.appendingPathComponent("calls.log"), encoding: .utf8))?
+            .split(separator: "\n").count ?? 0
+    }
+
+    @Test("Save then retrieve round-trips via subprocess (stdin+hex, no argv value)")
+    func saveRetrieveRoundTrip() throws {
+        let (service, stateDir) = try makeStub()
+        try service.save(value: "sk-test-value_123", for: "OPENAI_API_KEY")
+        #expect(try service.retrieve(for: "OPENAI_API_KEY") == "sk-test-value_123")
+        // 値ファイルは hex デコード済みで保存されている（stdin+hex 経路が機能）
+        let raw = try String(contentsOf: stateDir.appendingPathComponent("OPENAI_API_KEY"), encoding: .utf8)
+        #expect(raw == "sk-test-value_123")
+    }
+
+    @Test("Retrieve of a missing key returns nil (rc=44)")
+    func retrieveMissing() throws {
+        let (service, _) = try makeStub()
+        #expect(try service.retrieve(for: "MISSING_KEY") == nil)
+    }
+
+    @Test("Delete is idempotent (missing key is success)")
+    func deleteIdempotent() throws {
+        let (service, _) = try makeStub()
+        try service.save(value: "v", for: "DEL_KEY")
+        try service.delete(for: "DEL_KEY")
+        try service.delete(for: "DEL_KEY") // 2回目も throw しない
+        #expect(try service.retrieve(for: "DEL_KEY") == nil)
+    }
+
+    @Test("Control characters and empty values are rejected before touching security")
+    func inputValidation() throws {
+        let (service, stateDir) = try makeStub()
+        #expect(throws: KeychainError.self) {
+            try service.save(value: "line1\nline2", for: "MULTI")
+        }
+        #expect(throws: KeychainError.self) {
+            try service.save(value: "", for: "EMPTY")
+        }
+        #expect(throws: KeychainError.self) {
+            try service.save(value: "v", for: "9INVALID")
+        }
+        // security は一度も呼ばれていない
+        #expect(!FileManager.default.fileExists(atPath: stateDir.appendingPathComponent("MULTI").path))
+    }
+
+    @Test("A prompt-blocked read times out, is killed, and quarantines the key")
+    func timeoutQuarantine() throws {
+        let (service, stateDir) = try makeStub()
+        service.readTimeout = 0.3
+
+        let t0 = Date()
+        #expect(throws: KeychainError.self) {
+            _ = try service.retrieveNoninteractive(for: "HANG_KEY")
+        }
+        #expect(Date().timeIntervalSince(t0) < 3.0) // 60s sleep が kill されている
+
+        // 隔離中は spawn せず即時失敗する
+        let callsAfterFirst = findCalls(stateDir)
+        let t1 = Date()
+        #expect(throws: KeychainError.self) {
+            _ = try service.retrieveNoninteractive(for: "HANG_KEY")
+        }
+        #expect(Date().timeIntervalSince(t1) < 0.1)
+        #expect(findCalls(stateDir) == callsAfterFirst) // 追加 spawn なし
+    }
+
+    @Test("Successful save clears the quarantine")
+    func saveClearsQuarantine() throws {
+        let (service, _) = try makeStub()
+        service.readTimeout = 0.3
+        #expect(throws: KeychainError.self) {
+            _ = try service.retrieveNoninteractive(for: "HANG_KEY")
+        }
+        // save は writeTimeout 系なので成功し、隔離を解除する…が HANG_KEY は read-back
+        // で再びハングするため、ここでは別キーで解除ロジックのみ検証する
+        try service.save(value: "v", for: "OK_KEY")
+        #expect(try service.retrieveNoninteractive(for: "OK_KEY") == "v")
+    }
+
+    @Test("Concurrent reads of the same key are coalesced into one subprocess")
+    func coalescing() throws {
+        let (service, stateDir) = try makeStub()
+        try service.save(value: "slow-value", for: "SLOW_KEY")
+        let before = findCalls(stateDir)
+
+        let group = DispatchGroup()
+        var results = [String?](repeating: nil, count: 3)
+        let lock = NSLock()
+        for i in 0..<3 {
+            group.enter()
+            DispatchQueue.global().async {
+                let v = try? service.retrieveNoninteractive(for: "SLOW_KEY")
+                lock.lock(); results[i] = v; lock.unlock()
+                group.leave()
+            }
+        }
+        #expect(group.wait(timeout: .now() + 10) == .success)
+        #expect(results.allSatisfy { $0 == "slow-value" })
+        // SLOW_KEY(0.5s) への 3 並行読みが 1 spawn に束ねられている
+        #expect(findCalls(stateDir) - before == 1)
+    }
+
+    @Test("Hex output from security -w is decoded when it is valid UTF-8 hex")
+    func hexDecode() {
+        #expect(SecurityCLIKeychainService.decodeHexIfLikely("68656c6c6f") == "hello")
+        #expect(SecurityCLIKeychainService.decodeHexIfLikely("sk-plain") == nil)     // 非 hex
+        #expect(SecurityCLIKeychainService.decodeHexIfLikely("abc") == nil)          // 奇数長
+        #expect(SecurityCLIKeychainService.decodeHexIfLikely("") == nil)
+    }
+
+    @Test("Writes and lists target the managed namespace, never the legacy service")
+    func managedNamespaceOnly() {
+        #expect(SecurityCLIKeychainService.managedService == "com.aieo.aikeychain.managed")
+        #expect(SecurityCLIKeychainService.managedService != "com.aieo.aikeychain")
+        // manual スキームの発見は廃止 (#167)
+        let service = SecurityCLIKeychainService()
+        #expect(service.manualServices().isEmpty)
+    }
+}

--- a/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
@@ -15,14 +15,18 @@ struct SecurityCLIKeychainServiceTests {
         let stub = dir.appendingPathComponent("security")
         let script = """
         #!/bin/bash
+        # state ファイルは "state/<service>/<name>"。-s を無視すると「書き込み先
+        # service が誤っていても緑」になる（#179 二段レビュー S6）ため必ず反映する。
         dir="$(cd "$(dirname "$0")" && pwd)/state"
         mkdir -p "$dir"
         if [ "$1" = "-i" ]; then
           read -r line
+          svc=$(printf '%s' "$line" | sed -n 's/.*-s "\\([^"]*\\)".*/\\1/p')
           acct=$(printf '%s' "$line" | sed -n 's/.*-a "\\([^"]*\\)".*/\\1/p')
           hex=$(printf '%s' "$line" | sed -n 's/.*-X \\([0-9a-fA-F]*\\).*/\\1/p')
-          [ -n "$acct" ] && [ -n "$hex" ] || exit 1
-          printf '%s' "$hex" | xxd -r -p > "$dir/$acct"
+          [ -n "$svc" ] && [ -n "$acct" ] && [ -n "$hex" ] || exit 1
+          mkdir -p "$dir/$svc"
+          printf '%s' "$hex" | xxd -r -p > "$dir/$svc/$acct"
           exit 0
         fi
         cmd="$1"; shift
@@ -33,16 +37,22 @@ struct SecurityCLIKeychainServiceTests {
           -w) w=true; shift ;;
           *) shift ;;
         esac; done
+        name="${acct:-$svc}"   # manual スキーム (-a なし) は service 名で引く
+        path="$dir/$svc/$name"
         case "$cmd" in
         find-generic-password)
-          echo "find $acct" >> "$dir/calls.log"
-          case "$acct" in
-            HANG_KEY) [ -f "$dir/$acct" ] || sleep 60 ;;  # 保存後は即応答（quarantine 解除テスト用）
+          echo "find $svc|$name" >> "$dir/calls.log"
+          case "$name" in
+            HANG_KEY) [ -f "$path" ] || sleep 60 ;;  # 保存後は即応答（quarantine 解除テスト用）
             SLOW_KEY) sleep 0.5 ;;
           esac
-          if [ -f "$dir/$acct" ]; then cat "$dir/$acct"; echo; exit 0; else exit 44; fi ;;
+          if [ -f "$path" ]; then cat "$path"; echo; exit 0; else exit 44; fi ;;
         delete-generic-password)
-          if [ -f "$dir/$acct" ]; then rm "$dir/$acct"; exit 0; else exit 44; fi ;;
+          echo "delete $svc|$name" >> "$dir/calls.log"
+          if [ "$svc" = "com.aieo.aikeychain" ] && [ "$name" = "LEGACY_FAIL_KEY" ]; then
+            echo denied >&2; exit 51
+          fi
+          if [ -f "$path" ]; then rm "$path"; exit 0; else exit 44; fi ;;
         esac
         exit 1
         """
@@ -54,8 +64,24 @@ struct SecurityCLIKeychainServiceTests {
     }
 
     private func findCalls(_ stateDir: URL) -> Int {
-        (try? String(contentsOf: stateDir.appendingPathComponent("calls.log"), encoding: .utf8))?
-            .split(separator: "\n").count ?? 0
+        callLog(stateDir).filter { $0.hasPrefix("find ") }.count
+    }
+
+    private func callLog(_ stateDir: URL) -> [String] {
+        ((try? String(contentsOf: stateDir.appendingPathComponent("calls.log"), encoding: .utf8)) ?? "")
+            .split(separator: "\n").map(String.init)
+    }
+
+    /// stub の state ファイルパス（service 別ディレクトリ）
+    private func statePath(_ stateDir: URL, service: String, name: String) -> URL {
+        stateDir.appendingPathComponent(service).appendingPathComponent(name)
+    }
+
+    /// 旧 namespace のアイテムを直接シード（旧 GUI store / manual スキームの残置を模す）
+    private func seed(_ stateDir: URL, service: String, name: String, value: String = "legacy") throws {
+        let dir = stateDir.appendingPathComponent(service)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try value.write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
     }
 
     @Test("Save then retrieve round-trips via subprocess (stdin+hex, no argv value)")
@@ -63,9 +89,16 @@ struct SecurityCLIKeychainServiceTests {
         let (service, stateDir) = try makeStub()
         try service.save(value: "sk-test-value_123", for: "OPENAI_API_KEY")
         #expect(try service.retrieve(for: "OPENAI_API_KEY") == "sk-test-value_123")
-        // 値ファイルは hex デコード済みで保存されている（stdin+hex 経路が機能）
-        let raw = try String(contentsOf: stateDir.appendingPathComponent("OPENAI_API_KEY"), encoding: .utf8)
+        // 値ファイルは hex デコード済みで、managed namespace 配下に保存されている
+        // （stdin+hex 経路 + 書き込み先 service の両方が機能 / #179 S6）
+        let raw = try String(
+            contentsOf: statePath(stateDir, service: SecurityCLIKeychainService.managedService,
+                                  name: "OPENAI_API_KEY"),
+            encoding: .utf8)
         #expect(raw == "sk-test-value_123")
+        // 旧 namespace には何も書かれていない
+        #expect(!FileManager.default.fileExists(
+            atPath: statePath(stateDir, service: "com.aieo.aikeychain", name: "OPENAI_API_KEY").path))
     }
 
     @Test("Retrieve of a missing key returns nil (rc=44)")
@@ -95,8 +128,14 @@ struct SecurityCLIKeychainServiceTests {
         #expect(throws: KeychainError.self) {
             try service.save(value: "v", for: "9INVALID")
         }
+        // 長さ上限（stdin パイプバッファ束縛 / #179 S4）
+        #expect(throws: KeychainError.self) {
+            try service.save(value: String(repeating: "a", count: SecurityCLIKeychainService.maxValueLength + 1),
+                             for: "TOO_LONG")
+        }
         // security は一度も呼ばれていない
-        #expect(!FileManager.default.fileExists(atPath: stateDir.appendingPathComponent("MULTI").path))
+        #expect(!FileManager.default.fileExists(
+            atPath: statePath(stateDir, service: SecurityCLIKeychainService.managedService, name: "MULTI").path))
     }
 
     @Test("A prompt-blocked read times out, is killed, and quarantines the key")
@@ -175,12 +214,55 @@ struct SecurityCLIKeychainServiceTests {
         }
     }
 
-    @Test("Writes and lists target the managed namespace, never the legacy service")
-    func managedNamespaceOnly() {
-        #expect(SecurityCLIKeychainService.managedService == "com.aieo.aikeychain.managed")
-        #expect(SecurityCLIKeychainService.managedService != "com.aieo.aikeychain")
-        // manual スキームの発見は廃止 (#167)
-        let service = SecurityCLIKeychainService()
-        #expect(service.manualServices().isEmpty)
+    @Test("Reads query only the managed namespace (issued commands, not constants)")
+    func managedNamespaceOnly() throws {
+        let (service, stateDir) = try makeStub()
+        _ = try service.retrieve(for: "SOME_KEY")
+        // 実際に発行されたコマンドの service を検証する（定数比較では書き込み先の
+        // 誤りを検出できない — #179 二段レビュー S6）
+        #expect(callLog(stateDir) == ["find com.aieo.aikeychain.managed|SOME_KEY"])
+    }
+
+    @Test("Delete cleans legacy copies first (manual loop -> legacy GUI -> managed)")
+    func deleteCleansLegacyCopies() throws {
+        let (service, stateDir) = try makeStub()
+        try service.save(value: "v1", for: "CLEAN_KEY")
+        try seed(stateDir, service: "com.aieo.aikeychain", name: "CLEAN_KEY")
+        try seed(stateDir, service: "CLEAN_KEY", name: "CLEAN_KEY") // manual スキーム
+
+        try service.delete(for: "CLEAN_KEY")
+
+        // 全 namespace から消えている（残すと akc の legacy fallback が復活させる / B3）
+        #expect(!FileManager.default.fileExists(
+            atPath: statePath(stateDir, service: SecurityCLIKeychainService.managedService, name: "CLEAN_KEY").path))
+        #expect(!FileManager.default.fileExists(
+            atPath: statePath(stateDir, service: "com.aieo.aikeychain", name: "CLEAN_KEY").path))
+        #expect(!FileManager.default.fileExists(
+            atPath: statePath(stateDir, service: "CLEAN_KEY", name: "CLEAN_KEY").path))
+
+        // 順序: manual（44 まで反復）→ 旧 GUI → managed
+        let deletes = callLog(stateDir).filter { $0.hasPrefix("delete ") }
+        #expect(deletes == [
+            "delete CLEAN_KEY|CLEAN_KEY",            // 1件目を削除 (exit 0)
+            "delete CLEAN_KEY|CLEAN_KEY",            // 重複掃除の反復 → 44 で終端 (#100)
+            "delete com.aieo.aikeychain|CLEAN_KEY",
+            "delete com.aieo.aikeychain.managed|CLEAN_KEY",
+        ])
+    }
+
+    @Test("Delete propagates a legacy cleanup failure and leaves the managed copy intact")
+    func deleteLegacyFailureIsPropagated() throws {
+        let (service, stateDir) = try makeStub()
+        try service.save(value: "v1", for: "LEGACY_FAIL_KEY")
+
+        // 旧 GUI store の削除が拒否される（stub: exit 51）→ throw し、
+        // 権威コピー（managed）には触れない — 「削除成功と報告して fallback から
+        // 復活」という half-deleted 状態を作らない（#179 二段レビュー B3）
+        #expect(throws: KeychainError.self) {
+            try service.delete(for: "LEGACY_FAIL_KEY")
+        }
+        #expect(try service.retrieve(for: "LEGACY_FAIL_KEY") == "v1")
+        let deletes = callLog(stateDir).filter { $0.hasPrefix("delete ") }
+        #expect(!deletes.contains("delete com.aieo.aikeychain.managed|LEGACY_FAIL_KEY"))
     }
 }

--- a/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
@@ -37,7 +37,7 @@ struct SecurityCLIKeychainServiceTests {
         find-generic-password)
           echo "find $acct" >> "$dir/calls.log"
           case "$acct" in
-            HANG_KEY) sleep 60 ;;
+            HANG_KEY) [ -f "$dir/$acct" ] || sleep 60 ;;  # 保存後は即応答（quarantine 解除テスト用）
             SLOW_KEY) sleep 0.5 ;;
           esac
           if [ -f "$dir/$acct" ]; then cat "$dir/$acct"; echo; exit 0; else exit 44; fi ;;
@@ -120,17 +120,21 @@ struct SecurityCLIKeychainServiceTests {
         #expect(findCalls(stateDir) == callsAfterFirst) // 追加 spawn なし
     }
 
-    @Test("Successful save clears the quarantine")
+    @Test("Successful save clears the quarantine for that key")
     func saveClearsQuarantine() throws {
         let (service, _) = try makeStub()
         service.readTimeout = 0.3
+        // 未保存の HANG_KEY はハング → timeout-kill → 隔離
         #expect(throws: KeychainError.self) {
             _ = try service.retrieveNoninteractive(for: "HANG_KEY")
         }
-        // save は writeTimeout 系なので成功し、隔離を解除する…が HANG_KEY は read-back
-        // で再びハングするため、ここでは別キーで解除ロジックのみ検証する
-        try service.save(value: "v", for: "OK_KEY")
-        #expect(try service.retrieveNoninteractive(for: "OK_KEY") == "v")
+        // 隔離中は即時失敗する
+        #expect(throws: KeychainError.self) {
+            _ = try service.retrieveNoninteractive(for: "HANG_KEY")
+        }
+        // 保存成功（stub は保存後の HANG_KEY に即応答する）→ 隔離が解除され読める
+        try service.save(value: "healed", for: "HANG_KEY")
+        #expect(try service.retrieveNoninteractive(for: "HANG_KEY") == "healed")
     }
 
     @Test("Concurrent reads of the same key are coalesced into one subprocess")
@@ -156,12 +160,19 @@ struct SecurityCLIKeychainServiceTests {
         #expect(findCalls(stateDir) - before == 1)
     }
 
-    @Test("Hex output from security -w is decoded when it is valid UTF-8 hex")
-    func hexDecode() {
-        #expect(SecurityCLIKeychainService.decodeHexIfLikely("68656c6c6f") == "hello")
-        #expect(SecurityCLIKeychainService.decodeHexIfLikely("sk-plain") == nil)     // 非 hex
-        #expect(SecurityCLIKeychainService.decodeHexIfLikely("abc") == nil)          // 奇数長
-        #expect(SecurityCLIKeychainService.decodeHexIfLikely("") == nil)
+    @Test("An all-hex ASCII secret round-trips verbatim (no hex-decode guessing, #179 review)")
+    func allHexSecretRoundTrip() throws {
+        let (service, _) = try makeStub()
+        try service.save(value: "4142434445464748", for: "HEXLIKE_KEY")
+        #expect(try service.retrieve(for: "HEXLIKE_KEY") == "4142434445464748")
+    }
+
+    @Test("Non-ASCII values are rejected until the C7 encoding convention lands")
+    func nonAsciiRejected() throws {
+        let (service, _) = try makeStub()
+        #expect(throws: KeychainError.self) {
+            try service.save(value: "秘密のトークン", for: "JP_KEY")
+        }
     }
 
     @Test("Writes and lists target the managed namespace, never the legacy service")

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -13,6 +13,7 @@ import {
   maskValue,
   KeychainError,
   GUI_SERVICE,
+  MANAGED_SERVICE,
 } from '../src/keychain.js';
 import { cmdRun } from '../src/run.js';
 import { runDoctor, formatReport } from '../src/doctor.js';
@@ -29,7 +30,7 @@ Usage:
   akc list
   akc check <KEY>
   akc get <KEY> [--reveal]
-  akc set <KEY> [--manual]
+  akc set <KEY>
   akc delete <KEY>
   akc doctor
   akc guide
@@ -122,15 +123,20 @@ async function cmdList() {
 async function cmdCheck(name) {
   const result = await keyExists(name);
   if (result.exists) {
-    const stores = [result.app && 'AI KeyChain store', result.manual && 'manual entry']
+    const stores = [
+      result.managed && 'managed store',
+      result.app && 'AI KeyChain store (legacy)',
+      result.manual && 'manual entry',
+    ]
       .filter(Boolean)
       .join(', ');
     process.stdout.write(`✅ ${name} exists (${stores})\n`);
-    if (result.app && !result.manual) {
-      // Store-only key: the bare `security -s <KEY> -w` form (no -a) returns
+    if ((result.managed || result.app) && !result.manual) {
+      // Namespaced key: the bare `security -s <KEY> -w` form (no -a) returns
       // exit 44 for these — a false "not registered" signal (issue #137).
+      const svc = result.managed ? MANAGED_SERVICE : GUI_SERVICE;
       process.stdout.write(
-        `   ↳ security CLI: use -s "${GUI_SERVICE}" -a "${name}" -w  (or: akc get ${name})\n`
+        `   ↳ security CLI: use -s "${svc}" -a "${name}" -w  (or: akc get ${name})\n`
       );
     }
     return 0;
@@ -161,13 +167,13 @@ async function cmdGet(name, { reveal }) {
   return 0;
 }
 
-async function cmdSet(name, { manual }) {
+async function cmdSet(name) {
   const value = await readSecret(name);
   if (!value) {
     process.stderr.write('akc: empty value, nothing saved\n');
     return 1;
   }
-  const saved = await setKey(name, value, { manual });
+  const saved = await setKey(name, value);
   process.stdout.write(
     `✅ Saved ${name} (${maskValue(value)}) to service "${saved.service}"\n`
   );
@@ -233,7 +239,16 @@ async function main() {
     }
     case 'set': {
       const name = requireKeyArg(rest, 'set');
-      return name === null ? 1 : cmdSet(name, { manual: rest.includes('--manual') });
+      if (rest.includes('--manual')) {
+        // #167: every write targets the managed namespace; the legacy manual
+        // scheme is read-only. The old --manual path could create
+        // acct-mismatched duplicates (issue #91).
+        process.stderr.write(
+          'akc: --manual is no longer supported: all writes go to the managed namespace\n'
+        );
+        return 1;
+      }
+      return name === null ? 1 : cmdSet(name);
     }
     case 'delete': {
       const name = requireKeyArg(rest, 'delete');

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -1,7 +1,10 @@
 // Thin wrapper around the macOS `security` CLI.
-// Lookup order matches scripts/akc (issue #91):
-//   1. service="com.aieo.aikeychain" account="<KEY>"  (AI KeyChain GUI store)
-//   2. service="<KEY>" with NO account               (only when GUI exits 44/not-found)
+// Lookup order matches scripts/akc (issues #91, #167):
+//   1. service="com.aieo.aikeychain.managed" account="<KEY>"  (managed namespace, v1.9+)
+//   2. service="com.aieo.aikeychain" account="<KEY>"          (legacy GUI store)
+//   3. service="<KEY>" with NO account                        (legacy manual scheme)
+// Each tier falls through ONLY on exit 44 (not found) — any other failure is
+// authoritative and fails closed (#147/#150 semantics).
 // Manual keys are looked up by service only because their `acct` attribute is
 // not consistent ($USER or the service name) — pinning -a can grab a stale
 // duplicate entry and return an invalid value.
@@ -54,16 +57,25 @@ export function assertMacOS() {
   }
 }
 
+// Bound every subprocess: a prompt-blocked keychain operation must fail after
+// SUBPROCESS_TIMEOUT_MS instead of hanging `akc run`/`akc set` forever — the
+// whole point of the headless epic (#167). Matches the Swift service's
+// timeout + SIGKILL semantics.
+export const SUBPROCESS_TIMEOUT_MS = 10_000;
+
 async function security(args) {
   try {
     const { stdout, stderr } = await pExecFile(SECURITY_BIN, args, {
       maxBuffer: 16 * 1024 * 1024,
+      timeout: SUBPROCESS_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
     return { ok: true, code: 0, stdout, stderr };
   } catch (err) {
     return {
       ok: false,
       code: err.code ?? null,
+      killed: err.killed ?? false,
       stdout: err.stdout ?? '',
       stderr: err.stderr ?? String(err),
     };
@@ -98,11 +110,25 @@ export async function resolveKey(name) {
   return null;
 }
 
-/** Check where a key exists without reading its secret value. */
+/**
+ * Check where a key exists without reading its secret value.
+ * Fails closed (#150 semantics, same as resolveKey): only exit 44 means
+ * "not in this store" — any other failure throws instead of being silently
+ * treated as absent, so `akc check`/`akc get` never report a key as usable
+ * (or missing) based on a store we could not actually query.
+ */
 export async function keyExists(name) {
-  const managed = (await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name])).ok;
-  const app = (await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name])).ok;
-  const manual = (await security(['find-generic-password', '-s', name])).ok;
+  const probe = async (args) => {
+    const r = await security(args);
+    if (r.ok) return true;
+    if (r.code === 44) return false;
+    throw new KeychainError(
+      `keychain probe failed (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
+    );
+  };
+  const managed = await probe(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name]);
+  const app = await probe(['find-generic-password', '-s', GUI_SERVICE, '-a', name]);
+  const manual = await probe(['find-generic-password', '-s', name]);
   return { name, managed, app, manual, exists: managed || app || manual };
 }
 
@@ -117,39 +143,64 @@ function securityInteractive(commandLine) {
     const child = spawn(SECURITY_BIN, ['-i'], { stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    // Same bound as security(): a prompt-blocked write must fail, not hang (#167).
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      settle({ ok: false, stdout, stderr: 'security -i timed out (prompt-blocked?)' });
+    }, SUBPROCESS_TIMEOUT_MS);
     child.stdout.on('data', (chunk) => (stdout += chunk));
     child.stderr.on('data', (chunk) => (stderr += chunk));
-    child.on('error', (err) => resolve({ ok: false, stdout, stderr: String(err) }));
-    child.on('close', (code) => resolve({ ok: code === 0, stdout, stderr }));
+    child.on('error', (err) => settle({ ok: false, stdout, stderr: String(err) }));
+    child.on('close', (code) => settle({ ok: code === 0, stdout, stderr }));
     child.stdin.write(`${commandLine}\n`);
     child.stdin.end();
   });
 }
 
+// Maximum value length, matching the Swift service (SecurityCLIKeychainService
+// .maxValueLength): keeps the whole `security -i` command within the 64KB pipe
+// buffer after hex expansion, so the stdin write can never deadlock.
+export const MAX_VALUE_LENGTH = 8192;
+
 /**
- * Store a key. Defaults to the AI KeyChain GUI store so the entry shows up in
- * the app. `-U` updates in place to avoid acct-mismatched duplicates.
+ * Store a key in the managed namespace (#167) — the single write target for
+ * both CLI and GUI. `-U` updates in place to avoid acct-mismatched duplicates
+ * (safe for headless reads even on security-owned items, spike S7').
  *
  * The secret never appears in any process's argv (issue #94): the command is
  * fed to `security -i` via stdin, and the value is hex-encoded with -X so no
  * quoting of the interactive command line is needed.
  */
-export async function setKey(name, value, { manual = false } = {}) {
+export async function setKey(name, value) {
   if (!name) throw new KeychainError('key name is required');
   if (!KEY_NAME_PATTERN.test(name)) {
     throw new KeychainError('key name must match [A-Za-z0-9_.-]+');
   }
   if (!value) throw new KeychainError('refusing to store an empty value');
-  // Control characters would store fine but `find-generic-password -w` falls
-  // back to hex output for them, breaking round-trips — reject up front.
-  // eslint-disable-next-line no-control-regex
-  if (/[\u0000-\u001f\u007f]/.test(value)) {
-    throw new KeychainError('value must not contain control characters (newlines, tabs, NUL)');
+  // Printable ASCII only, matching the Swift service: `find-generic-password
+  // -w` prints hex for any value containing a non-printable byte, and guessing
+  // "looks like hex -> decode it" corrupts legitimate all-hex secrets (#179
+  // review). Restrict the write side so the read side is always raw.
+  // Non-ASCII/multi-line support is deferred to the C7 (#174) encoding convention.
+  if (!/^[\x20-\x7e]+$/.test(value)) {
+    throw new KeychainError(
+      'value must be printable ASCII (no newlines, tabs, control or non-ASCII characters) — non-ASCII/multi-line values are not supported yet'
+    );
   }
-  // New writes always target the managed namespace (#167). Updating a legacy
-  // manual entry in place is no longer offered: the managed copy wins the
-  // resolve order, and legacy copies are cleaned up by delete/migration.
-  const service = manual ? name : MANAGED_SERVICE;
+  if (value.length > MAX_VALUE_LENGTH) {
+    throw new KeychainError(`value exceeds the ${MAX_VALUE_LENGTH}-character limit`);
+  }
+  // All writes target the managed namespace (#167). The legacy manual scheme
+  // is no longer a write target (the old --manual path could create
+  // acct-mismatched duplicates — the exact #91 failure mode).
+  const service = MANAGED_SERVICE;
   const hex = Buffer.from(value, 'utf8').toString('hex');
   const r = await securityInteractive(
     `add-generic-password -U -s "${service}" -a "${name}" -X ${hex}`
@@ -161,10 +212,11 @@ export async function setKey(name, value, { manual = false } = {}) {
   }
   // Read-back verification against the exact target item: -U can report
   // success in odd keychain states while leaving a stale value behind.
-  // (`find -w` prints hex for non-ASCII payloads, so accept that form too.)
+  // Values are printable ASCII (enforced above), so `find -w` always prints
+  // them raw — a hex-shaped readback is a real mismatch, not an encoding.
   const readBack = await security(['find-generic-password', '-s', service, '-a', name, '-w']);
   const got = readBack.ok ? stripTrailingNewline(readBack.stdout) : null;
-  if (got !== value && got?.toLowerCase() !== hex) {
+  if (got !== value) {
     throw new KeychainError(
       `save reported success but reading "${name}" back returned a different value — check Keychain state`
     );
@@ -172,20 +224,44 @@ export async function setKey(name, value, { manual = false } = {}) {
   return { service, account: name };
 }
 
-/** Delete a key from the GUI store and/or the manual store. Returns which stores were deleted. */
-export async function deleteKey(name, { app = true, manual = true } = {}) {
+/**
+ * Delete a key from every store it lives in. Returns which stores were deleted.
+ *
+ * Order matters (#179 review): fallback stores (manual -> legacy GUI) are
+ * cleaned up BEFORE the authoritative managed copy. If a fallback delete
+ * fails, we throw with the managed copy intact — the key still resolves and
+ * the user sees the failure, instead of "deleted" being reported while a
+ * stale fallback copy keeps resolving. Exit 44 (not found) is the only benign
+ * failure; anything else throws.
+ */
+export async function deleteKey(name) {
   const deleted = [];
-  if (app) {
-    const m = await security(['delete-generic-password', '-s', MANAGED_SERVICE, '-a', name]);
-    if (m.ok) deleted.push('managed');
+  const del = async (args) => {
+    const r = await security(args);
+    if (r.ok) return true;
+    if (r.code === 44) return false;
+    throw new KeychainError(
+      `failed to delete "${name}" (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
+    );
+  };
+
+  // Manual scheme: strict env-var-shaped names only — KEY_NAME_PATTERN also
+  // allows dots/lowercase, and deleting service="com.vendor.foo" would remove
+  // an unrelated app's item. `delete-generic-password -s NAME` removes only
+  // the first match, so loop until exit 44 to clear duplicates (#100).
+  if (MANUAL_NAME_PATTERN.test(name)) {
+    let removedAny = false;
+    for (let i = 0; i < 10; i++) {
+      if (!(await del(['delete-generic-password', '-s', name]))) break;
+      removedAny = true;
+    }
+    if (removedAny) deleted.push('manual');
   }
-  if (app) {
-    const r = await security(['delete-generic-password', '-s', GUI_SERVICE, '-a', name]);
-    if (r.ok) deleted.push('app');
+  if (await del(['delete-generic-password', '-s', GUI_SERVICE, '-a', name])) {
+    deleted.push('app');
   }
-  if (manual) {
-    const r = await security(['delete-generic-password', '-s', name]);
-    if (r.ok) deleted.push('manual');
+  if (await del(['delete-generic-password', '-s', MANAGED_SERVICE, '-a', name])) {
+    deleted.push('managed');
   }
   return deleted;
 }

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -37,6 +37,10 @@ export const SECURITY_BIN =
 export const KEY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
 export const GUI_SERVICE = 'com.aieo.aikeychain';
+// v1.9+ managed namespace (#167): every key under it was created by
+// /usr/bin/security, so headless reads never prompt. New writes go here;
+// GUI_SERVICE and the manual scheme remain read-only legacy fallbacks.
+export const MANAGED_SERVICE = 'com.aieo.aikeychain.managed';
 // Manual entries are identified by env-var-shaped service names (e.g. GITHUB_TOKEN).
 export const MANUAL_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 
@@ -72,6 +76,13 @@ function stripTrailingNewline(s) {
 
 /** Resolve a key to its secret value, or null if not found. */
 export async function resolveKey(name) {
+  // Lookup order: managed (v1.9+, always headless-readable) -> legacy GUI -> manual.
+  const managed = await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name, '-w']);
+  if (managed.ok) {
+    const value = stripTrailingNewline(managed.stdout);
+    return value || null;
+  }
+  if (managed.code !== 44) return null; // fail closed on unexpected errors (#147 semantics)
   const gui = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
   if (gui.ok) {
     const value = stripTrailingNewline(gui.stdout);
@@ -89,9 +100,10 @@ export async function resolveKey(name) {
 
 /** Check where a key exists without reading its secret value. */
 export async function keyExists(name) {
+  const managed = (await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name])).ok;
   const app = (await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name])).ok;
   const manual = (await security(['find-generic-password', '-s', name])).ok;
-  return { name, app, manual, exists: app || manual };
+  return { name, managed, app, manual, exists: managed || app || manual };
 }
 
 /** Redact hex-encoded secret material from text destined for errors/logs. */
@@ -134,7 +146,10 @@ export async function setKey(name, value, { manual = false } = {}) {
   if (/[\u0000-\u001f\u007f]/.test(value)) {
     throw new KeychainError('value must not contain control characters (newlines, tabs, NUL)');
   }
-  const service = manual ? name : GUI_SERVICE;
+  // New writes always target the managed namespace (#167). Updating a legacy
+  // manual entry in place is no longer offered: the managed copy wins the
+  // resolve order, and legacy copies are cleaned up by delete/migration.
+  const service = manual ? name : MANAGED_SERVICE;
   const hex = Buffer.from(value, 'utf8').toString('hex');
   const r = await securityInteractive(
     `add-generic-password -U -s "${service}" -a "${name}" -X ${hex}`
@@ -160,6 +175,10 @@ export async function setKey(name, value, { manual = false } = {}) {
 /** Delete a key from the GUI store and/or the manual store. Returns which stores were deleted. */
 export async function deleteKey(name, { app = true, manual = true } = {}) {
   const deleted = [];
+  if (app) {
+    const m = await security(['delete-generic-password', '-s', MANAGED_SERVICE, '-a', name]);
+    if (m.ok) deleted.push('managed');
+  }
   if (app) {
     const r = await security(['delete-generic-password', '-s', GUI_SERVICE, '-a', name]);
     if (r.ok) deleted.push('app');
@@ -198,7 +217,9 @@ export async function listKeys() {
     keys.get(name).add(source);
   };
   for (const { service, account } of parseDump(r.stdout)) {
-    if (service === GUI_SERVICE && account) {
+    if (service === MANAGED_SERVICE && account) {
+      add(account, 'app');
+    } else if (service === GUI_SERVICE && account) {
       add(account, 'app');
     } else if (service && service !== GUI_SERVICE && MANUAL_NAME_PATTERN.test(service)) {
       add(service, 'manual');
@@ -223,7 +244,7 @@ export async function listKeys() {
 export function findAmbiguousDuplicates(records) {
   const byService = new Map();
   for (const { service, account } of records) {
-    if (!service || service === GUI_SERVICE) continue;
+    if (!service || service === GUI_SERVICE || service === MANAGED_SERVICE) continue;
     if (!MANUAL_NAME_PATTERN.test(service)) continue;
     if (!byService.has(service)) byService.set(service, new Set());
     byService.get(service).add(account ?? '');

--- a/cli/src/mcp-server.js
+++ b/cli/src/mcp-server.js
@@ -72,7 +72,7 @@ export function buildServer() {
       return json({
         reference: `keychain://${name}`,
         exists: exists.exists,
-        stores: { app: exists.app, manual: exists.manual },
+        stores: { managed: exists.managed, app: exists.app, manual: exists.manual },
         usage: exportable
           ? `export ${name}=keychain://${name} && akc run -- <command>`
           : `env '${name}=keychain://${name}' akc run -- <command>`,
@@ -84,21 +84,17 @@ export function buildServer() {
     'set_secret',
     {
       description:
-        'Store or update a key in the AI KeyChain store (overwrites in place, no duplicates). ' +
+        'Store or update a key in the managed namespace (com.aieo.aikeychain.managed; overwrites in place, no duplicates). ' +
         'CAUTION: the secret value passes through the model context when you call this tool — ' +
         'prefer asking the user to run `akc set <KEY>` themselves unless they explicitly pasted ' +
         'the value into the conversation already.',
       inputSchema: {
         name: keyNameSchema,
         value: z.string().min(1).describe('The secret value to store'),
-        manual: z
-          .boolean()
-          .optional()
-          .describe('Store as a manual entry (service=<name>) instead of the AI KeyChain GUI store'),
       },
     },
-    async ({ name, value, manual }) => {
-      const saved = await setKey(name, value, { manual: manual ?? false });
+    async ({ name, value }) => {
+      const saved = await setKey(name, value);
       return json({ saved: true, service: saved.service, account: saved.account });
     }
   );
@@ -107,7 +103,7 @@ export function buildServer() {
     'delete_secret',
     {
       description:
-        'Delete a key from the Keychain (both the AI KeyChain store and manual entries). ' +
+        'Delete a key from the Keychain (managed namespace plus legacy AI KeyChain store / manual copies). ' +
         'Destructive — requires confirm=true, and you should confirm with the user first.',
       inputSchema: {
         name: keyNameSchema,

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -20,31 +20,37 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    --reveal only when you truly need the raw value on stdout; to inject it into
    a process instead, use \`akc run -- <command>\`. If you must use the raw
    security CLI directly, use the form that matches where the key lives:
-     [app] store keys (saved via the AI KeyChain GUI):
+     [managed] keys (saved by akc or the AI KeyChain GUI, v1.9+):
+       /usr/bin/security find-generic-password -s "com.aieo.aikeychain.managed" -a "<KEY>" -w
+     [app] legacy store keys (saved via an older AI KeyChain GUI):
        /usr/bin/security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w
-     [manual] keys (registered by hand) — service name only, do NOT pin the
-     account with -a "$USER":
+     [manual] legacy keys (registered by hand) — service name only, do NOT pin
+     the account with -a "$USER":
        /usr/bin/security find-generic-password -s "<KEY>" -w
    ⚠️ The bare -s "<KEY>" form (no -a) returns "could not be found" (exit 44)
-   for [app] store keys — that is NOT proof the key is unregistered. Confirm
-   with \`akc check <KEY>\` / \`akc get <KEY>\` before concluding a key is
-   missing. (Account attributes on [manual] entries are inconsistent across
+   for [managed]/[app] keys — that is NOT proof the key is unregistered.
+   Confirm with \`akc check <KEY>\` / \`akc get <KEY>\` before concluding a key
+   is missing. (Account attributes on [manual] entries are inconsistent across
    entries; pinning -a there can return a stale/invalid duplicate — AIkeychain
    issue #91.)
-4. To save/update a key, overwrite with -U so no duplicate entries are created:
-     security add-generic-password -s "KEY_NAME" -a "KEY_NAME" -w "<value>" -U
-   (prefer \`akc set KEY_NAME\`: the value is read from a hidden prompt or stdin
-   and handed to \`security -i\` via stdin as hex — it never appears in any
-   process's argv, shell history, or logs.)
+4. To save/update a key, use \`akc set KEY_NAME\`: it writes to the managed
+   namespace with -U (no duplicate entries), and the value is read from a
+   hidden prompt or stdin and handed to \`security -i\` via stdin as hex — it
+   never appears in any process's argv, shell history, or logs. Do NOT invent
+   your own \`security add-generic-password\` invocation: a -w "<value>" form
+   leaks the secret into argv/shell history, and writing to any other service
+   name creates entries outside the managed namespace.
 
 ## Where keys live
 
 | Store | service attribute | account attribute |
 |---|---|---|
-| AI KeyChain GUI store | com.aieo.aikeychain | <KEY_NAME> |
-| Manually-registered keys | <KEY_NAME> | (varies — do not rely on it) |
+| Managed namespace (v1.9+, all new writes) | com.aieo.aikeychain.managed | <KEY_NAME> |
+| AI KeyChain GUI store (legacy, read-only) | com.aieo.aikeychain | <KEY_NAME> |
+| Manually-registered keys (legacy, read-only) | <KEY_NAME> | (varies — do not rely on it) |
 
-\`akc\` looks up the GUI store first, then falls back to service-only lookup.
+\`akc\` looks up managed first, then the legacy GUI store, then the service-only
+manual lookup — falling through ONLY when a tier reports "not found" (exit 44).
 
 ## CLI quick reference
 

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -28,6 +28,12 @@ if [ "$cmd" = "-i" ]; then
   read -r line
   case "$line" in
     add-generic-password*-a\\ \\"NEW_KEY\\"*-X\\ *)
+      # The managed namespace is the ONLY legal write target (#167). A write
+      # to any other service must fail loudly so tests catch a wrong -s.
+      case "$line" in
+        *-s\\ \\"com.aieo.aikeychain.managed\\"*) ;;
+        *) echo "stub -i: write outside the managed namespace: $line" >&2; exit 98 ;;
+      esac
       printf '%s' "\${line##* }" | xxd -r -p > "$state_dir/state-NEW_KEY"
       exit 0 ;;
     add-generic-password*-a\\ \\"ECHO_KEY\\"*-X\\ *)
@@ -51,7 +57,7 @@ case "$cmd" in
     if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "GOOD_KEY" ]; then
       $want_value && echo "stub-good-value"; exit 0
     fi
-    if { [ "$svc" = "com.aieo.aikeychain.managed" ] || [ "$svc" = "com.aieo.aikeychain" ]; } && [ "$acct" = "NEW_KEY" ] && [ -f "$state_dir/state-NEW_KEY" ]; then
+    if [ "$svc" = "com.aieo.aikeychain.managed" ] && [ "$acct" = "NEW_KEY" ] && [ -f "$state_dir/state-NEW_KEY" ]; then
       $want_value && { cat "$state_dir/state-NEW_KEY"; echo; }; exit 0
     fi
     if [ "$svc" = "MANUAL_KEY" ]; then
@@ -276,5 +282,57 @@ test('set rejects invalid names and control characters before touching security'
     (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })
   );
   assert.equal(ctrl.code, 1);
-  assert.match(ctrl.stderr, /control characters/);
+  assert.match(ctrl.stderr, /printable ASCII/);
+});
+
+test('set stores an all-hex ASCII secret verbatim (#179 review: no hex-decode guessing)', async () => {
+  const r = await pExecFile(
+    'bash',
+    ['-c', `printf '4142434445464748' | ${process.execPath} ${AKC} set NEW_KEY`],
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
+  ).then(
+    (r) => ({ code: 0, ...r }),
+    (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
+  );
+  assert.equal(r.code, 0);
+
+  const back = await runAkc(['get', 'NEW_KEY', '--reveal']);
+  assert.equal(back.code, 0);
+  // 値がそのまま返ること — "ABCDEFGH" に化けたら hex 推測復号が復活している
+  assert.equal(back.stdout.trim(), '4142434445464748');
+});
+
+test('set rejects non-ASCII values until the C7 encoding convention lands', async () => {
+  const r = await pExecFile(
+    'bash',
+    ['-c', `printf '秘密のトークン' | ${process.execPath} ${AKC} set NEW_KEY`],
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
+  ).then(
+    () => ({ code: 0 }),
+    (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })
+  );
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /printable ASCII/);
+});
+
+test('set --manual is rejected (#167: managed namespace is the only write target)', async () => {
+  const r = await pExecFile(
+    'bash',
+    ['-c', `echo "v" | ${process.execPath} ${AKC} set NEW_KEY --manual`],
+    { env: { PATH: process.env.PATH, AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security') } }
+  ).then(
+    () => ({ code: 0 }),
+    (e) => ({ code: e.code ?? 1, stderr: e.stderr ?? '' })
+  );
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /--manual is no longer supported/);
+});
+
+test('check shows the managed store and hints the managed `security` form', async () => {
+  // NEW_KEY was stored to the managed namespace by the earlier set test
+  const r = await runAkc(['check', 'NEW_KEY']);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /managed store/);
+  assert.doesNotMatch(r.stdout, /exists \(\)/); // 空括弧にならない (#179 S2)
+  assert.match(r.stdout, /-s "com\.aieo\.aikeychain\.managed" -a "NEW_KEY" -w/);
 });

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -51,7 +51,7 @@ case "$cmd" in
     if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "GOOD_KEY" ]; then
       $want_value && echo "stub-good-value"; exit 0
     fi
-    if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "NEW_KEY" ] && [ -f "$state_dir/state-NEW_KEY" ]; then
+    if { [ "$svc" = "com.aieo.aikeychain.managed" ] || [ "$svc" = "com.aieo.aikeychain" ]; } && [ "$acct" = "NEW_KEY" ] && [ -f "$state_dir/state-NEW_KEY" ]; then
       $want_value && { cat "$state_dir/state-NEW_KEY"; echo; }; exit 0
     fi
     if [ "$svc" = "MANUAL_KEY" ]; then

--- a/cli/test/delete-keychain.test.js
+++ b/cli/test/delete-keychain.test.js
@@ -1,0 +1,119 @@
+// deleteKey semantics (#179 second-stage review B3/B4):
+//   - fallback stores (manual -> legacy GUI) are cleaned BEFORE the managed copy
+//   - manual duplicates are deleted until exit 44 (first-match-only otherwise, #100)
+//   - a non-44 failure aborts with the managed copy intact (no resurrection)
+//   - non-env-var-shaped names never touch the manual tier (other apps' items)
+import { after, before, beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, rm, writeFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let deleteKey;
+let stubDir;
+let callsPath;
+
+// State model: file "managed-<acct>" / "gui-<acct>" exists -> one deletable
+// item; file "manual-<svc>" holds a duplicate counter (issue #100 scenario).
+const STUB = `#!/bin/bash
+dir="$(cd "$(dirname "$0")" && pwd)"
+cmd="$1"; shift
+svc=""; acct=""
+while [ $# -gt 0 ]; do case "$1" in
+  -s) svc="$2"; shift 2 ;;
+  -a) acct="$2"; shift 2 ;;
+  *) shift ;;
+esac; done
+[ "$cmd" = "delete-generic-password" ] || exit 1
+printf '%s|%s\\n' "$svc" "$acct" >> "$dir/calls"
+case "$svc" in
+  com.aieo.aikeychain)
+    case "$acct" in
+      LEGACY_FAIL_KEY) echo "denied" >&2; exit 51 ;;
+    esac
+    if [ -f "$dir/gui-$acct" ]; then rm "$dir/gui-$acct"; exit 0; fi
+    exit 44 ;;
+  com.aieo.aikeychain.managed)
+    if [ -f "$dir/managed-$acct" ]; then rm "$dir/managed-$acct"; exit 0; fi
+    exit 44 ;;
+  *)
+    f="$dir/manual-$svc"
+    if [ -f "$f" ]; then
+      n=$(cat "$f")
+      if [ "$n" -gt 1 ]; then echo $((n-1)) > "$f"; else rm "$f"; fi
+      exit 0
+    fi
+    exit 44 ;;
+esac
+`;
+
+before(async () => {
+  stubDir = await mkdtemp(join(tmpdir(), 'akc-delete-keychain-'));
+  const stubPath = join(stubDir, 'security');
+  callsPath = join(stubDir, 'calls');
+  await writeFile(stubPath, STUB);
+  await chmod(stubPath, 0o755);
+  process.env.AIKEYCHAIN_SECURITY_BIN = stubPath;
+  ({ deleteKey } = await import('../src/keychain.js'));
+});
+
+beforeEach(async () => {
+  await writeFile(callsPath, '');
+});
+
+after(async () => {
+  delete process.env.AIKEYCHAIN_SECURITY_BIN;
+  await rm(stubDir, { recursive: true, force: true });
+});
+
+const exists = (name) => access(join(stubDir, name)).then(() => true, () => false);
+
+test('deleteKey removes manual duplicates until 44, then legacy, then managed', async () => {
+  await writeFile(join(stubDir, 'manual-DUP_KEY'), '3');
+  await writeFile(join(stubDir, 'gui-DUP_KEY'), '');
+  await writeFile(join(stubDir, 'managed-DUP_KEY'), '');
+
+  const deleted = await deleteKey('DUP_KEY');
+  assert.deepEqual(deleted, ['manual', 'app', 'managed']);
+  assert.equal(await exists('manual-DUP_KEY'), false);
+  assert.equal(await exists('gui-DUP_KEY'), false);
+  assert.equal(await exists('managed-DUP_KEY'), false);
+
+  const calls = (await readFile(callsPath, 'utf8')).trim().split('\n');
+  // manual x3 (削除) + manual x1 (44 で終端) → legacy GUI → managed の順
+  assert.deepEqual(calls, [
+    'DUP_KEY|', 'DUP_KEY|', 'DUP_KEY|', 'DUP_KEY|',
+    'com.aieo.aikeychain|DUP_KEY',
+    'com.aieo.aikeychain.managed|DUP_KEY',
+  ]);
+});
+
+test('deleteKey aborts on a legacy failure and leaves the managed copy intact', async () => {
+  await writeFile(join(stubDir, 'managed-LEGACY_FAIL_KEY'), '');
+
+  await assert.rejects(() => deleteKey('LEGACY_FAIL_KEY'), /failed to delete/);
+  // 権威コピーは無傷（「削除成功」報告後に fallback から復活、を構造的に防ぐ）
+  assert.equal(await exists('managed-LEGACY_FAIL_KEY'), true);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.doesNotMatch(calls, /com\.aieo\.aikeychain\.managed/);
+});
+
+test('deleteKey never touches the manual tier for non-env-var-shaped names', async () => {
+  // KEY_NAME_PATTERN はドット/小文字を許すが、service="com.vendor.foo" の削除は
+  // 無関係アプリのアイテム破壊になる — manual 掃除は厳格名のみ (#179 B4)
+  await writeFile(join(stubDir, 'manual-com.vendor.foo'), '1');
+
+  const deleted = await deleteKey('com.vendor.foo');
+  assert.deepEqual(deleted, []);
+  assert.equal(await exists('manual-com.vendor.foo'), true);
+  const calls = (await readFile(callsPath, 'utf8')).trim().split('\n');
+  assert.deepEqual(calls, [
+    'com.aieo.aikeychain|com.vendor.foo',
+    'com.aieo.aikeychain.managed|com.vendor.foo',
+  ]);
+});
+
+test('deleteKey is idempotent when nothing exists anywhere', async () => {
+  const deleted = await deleteKey('NOT_THERE_KEY');
+  assert.deepEqual(deleted, []);
+});

--- a/cli/test/resolve-keychain-bash.test.js
+++ b/cli/test/resolve-keychain-bash.test.js
@@ -24,9 +24,20 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
+  printf '%s\\n' managed >> "$CALLS_PATH"
+  case "$SCENARIO" in
+    managed_value) printf '%s\\n' managed-value; exit 0 ;;
+    managed_51) exit 51 ;;
+    managed_empty) exit 0 ;;
+  esac
+  exit 44
+fi
+
 if [ "$svc" = "com.aieo.aikeychain" ]; then
   printf '%s\\n' gui >> "$CALLS_PATH"
   case "$SCENARIO" in
+    managed_51) printf '%s\\n' stale-gui-value; exit 0 ;;
     gui_51) exit 51 ;;
     gui_empty) exit 0 ;;
     gui_44_manual) exit 44 ;;
@@ -102,35 +113,57 @@ async function assertScenario(scenario, expected) {
 test('scripts/akc resolve_keychain fails closed on GUI exit 51', async () => {
   await assertScenario('gui_51', {
     result: { status: 51, stdout: '', stderr: '' },
-    calls: 'gui\n',
+    calls: 'managed\ngui\n',
   });
 });
 
 test('scripts/akc resolve_keychain fails closed on successful empty GUI value', async () => {
   await assertScenario('gui_empty', {
     result: { status: 1, stdout: '', stderr: '' },
-    calls: 'gui\n',
+    calls: 'managed\ngui\n',
   });
 });
 
 test('scripts/akc resolve_keychain falls back to manual only on GUI exit 44', async () => {
   await assertScenario('gui_44_manual', {
     result: { status: 0, stdout: 'manual-value', stderr: '' },
-    calls: 'gui\nmanual\n',
+    calls: 'managed\ngui\nmanual\n',
   });
 });
 
 test('scripts/akc resolve_keychain returns nonzero on GUI exit 44 and successful empty manual value', async () => {
   await assertScenario('gui_44_manual_empty', {
     result: { status: 1, stdout: '', stderr: '' },
-    calls: 'gui\nmanual\n',
+    calls: 'managed\ngui\nmanual\n',
   });
 });
 
 test('scripts/akc resolve_keychain returns a nonempty GUI value without manual fallback', async () => {
   await assertScenario('gui_value', {
     result: { status: 0, stdout: 'gui-value', stderr: '' },
-    calls: 'gui\n',
+    calls: 'managed\ngui\n',
+  });
+});
+
+test('scripts/akc resolve_keychain returns a managed value without legacy fallback (#167)', async () => {
+  await assertScenario('managed_value', {
+    result: { status: 0, stdout: 'managed-value', stderr: '' },
+    calls: 'managed\n',
+  });
+});
+
+test('scripts/akc resolve_keychain fails closed on managed exit 51 (#179 review B1)', async () => {
+  // GUI 段は stale な値を返せる状態だが、managed の権威的失敗で止まること
+  await assertScenario('managed_51', {
+    result: { status: 51, stdout: '', stderr: '' },
+    calls: 'managed\n',
+  });
+});
+
+test('scripts/akc resolve_keychain fails closed on successful empty managed value', async () => {
+  await assertScenario('managed_empty', {
+    result: { status: 1, stdout: '', stderr: '' },
+    calls: 'managed\n',
   });
 });
 
@@ -145,5 +178,5 @@ test('scripts/akc cmd_run rejects nonempty resolver output when its exit status 
   assert.match(result.stdout, /Resolved: 0, Failed: 1/);
   assert.doesNotMatch(result.stdout, /rejected-value/);
   assert.match(result.stderr, /TEST_REF .* not found in Keychain/);
-  assert.equal(await readFile(callsPath, 'utf8'), 'gui\nmanual\n');
+  assert.equal(await readFile(callsPath, 'utf8'), 'managed\ngui\nmanual\n');
 });

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 let resolveKey;
+let keyExists;
 let stubDir;
 let callsPath;
 
@@ -21,6 +22,20 @@ while [ $# -gt 0 ]; do
   esac
 done
 printf '%s|%s\\n' "$svc" "$acct" >> "$stub_dir/calls"
+
+if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
+  case "$acct" in
+    MANAGED_KEY) printf '%s\\n' "managed-value"; exit 0 ;;
+    MANAGED_EMPTY_KEY) exit 0 ;;
+    MGERR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
+  esac
+fi
+
+if [ "$svc" = "com.aieo.aikeychain" ]; then
+  case "$acct" in
+    MGERR_KEY) printf '%s\\n' "stale-gui-value"; exit 0 ;;
+  esac
+fi
 
 if [ "$svc" = "com.aieo.aikeychain" ]; then
   case "$acct" in
@@ -48,7 +63,7 @@ before(async () => {
   await writeFile(stubPath, STUB);
   await chmod(stubPath, 0o755);
   process.env.AIKEYCHAIN_SECURITY_BIN = stubPath;
-  ({ resolveKey } = await import('../src/keychain.js'));
+  ({ resolveKey, keyExists } = await import('../src/keychain.js'));
 });
 
 beforeEach(async () => {
@@ -82,4 +97,36 @@ test('resolveKey treats an empty successful GUI value as authoritative failure',
 
 test('resolveKey returns the GUI storage value without manual fallback', async () => {
   assert.equal(await resolveKey('GUI_KEY'), 'gui-value');
+});
+
+test('resolveKey returns the managed value without touching legacy tiers (#167)', async () => {
+  assert.equal(await resolveKey('MANAGED_KEY'), 'managed-value');
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|MANAGED_KEY\n');
+});
+
+test('resolveKey fails closed on a non-44 managed lookup error (#179 review)', async () => {
+  // GUI 段には stale な値が存在するが、managed 段の権威的失敗 (exit 51) で
+  // チェーンは止まらなければならない（#150 の GUI 応答=権威と同じ原則）。
+  assert.equal(await resolveKey('MGERR_KEY'), null);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|MGERR_KEY\n');
+});
+
+test('resolveKey treats an empty successful managed value as authoritative failure', async () => {
+  assert.equal(await resolveKey('MANAGED_EMPTY_KEY'), null);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|MANAGED_EMPTY_KEY\n');
+});
+
+test('keyExists reports the managed store', async () => {
+  const r = await keyExists('MANAGED_KEY');
+  assert.equal(r.managed, true);
+  assert.equal(r.app, false);
+  assert.equal(r.manual, false);
+  assert.equal(r.exists, true);
+});
+
+test('keyExists fails closed (throws) on a non-44 probe error (#179 review S1)', async () => {
+  await assert.rejects(() => keyExists('MGERR_KEY'), /keychain probe failed/);
 });

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -63,7 +63,7 @@ after(async () => {
 test('resolveKey fails closed on a non-44 GUI lookup error (#147)', async () => {
   assert.equal(await resolveKey('ERROR_KEY'), null);
   const calls = await readFile(callsPath, 'utf8');
-  assert.equal(calls, 'com.aieo.aikeychain|ERROR_KEY\n');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|ERROR_KEY\ncom.aieo.aikeychain|ERROR_KEY\n');
 });
 
 test('resolveKey falls back to manual storage when GUI lookup exits 44', async () => {
@@ -77,7 +77,7 @@ test('resolveKey returns null when GUI lookup exits 44 and manual value is empty
 test('resolveKey treats an empty successful GUI value as authoritative failure', async () => {
   assert.equal(await resolveKey('EMPTY_KEY'), null);
   const calls = await readFile(callsPath, 'utf8');
-  assert.equal(calls, 'com.aieo.aikeychain|EMPTY_KEY\n');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|EMPTY_KEY\ncom.aieo.aikeychain|EMPTY_KEY\n');
 });
 
 test('resolveKey returns the GUI storage value without manual fallback', async () => {

--- a/scripts/akc
+++ b/scripts/akc
@@ -10,9 +10,10 @@
 # via macOS Keychain (security find-generic-password) and injected into the
 # child process environment. The parent process env is never modified.
 #
-# Lookup order:
-#   1. service="com.aieo.aikeychain" account="<KEY_NAME>"  (AI KeyChain GUI store)
-#   2. service="<KEY_NAME>"  (GUI が exit 44/not-found の場合のみ; account 非指定)
+# Lookup order (各段は exit 44/not-found の場合のみ次へ / #150):
+#   1. service="com.aieo.aikeychain.managed" account="<KEY_NAME>"  (managed namespace, v1.9+ / #167)
+#   2. service="com.aieo.aikeychain" account="<KEY_NAME>"  (旧 AI KeyChain GUI store)
+#   3. service="<KEY_NAME>"  (旧 manual スキーム; account 非指定)
 #      -a は付けない: 手動登録キーは acct の値が一定しないため、
 #      service 名のみで引く方が安定する (issue #91)
 
@@ -57,6 +58,16 @@ resolve_keychain() {
     local key_name="$1"
     local value
     local rc
+
+    # managed namespace (#167, v1.9+): akc/GUI の新規保存は全てここ。
+    # 44 (not found) のときだけ次の段へ落ちる（それ以外は権威的失敗 / #150）
+    if value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain.managed" -a "$key_name" -w 2>/dev/null); then
+        [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+        return 1
+    else
+        rc=$?
+        [ "$rc" -eq 44 ] || return "$rc"
+    fi
 
     if value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null); then
         [ -n "$value" ] && { printf '%s' "$value"; return 0; }


### PR DESCRIPTION
Refs #169 / #167（クローズはしない — C2 の受入は v1.9 リリーストレイン全体で判定）

## 概要
#167 v2 設計のコア。`/usr/bin/security` を単一の作成/更新アイデンティティにし、予約 namespace **`com.aieo.aikeychain.managed`** で「キー = security 作成 = `akc run` がヘッドレスで読める」を構造的に保証する。

## 実測根拠（#168 全ゲート green）
- **S6**: LaunchServices 起動・DevID・hardened runtime アプリの子 security 作成キーを headless security が無音読取（土台）
- **S7'**: security 所有キーへの `-U` 更新は headless 読取を保持（CLI/GUI とも -U 維持で原子性問題が消える）
- **S5**: prompt-blocked 子の SIGKILL はゾンビ/モーダルブロックなし → timeout+kill で permit 回収可
- **E6-1**: cross-owner in-process 読みは ~7s ブロック → in-process 値読取は全廃

## 変更
- `SecurityCLIKeychainService` 新設（詳細はコミットメッセージ）: stdin+hex 書込 / subprocess 読取 + timeout + PG-SIGKILL / **per-key quarantine + coalescing** / 属性のみの無音列挙 / manual 発見廃止
- GUI・Proxy の既定サービスを切替（9 箇所）
- stub security による新テスト 9 件、**全 184 テストパス**

## 遷移期の既知事項（ゲート運用）
既存キー（旧 namespace）は C5 移行アシスタント（#172）が入るまで GUI に出ない。**v1.9 リリースは C2+C3+C5 が揃うまで行わない**（リリースは手動・CI は notes-only のため main マージは安全）。

## レビュー
コア変更のため二段階レビュー（Fable workflow + codex solultra）を実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vYEmXxxBRyjwYZoy7u5pq