### PR TITLE
feat(cli): C4 — akc/MCP の有界失敗 + migration required + doctor 未移行検出 (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ akc init                     # set up AI-agent discovery machine-wide (Claude + 
 # Secret Reference workflow
 export OPENAI_API_KEY=keychain://OPENAI_API_KEY
 akc run -- claude            # real value injected into the child process only
+# Headless contract: managed keys resolve silently; a legacy GUI-owned key
+# never hangs akc — the read times out with an explicit "migration required"
+# error (migrate with `akc set <KEY>`; `akc doctor` lists unmigrated keys)
 
 akc list                     # key names (never prints values)
 akc set GITHUB_TOKEN         # hidden prompt, overwrites in place

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -49,7 +49,7 @@ Commands:
   get      Print the keychain:// reference for a key (--reveal prints the raw value)
   set      Store/update a key (value via hidden prompt, or piped stdin)
   delete   Delete a key from the Keychain
-  doctor   Diagnose env + ~/.zshrc keychain references (values masked)
+  doctor   Diagnose env + ~/.zshrc refs + unmigrated legacy keys (values masked)
   guide    Print the AI KeyChain usage guide
   mcp      Start the MCP server on stdio (for Claude Code / Codex etc.)
 

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -6,7 +6,13 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, isAbsolute } from 'node:path';
 import { collectRefs, resolveRefs } from './run.js';
-import { listKeys, resolveKey, listAmbiguousDuplicates, KeychainError } from './keychain.js';
+import {
+  listKeys,
+  resolveKey,
+  listAmbiguousDuplicates,
+  listUnmigratedKeys,
+  KeychainError,
+} from './keychain.js';
 
 /** Extract keychain://KEY and `security find-generic-password -s "KEY"` keys from shell config text. */
 export function scanShellConfig(text) {
@@ -168,6 +174,31 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
     // keychain access already reported above; skip duplicate scan on failure
   }
 
+  // Unmigrated legacy keys (#171): exist only in the GUI store / manual scheme
+  // with no managed copy. Headless reads of GUI-owned ones prompt/hang (bounded
+  // to a timeout since #171). Detection is non-destructive — dump-keychain
+  // attributes only, no `find -w` probes (those would rain consent dialogs).
+  try {
+    const unmigrated = await listUnmigratedKeys();
+    if (unmigrated.length === 0) {
+      check('migration', true, 'no unmigrated legacy keys (all keys have a managed copy)');
+    } else {
+      check(
+        'migration',
+        false,
+        `${unmigrated.length} key(s) exist only in legacy stores — headless reads may be ` +
+          'bounded-failed (migration required):' + '\n' +
+          unmigrated
+            .map((k) => `       - ${k.name} [${k.stores.join(', ')}] → migrate: akc set ${k.name}`)
+            .join('\n') +
+          '\n       (or use the AI KeyChain app to migrate; legacy copies are cleaned up on delete)'
+      );
+    }
+  } catch (err) {
+    if (!(err instanceof KeychainError)) throw err;
+    // keychain access failure already reported above; skip migration scan
+  }
+
   // MCP registration path-independence (issue #131): warn on bare `akc` or a
   // stale absolute path. Read config files directly (read-only, testable) —
   // no `claude mcp list` (which health-checks every server and can hang).
@@ -204,8 +235,13 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
     } else {
       const missing = [];
       for (const key of keys) {
-        const value = await resolveKey(key);
-        if (!value) missing.push(key);
+        try {
+          const value = await resolveKey(key);
+          if (!value) missing.push(key);
+        } catch (err) {
+          if (!(err instanceof KeychainError)) throw err;
+          missing.push(`${key} (${err.message.split('.')[0]})`); // 有界失敗の理由を短く添える
+        }
       }
       check(
         'shell config',

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -7,11 +7,14 @@ import { homedir } from 'node:os';
 import { join, isAbsolute } from 'node:path';
 import { collectRefs, resolveRefs } from './run.js';
 import {
-  listKeys,
   resolveKey,
-  listAmbiguousDuplicates,
-  listUnmigratedKeys,
+  dumpRecords,
+  findAmbiguousDuplicates,
+  findUnmigratedKeys,
   KeychainError,
+  GUI_SERVICE,
+  MANAGED_SERVICE,
+  MANUAL_NAME_PATTERN,
 } from './keychain.js';
 
 /** Extract keychain://KEY and `security find-generic-password -s "KEY"` keys from shell config text. */
@@ -136,12 +139,21 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
   }
   check('platform', true, 'macOS');
 
-  // GUI / manual store reachability (names only)
-  let appKeyCount = null;
+  // Keychain enumeration — ONE bounded dump-keychain call shared by the three
+  // checks below (#185 S7: three independent dumps would stack three timeouts
+  // when the enumeration hangs). Names/accts only; values are never read.
+  let records = null;
   try {
-    const keys = await listKeys();
-    appKeyCount = keys.filter((k) => k.sources.includes('app')).length;
-    check('keychain access', true, `${keys.length} key(s) visible (${appKeyCount} in AI KeyChain store)`);
+    records = await dumpRecords();
+    const names = new Set();
+    for (const { service, account } of records) {
+      if ((service === MANAGED_SERVICE || service === GUI_SERVICE) && account) names.add(account);
+      else if (service && MANUAL_NAME_PATTERN.test(service)) names.add(service);
+    }
+    const managedCount = new Set(
+      records.filter((r) => r.service === MANAGED_SERVICE && r.account).map((r) => r.account)
+    ).size;
+    check('keychain access', true, `${names.size} key(s) visible (${managedCount} in the managed namespace)`);
   } catch (err) {
     if (err instanceof KeychainError) {
       check('keychain access', false, err.message);
@@ -150,9 +162,9 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
     }
   }
 
-  // Ambiguous duplicate entries (issue #91): same service name, multiple accts.
-  try {
-    const dups = await listAmbiguousDuplicates();
+  if (records !== null) {
+    // Ambiguous duplicate entries (issue #91): same service name, multiple accts.
+    const dups = findAmbiguousDuplicates(records);
     if (dups.length === 0) {
       check('duplicate entries', true, 'no ambiguous duplicate keychain entries');
     } else {
@@ -169,19 +181,28 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
             .join('\n')
       );
     }
-  } catch (err) {
-    if (!(err instanceof KeychainError)) throw err;
-    // keychain access already reported above; skip duplicate scan on failure
-  }
 
-  // Unmigrated legacy keys (#171): exist only in the GUI store / manual scheme
-  // with no managed copy. Headless reads of GUI-owned ones prompt/hang (bounded
-  // to a timeout since #171). Detection is non-destructive — dump-keychain
-  // attributes only, no `find -w` probes (those would rain consent dialogs).
-  try {
-    const unmigrated = await listUnmigratedKeys();
+    // Unmigrated legacy keys (#171): exist only in the GUI store / manual scheme
+    // with no managed copy. Headless reads of GUI-owned ones prompt/hang (bounded
+    // to a timeout since #171). Detection is non-destructive — dump attributes
+    // only, no `find -w` probes (those would rain consent dialogs). Manual-scheme
+    // hits are candidates by name shape — an unrelated app's UPPER_SNAKE service
+    // would match too (#185 D-Q1; same rule as `akc list` since #160).
+    const { keys: unmigrated, unparseable } = findUnmigratedKeys(records);
+    if (unparseable > 0) {
+      report.warnings.push(
+        `${unparseable} AI KeyChain store record(s) could not be parsed from dump-keychain — ` +
+          'migration status may be incomplete'
+      );
+    }
     if (unmigrated.length === 0) {
-      check('migration', true, 'no unmigrated legacy keys (all keys have a managed copy)');
+      check(
+        'migration',
+        true,
+        unparseable > 0
+          ? 'no unmigrated legacy keys detected (but see the unparseable-records warning)'
+          : 'no unmigrated legacy keys (all keys have a managed copy)'
+      );
     } else {
       check(
         'migration',
@@ -191,12 +212,10 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
           unmigrated
             .map((k) => `       - ${k.name} [${k.stores.join(', ')}] → migrate: akc set ${k.name}`)
             .join('\n') +
-          '\n       (or use the AI KeyChain app to migrate; legacy copies are cleaned up on delete)'
+          '\n       (or use the AI KeyChain app to migrate; legacy copies are cleaned up on delete.' +
+          '\n        [manual] entries are name-shape candidates and may belong to another tool)'
       );
     }
-  } catch (err) {
-    if (!(err instanceof KeychainError)) throw err;
-    // keychain access failure already reported above; skip migration scan
   }
 
   // MCP registration path-independence (issue #131): warn on bare `akc` or a
@@ -215,7 +234,11 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
       'env references',
       failed.length === 0,
       `${Object.keys(resolved).length}/${refs.length} resolved` +
-        (failed.length ? ` — missing: ${failed.map((f) => f.keyName).join(', ')}` : '')
+        (failed.length
+          ? ` — failed: ${failed
+              .map((f) => (f.reason ? `${f.keyName} (${f.reason.split('\n')[0]})` : `${f.keyName} (not found)`))
+              .join(', ')}`
+          : '')
     );
   }
 
@@ -240,7 +263,7 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
           if (!value) missing.push(key);
         } catch (err) {
           if (!(err instanceof KeychainError)) throw err;
-          missing.push(`${key} (${err.message.split('.')[0]})`); // 有界失敗の理由を短く添える
+          missing.push(`${key} (${err.message.split('\n')[0]})`); // 有界失敗の理由を添える（'.'分割はドット入りキー名で壊れる — #185 S6）
         }
       }
       check(

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -49,6 +49,25 @@ export const MANUAL_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 
 export class KeychainError extends Error {}
 
+/**
+ * A legacy (GUI-owned or manual) item blocked the headless read on a keychain
+ * consent prompt and the subprocess was killed (#171). The contract is
+ * "new/migrated (managed) keys succeed silently; legacy keys fail bounded" —
+ * NOT "mixed stores always succeed". The fix is migration, so say so.
+ */
+export class MigrationRequiredError extends KeychainError {
+  constructor(name, store) {
+    super(
+      `"${name}" is stored as a legacy ${store} item that cannot be read headlessly ` +
+        `(the read blocked on a keychain prompt and was killed after ${SUBPROCESS_TIMEOUT_MS / 1000}s). ` +
+        `Migrate it to the managed namespace: re-register with \`akc set ${name}\`, ` +
+        `or use the AI KeyChain app's migration assistant.`
+    );
+    this.keyName = name;
+    this.store = store;
+  }
+}
+
 export function assertMacOS() {
   if (process.platform !== 'darwin') {
     throw new KeychainError(
@@ -59,9 +78,14 @@ export function assertMacOS() {
 
 // Bound every subprocess: a prompt-blocked keychain operation must fail after
 // SUBPROCESS_TIMEOUT_MS instead of hanging `akc run`/`akc set` forever — the
-// whole point of the headless epic (#167). Matches the Swift service's
+// whole point of the headless epic (#167/#171). Matches the Swift service's
 // timeout + SIGKILL semantics.
-export const SUBPROCESS_TIMEOUT_MS = 10_000;
+//
+// AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS is a test-only override (so the hang path
+// can be exercised without waiting 10s). Production always uses the default.
+const timeoutOverride = Number(process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS);
+export const SUBPROCESS_TIMEOUT_MS =
+  Number.isFinite(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : 10_000;
 
 async function security(args) {
   try {
@@ -75,7 +99,10 @@ async function security(args) {
     return {
       ok: false,
       code: err.code ?? null,
-      killed: err.killed ?? false,
+      // execFile sets killed=true when OUR timeout fired and we sent the kill
+      // signal — the marker for "the read blocked (keychain prompt) and was
+      // killed", which callers turn into a bounded, explanatory error (#171).
+      timedOut: err.killed === true,
       stdout: err.stdout ?? '',
       stderr: err.stderr ?? String(err),
     };
@@ -86,7 +113,13 @@ function stripTrailingNewline(s) {
   return s.endsWith('\n') ? s.slice(0, -1) : s;
 }
 
-/** Resolve a key to its secret value, or null if not found. */
+/**
+ * Resolve a key to its secret value, or null if not found.
+ * Throws MigrationRequiredError when a legacy tier blocks on a prompt (#171),
+ * and KeychainError when the managed tier times out (managed items are
+ * security-owned and never prompt — a timeout there means a locked/unavailable
+ * keychain, not an ownership problem).
+ */
 export async function resolveKey(name) {
   // Lookup order: managed (v1.9+, always headless-readable) -> legacy GUI -> manual.
   const managed = await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name, '-w']);
@@ -94,12 +127,19 @@ export async function resolveKey(name) {
     const value = stripTrailingNewline(managed.stdout);
     return value || null;
   }
+  if (managed.timedOut) {
+    throw new KeychainError(
+      `reading "${name}" from the managed namespace timed out — the keychain is likely locked ` +
+        'or unavailable. Unlock the login keychain and retry.'
+    );
+  }
   if (managed.code !== 44) return null; // fail closed on unexpected errors (#147 semantics)
   const gui = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
   if (gui.ok) {
     const value = stripTrailingNewline(gui.stdout);
     return value || null;
   }
+  if (gui.timedOut) throw new MigrationRequiredError(name, 'GUI-store');
   if (gui.code !== 44) return null;
 
   const manual = await security(['find-generic-password', '-s', name, '-w']);
@@ -107,6 +147,7 @@ export async function resolveKey(name) {
     const value = stripTrailingNewline(manual.stdout);
     if (value) return value;
   }
+  if (manual.timedOut) throw new MigrationRequiredError(name, 'manual');
   return null;
 }
 
@@ -329,6 +370,46 @@ export function findAmbiguousDuplicates(records) {
     .filter(([, accts]) => accts.size > 1)
     .map(([service, accts]) => ({ service, accounts: [...accts].sort() }))
     .sort((a, b) => a.service.localeCompare(b.service));
+}
+
+/**
+ * Detect keys that exist only in legacy namespaces (GUI store / manual scheme)
+ * with no managed copy (#171). These are exactly the keys whose headless reads
+ * can prompt/hang; the doctor surfaces them with migration guidance.
+ * Non-destructive: derived from dump-keychain attributes — no values are read
+ * and no `find -w` probes run (a probe would rain consent dialogs when headed).
+ */
+export function findUnmigratedKeys(records) {
+  const managed = new Set(
+    records.filter((r) => r.service === MANAGED_SERVICE && r.account).map((r) => r.account)
+  );
+  const byName = new Map();
+  for (const { service, account } of records) {
+    let name = null;
+    let store = null;
+    if (service === GUI_SERVICE && account) {
+      name = account;
+      store = 'gui';
+    } else if (service && service !== MANAGED_SERVICE && MANUAL_NAME_PATTERN.test(service)) {
+      name = service;
+      store = 'manual';
+    }
+    if (!name || managed.has(name)) continue;
+    if (!byName.has(name)) byName.set(name, new Set());
+    byName.get(name).add(store);
+  }
+  return [...byName.entries()]
+    .map(([name, stores]) => ({ name, stores: [...stores].sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Convenience wrapper around the live keychain dump (names/accts only). */
+export async function listUnmigratedKeys() {
+  const r = await security(['dump-keychain']);
+  if (!r.ok) {
+    throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
+  }
+  return findUnmigratedKeys(parseDump(r.stdout));
 }
 
 /** Convenience wrapper around the live keychain dump (names/accts only). */

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -82,10 +82,18 @@ export function assertMacOS() {
 // timeout + SIGKILL semantics.
 //
 // AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS is a test-only override (so the hang path
-// can be exercised without waiting 10s). Production always uses the default.
-const timeoutOverride = Number(process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS);
+// can be exercised without waiting 10s). Strictly validated (#185 S3): a
+// positive integer between 100ms and 600s — anything else (floats break
+// execFile's integer timeout, tiny values would fail healthy reads, huge
+// values clamp weirdly in Node's timers) falls back to the default.
+const timeoutOverride = process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS;
 export const SUBPROCESS_TIMEOUT_MS =
-  Number.isFinite(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : 10_000;
+  typeof timeoutOverride === 'string' &&
+  /^\d+$/.test(timeoutOverride) &&
+  Number(timeoutOverride) >= 100 &&
+  Number(timeoutOverride) <= 600_000
+    ? Number(timeoutOverride)
+    : 10_000;
 
 async function security(args) {
   try {
@@ -133,14 +141,25 @@ export async function resolveKey(name) {
         'or unavailable. Unlock the login keychain and retry.'
     );
   }
-  if (managed.code !== 44) return null; // fail closed on unexpected errors (#147 semantics)
+  if (managed.code !== 44) {
+    // fail closed on unexpected errors (#147 semantics) — but say why (#185 S4)
+    throw new KeychainError(
+      `reading "${name}" from the managed namespace failed (exit ${managed.code}): ` +
+        `${managed.stderr.trim() || 'unknown error'}`
+    );
+  }
   const gui = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
   if (gui.ok) {
     const value = stripTrailingNewline(gui.stdout);
     return value || null;
   }
   if (gui.timedOut) throw new MigrationRequiredError(name, 'GUI-store');
-  if (gui.code !== 44) return null;
+  if (gui.code !== 44) {
+    throw new KeychainError(
+      `reading "${name}" from the legacy GUI store failed (exit ${gui.code}): ` +
+        `${gui.stderr.trim() || 'unknown error'}`
+    );
+  }
 
   const manual = await security(['find-generic-password', '-s', name, '-w']);
   if (manual.ok) {
@@ -148,6 +167,12 @@ export async function resolveKey(name) {
     if (value) return value;
   }
   if (manual.timedOut) throw new MigrationRequiredError(name, 'manual');
+  if (!manual.ok && manual.code !== 44) {
+    throw new KeychainError(
+      `reading "${name}" from the manual scheme failed (exit ${manual.code}): ` +
+        `${manual.stderr.trim() || 'unknown error'}`
+    );
+  }
   return null;
 }
 
@@ -383,8 +408,16 @@ export function findUnmigratedKeys(records) {
   const managed = new Set(
     records.filter((r) => r.service === MANAGED_SERVICE && r.account).map((r) => r.account)
   );
+  // GUI/managed store のレコードで account が解析できなかったものは、未移行判定の
+  // 信頼性を落とす（false negative の芽）。黙って捨てず件数を返して doctor が
+  // 「判定不能あり」と警告できるようにする (#185 S8)。
+  let unparseable = 0;
   const byName = new Map();
   for (const { service, account } of records) {
+    if ((service === GUI_SERVICE || service === MANAGED_SERVICE) && !account) {
+      unparseable += 1;
+      continue;
+    }
     let name = null;
     let store = null;
     if (service === GUI_SERVICE && account) {
@@ -398,18 +431,25 @@ export function findUnmigratedKeys(records) {
     if (!byName.has(name)) byName.set(name, new Set());
     byName.get(name).add(store);
   }
-  return [...byName.entries()]
+  const keys = [...byName.entries()]
     .map(([name, stores]) => ({ name, stores: [...stores].sort() }))
     .sort((a, b) => a.name.localeCompare(b.name));
+  return { keys, unparseable };
 }
 
-/** Convenience wrapper around the live keychain dump (names/accts only). */
-export async function listUnmigratedKeys() {
+/** One dump-keychain call, parsed. Shared by doctor so a hanging enumeration
+ *  costs one bounded subprocess, not three (#185 S7). Names/accts only. */
+export async function dumpRecords() {
   const r = await security(['dump-keychain']);
   if (!r.ok) {
     throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
   }
-  return findUnmigratedKeys(parseDump(r.stdout));
+  return parseDump(r.stdout);
+}
+
+/** Convenience wrapper around the live keychain dump (names/accts only). */
+export async function listUnmigratedKeys() {
+  return findUnmigratedKeys(await dumpRecords());
 }
 
 /** Convenience wrapper around the live keychain dump (names/accts only). */

--- a/cli/src/run.js
+++ b/cli/src/run.js
@@ -5,7 +5,7 @@
 
 import { spawn } from 'node:child_process';
 import { constants as osConstants } from 'node:os';
-import { resolveKey, maskValue } from './keychain.js';
+import { resolveKey, maskValue, KeychainError } from './keychain.js';
 
 export const REF_PREFIX = 'keychain://';
 
@@ -16,19 +16,37 @@ export function collectRefs(env) {
     .map(([varName, value]) => ({ varName, keyName: value.slice(REF_PREFIX.length) }));
 }
 
-/** Resolve refs sequentially (parallel lookups can stack keychain auth prompts). */
+/**
+ * Resolve refs sequentially (parallel lookups can stack keychain auth prompts).
+ * Failures carry a `reason`: 'not-found', or a bounded-failure message from
+ * resolveKey (migration required / keychain locked — #171). One key's bounded
+ * failure must not abort the scan: the user should see ALL broken refs at once.
+ */
 export async function resolveRefs(refs) {
   const resolved = {};
   const failed = [];
   for (const { varName, keyName } of refs) {
-    const value = await resolveKey(keyName);
-    if (value) {
-      resolved[varName] = value;
-    } else {
-      failed.push({ varName, keyName });
+    try {
+      const value = await resolveKey(keyName);
+      if (value) {
+        resolved[varName] = value;
+      } else {
+        failed.push({ varName, keyName, reason: null });
+      }
+    } catch (err) {
+      if (!(err instanceof KeychainError)) throw err;
+      failed.push({ varName, keyName, reason: err.message });
     }
   }
   return { resolved, failed };
+}
+
+function failureLine(varName, keyName, reason) {
+  return reason
+    ? `  ❌ ${varName} — keychain://${keyName}: ${reason}
+`
+    : `  ❌ ${varName} — keychain://${keyName} not found in Keychain
+`;
 }
 
 export async function cmdRun(argv) {
@@ -67,7 +85,8 @@ export async function cmdRun(argv) {
           `  ✅ ${varName} = ${maskValue(resolved[varName])} (from keychain://${keyName})\n`
         );
       } else {
-        process.stderr.write(`  ❌ ${varName} — keychain://${keyName} not found in Keychain\n`);
+        const reason = failed.find((f) => f.varName === varName)?.reason;
+        process.stderr.write(failureLine(varName, keyName, reason));
       }
     }
     process.stdout.write(`\nResolved: ${Object.keys(resolved).length}, Failed: ${failed.length}\n`);
@@ -78,8 +97,8 @@ export async function cmdRun(argv) {
   }
 
   if (failed.length > 0) {
-    for (const { varName, keyName } of failed) {
-      process.stderr.write(`  ❌ ${varName} — keychain://${keyName} not found in Keychain\n`);
+    for (const { varName, keyName, reason } of failed) {
+      process.stderr.write(failureLine(varName, keyName, reason));
     }
     process.stderr.write(`akc: ${failed.length} keychain reference(s) could not be resolved\n`);
     process.stderr.write("akc: run 'akc run --dry-run' to see details\n");

--- a/cli/src/run.js
+++ b/cli/src/run.js
@@ -5,7 +5,7 @@
 
 import { spawn } from 'node:child_process';
 import { constants as osConstants } from 'node:os';
-import { resolveKey, maskValue, KeychainError } from './keychain.js';
+import { resolveKey, maskValue, KeychainError, SUBPROCESS_TIMEOUT_MS } from './keychain.js';
 
 export const REF_PREFIX = 'keychain://';
 
@@ -18,24 +18,45 @@ export function collectRefs(env) {
 
 /**
  * Resolve refs sequentially (parallel lookups can stack keychain auth prompts).
- * Failures carry a `reason`: 'not-found', or a bounded-failure message from
- * resolveKey (migration required / keychain locked — #171). One key's bounded
- * failure must not abort the scan: the user should see ALL broken refs at once.
+ * Failures carry a `reason`: null for plain not-found, or a bounded-failure
+ * message from resolveKey (migration required / keychain locked — #171).
+ * One key's bounded failure must not abort the scan (the user should see ALL
+ * broken refs at once) — but the scan as a whole is still bounded (#185 S7):
+ * - duplicate keyNames are resolved once (cache)
+ * - after `deadlineMs`, remaining unresolved keys are skipped with an
+ *   explanatory reason instead of stacking N x timeout
  */
-export async function resolveRefs(refs) {
+export async function resolveRefs(refs, { deadlineMs = SUBPROCESS_TIMEOUT_MS * 3 } = {}) {
   const resolved = {};
   const failed = [];
+  const cache = new Map(); // keyName -> { value } | { err }
+  const deadline = Date.now() + deadlineMs;
   for (const { varName, keyName } of refs) {
-    try {
-      const value = await resolveKey(keyName);
-      if (value) {
-        resolved[varName] = value;
+    let entry = cache.get(keyName);
+    if (!entry) {
+      if (Date.now() > deadline) {
+        entry = {
+          err: new KeychainError(
+            'skipped: command deadline exceeded after earlier keychain timeouts — ' +
+              'fix the keys reported above, then retry (see `akc doctor`)'
+          ),
+        };
       } else {
-        failed.push({ varName, keyName, reason: null });
+        try {
+          entry = { value: await resolveKey(keyName) };
+        } catch (err) {
+          if (!(err instanceof KeychainError)) throw err;
+          entry = { err };
+        }
       }
-    } catch (err) {
-      if (!(err instanceof KeychainError)) throw err;
-      failed.push({ varName, keyName, reason: err.message });
+      cache.set(keyName, entry);
+    }
+    if (entry.err) {
+      failed.push({ varName, keyName, reason: entry.err.message });
+    } else if (entry.value) {
+      resolved[varName] = entry.value;
+    } else {
+      failed.push({ varName, keyName, reason: null });
     }
   }
   return { resolved, failed };

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -41,6 +41,19 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    leaks the secret into argv/shell history, and writing to any other service
    name creates entries outside the managed namespace.
 
+## Headless contract (what akc promises)
+
+- Keys in the **managed namespace** (saved by \`akc set\` or the AI KeyChain app
+  v1.9+) resolve **silently** — no prompts, no hangs, ever.
+- **Legacy keys** (old GUI store / manually registered) may be readable, but a
+  GUI-owned item can block on a keychain consent prompt. akc **never hangs**:
+  the read is killed after a timeout and you get an explicit
+  "migration required" error telling you to re-register the key
+  (\`akc set <KEY>\`) or use the app's migration assistant.
+- The promise is "new/migrated keys succeed silently; legacy keys fail bounded"
+  — NOT "mixed stores always succeed". Run \`akc doctor\` to list unmigrated
+  keys before relying on headless execution.
+
 ## Where keys live
 
 | Store | service attribute | account attribute |
@@ -60,7 +73,7 @@ manual lookup — falling through ONLY when a tier reports "not found" (exit 44)
   akc check <KEY>             check whether a key exists and where
   akc set <KEY>               store/update a key (value via hidden prompt or stdin)
   akc delete <KEY>            delete a key
-  akc doctor                  diagnose env + ~/.zshrc keychain references
+  akc doctor                  diagnose env + ~/.zshrc refs + unmigrated legacy keys
   akc mcp                     start the MCP server (stdio)
 
 ## MCP setup (Claude Code)

--- a/cli/test/resolve-keychain-bash.test.js
+++ b/cli/test/resolve-keychain-bash.test.js
@@ -1,7 +1,7 @@
 import { after, before, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -31,6 +31,7 @@ if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
     managed_51) exit 51 ;;
     managed_empty) exit 0 ;;
     gui_hang) exit 44 ;;
+    managed_hang) sleep 60 ;;
   esac
   exit 44
 fi
@@ -177,15 +178,52 @@ test('scripts/akc resolve_keychain fails closed on successful empty managed valu
   });
 });
 
-test('scripts/akc resolve_keychain kills a prompt-blocked read and returns 124 (#171)', async () => {
+test('scripts/akc resolve_keychain kills a prompt-blocked legacy read and returns 124 (#171)', async () => {
   await writeFile(callsPath, '');
+  // シークレットを一時ファイル経由で運ばないことの検証 (#185 B1): 専用 TMPDIR を
+  // 与え、実行後に何も残っていない（そもそも作られない）ことを確認する
+  const isolatedTmp = await mkdtemp(join(tmpdir(), 'akc-b1-check-'));
   const t0 = Date.now();
-  const result = runResolver('gui_hang', { AKC_SECURITY_TIMEOUT_SECS: '1' });
+  const result = runResolver('gui_hang', { AKC_SECURITY_TIMEOUT_SECS: '1', TMPDIR: isolatedTmp });
   const elapsed = Date.now() - t0;
   assert.equal(result.status, 124); // 有界失敗（ハングもプロンプトもしない）
   assert.equal(result.stdout, ''); // 値は漏れない
+  assert.ok(elapsed >= 900, `should actually wait for the 1s timeout (took ${elapsed}ms)`);
   assert.ok(elapsed < 10_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
   assert.equal(await readFile(callsPath, 'utf8'), 'managed\ngui\n');
+  const leftover = await readdir(isolatedTmp);
+  assert.deepEqual(leftover, [], 'no temp files may be created on the secret path (#185 B1)');
+  await rm(isolatedTmp, { recursive: true, force: true });
+});
+
+test('scripts/akc resolve_keychain maps a managed-tier timeout to 125 (locked keychain, #185 S1)', async () => {
+  await writeFile(callsPath, '');
+  const t0 = Date.now();
+  const result = runResolver('managed_hang', { AKC_SECURITY_TIMEOUT_SECS: '1' });
+  const elapsed = Date.now() - t0;
+  assert.equal(result.status, 125); // managed timeout は移行案内ではなくロック扱い
+  assert.equal(result.stdout, '');
+  assert.ok(elapsed >= 900 && elapsed < 10_000, `bounded (took ${elapsed}ms)`);
+  assert.equal(await readFile(callsPath, 'utf8'), 'managed\n'); // fail-closed: レガシー段へ落ちない
+});
+
+test('scripts/akc neutralizes a hostile AKC_SECURITY_TIMEOUT_SECS (#185 B2: arithmetic injection)', async () => {
+  await writeFile(callsPath, '');
+  const canary = join(tmpdir(), `akc-b2-canary-${Date.now()}`);
+  // $(( )) は配列添字のコマンド置換まで評価する — 検証が無いと任意コマンド実行
+  const payload = `PATH[$(touch ${canary})]`;
+  const result = runResolver('managed_value', { AKC_SECURITY_TIMEOUT_SECS: payload });
+  // 注入は無害化され（既定 10s に fallback）、正常解決する
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, 'managed-value');
+  let executed = true;
+  try {
+    await readFile(canary);
+  } catch {
+    executed = false;
+  }
+  assert.equal(executed, false, 'injected command must NOT run');
+  await rm(canary, { force: true });
 });
 
 test('scripts/akc cmd_run rejects nonempty resolver output when its exit status is nonzero', async () => {
@@ -198,6 +236,8 @@ test('scripts/akc cmd_run rejects nonempty resolver output when its exit status 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Resolved: 0, Failed: 1/);
   assert.doesNotMatch(result.stdout, /rejected-value/);
-  assert.match(result.stderr, /TEST_REF .* not found in Keychain/);
+  assert.doesNotMatch(result.stderr, /rejected-value/);
+  // 非 44 の失敗は「not found」ではなく exit code 付きで報告する (#185 S4)
+  assert.match(result.stderr, /TEST_REF .* keychain lookup failed \(exit 52\)/);
   assert.equal(await readFile(callsPath, 'utf8'), 'managed\ngui\nmanual\n');
 });

--- a/cli/test/resolve-keychain-bash.test.js
+++ b/cli/test/resolve-keychain-bash.test.js
@@ -30,8 +30,15 @@ if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
     managed_value) printf '%s\\n' managed-value; exit 0 ;;
     managed_51) exit 51 ;;
     managed_empty) exit 0 ;;
+    gui_hang) exit 44 ;;
   esac
   exit 44
+fi
+
+if [ "$svc" = "com.aieo.aikeychain" ] && [ "$SCENARIO" = "gui_hang" ]; then
+  printf '%s\\n' gui >> "$CALLS_PATH"
+  sleep 60   # SecurityAgent プロンプト待ちを模す (#171)
+  exit 0
 fi
 
 if [ "$svc" = "com.aieo.aikeychain" ]; then
@@ -62,9 +69,11 @@ printf '%s\\n' 'TEST_REF=keychain://TEST_KEY'
 
 before(async () => {
   const script = await readFile(new URL('../../scripts/akc', import.meta.url), 'utf8');
-  const start = script.indexOf('resolve_keychain() {');
+  // security_bounded (#171) が resolve_keychain の依存になったため、有界実行の
+  // 定義（タイムアウト変数から）ごと切り出す。
+  const start = script.indexOf('AKC_SECURITY_TIMEOUT_SECS=');
   const end = script.indexOf('\n}\n\nmask_value()', start);
-  assert.notEqual(start, -1, 'resolve_keychain function start must exist');
+  assert.notEqual(start, -1, 'security_bounded prelude must exist');
   assert.notEqual(end, -1, 'resolve_keychain function end must exist');
   const resolver = script.slice(start, end + 2);
   const functionsEnd = script.indexOf('\n\n# Main dispatch', start);
@@ -79,7 +88,7 @@ before(async () => {
   callsPath = join(tempDir, 'calls');
   await writeFile(
     harnessPath,
-    `#!/bin/bash\nset -uo pipefail\nSECURITY_BIN="$1"\nCALLS_PATH="$2"\nSCENARIO="$3"\nexport CALLS_PATH SCENARIO\n${resolver}\nresolve_keychain TEST_KEY\n`
+    `#!/bin/bash\nset -uo pipefail\nSECURITY_BIN="$1"\nCALLS_PATH="$2"\nSCENARIO="$3"\nAKC_SECURITY_TIMEOUT_SECS="\${AKC_SECURITY_TIMEOUT_SECS:-10}"\nexport CALLS_PATH SCENARIO\n${resolver}\nresolve_keychain TEST_KEY\n`
   );
   await writeFile(
     cmdHarnessPath,
@@ -97,9 +106,10 @@ after(async () => {
   await rm(tempDir, { recursive: true, force: true });
 });
 
-function runResolver(scenario) {
+function runResolver(scenario, env = {}) {
   const result = spawnSync('/bin/bash', [harnessPath, securityPath, callsPath, scenario], {
     encoding: 'utf8',
+    env: { ...process.env, ...env },
   });
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
@@ -165,6 +175,17 @@ test('scripts/akc resolve_keychain fails closed on successful empty managed valu
     result: { status: 1, stdout: '', stderr: '' },
     calls: 'managed\n',
   });
+});
+
+test('scripts/akc resolve_keychain kills a prompt-blocked read and returns 124 (#171)', async () => {
+  await writeFile(callsPath, '');
+  const t0 = Date.now();
+  const result = runResolver('gui_hang', { AKC_SECURITY_TIMEOUT_SECS: '1' });
+  const elapsed = Date.now() - t0;
+  assert.equal(result.status, 124); // 有界失敗（ハングもプロンプトもしない）
+  assert.equal(result.stdout, ''); // 値は漏れない
+  assert.ok(elapsed < 10_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
+  assert.equal(await readFile(callsPath, 'utf8'), 'managed\ngui\n');
 });
 
 test('scripts/akc cmd_run rejects nonempty resolver output when its exit status is nonzero', async () => {

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 let resolveKey;
 let keyExists;
+let MigrationRequiredError;
 let stubDir;
 let callsPath;
 
@@ -28,12 +29,14 @@ if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
     MANAGED_KEY) printf '%s\\n' "managed-value"; exit 0 ;;
     MANAGED_EMPTY_KEY) exit 0 ;;
     MGERR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
+    MGHANG_KEY) sleep 60 ;;
   esac
 fi
 
 if [ "$svc" = "com.aieo.aikeychain" ]; then
   case "$acct" in
     MGERR_KEY) printf '%s\\n' "stale-gui-value"; exit 0 ;;
+    GUIHANG_KEY) sleep 60 ;;   # SecurityAgent プロンプト待ちを模す (#171)
   esac
 fi
 
@@ -63,7 +66,9 @@ before(async () => {
   await writeFile(stubPath, STUB);
   await chmod(stubPath, 0o755);
   process.env.AIKEYCHAIN_SECURITY_BIN = stubPath;
-  ({ resolveKey, keyExists } = await import('../src/keychain.js'));
+  // ハング経路のテストを 60s 待たずに検証する（テスト専用オーバーライド / #171）
+  process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS = '500';
+  ({ resolveKey, keyExists, MigrationRequiredError } = await import('../src/keychain.js'));
 });
 
 beforeEach(async () => {
@@ -72,6 +77,7 @@ beforeEach(async () => {
 
 after(async () => {
   delete process.env.AIKEYCHAIN_SECURITY_BIN;
+  delete process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS;
   await rm(stubDir, { recursive: true, force: true });
 });
 
@@ -129,4 +135,37 @@ test('keyExists reports the managed store', async () => {
 
 test('keyExists fails closed (throws) on a non-44 probe error (#179 review S1)', async () => {
   await assert.rejects(() => keyExists('MGERR_KEY'), /keychain probe failed/);
+});
+
+test('a prompt-blocked legacy read is killed and raises MigrationRequiredError (#171)', async () => {
+  const t0 = Date.now();
+  await assert.rejects(
+    () => resolveKey('GUIHANG_KEY'),
+    (err) => {
+      assert.ok(err instanceof MigrationRequiredError);
+      assert.match(err.message, /migrat/i);
+      assert.match(err.message, /akc set GUIHANG_KEY/);
+      return true;
+    }
+  );
+  // 有界: 60s の stub ハングに対し timeout(500ms) + kill で返る
+  assert.ok(Date.now() - t0 < 10_000);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|GUIHANG_KEY\ncom.aieo.aikeychain|GUIHANG_KEY\n');
+});
+
+test('a managed-tier timeout raises a locked-keychain error, not migration guidance (#171)', async () => {
+  const t0 = Date.now();
+  await assert.rejects(
+    () => resolveKey('MGHANG_KEY'),
+    (err) => {
+      assert.ok(!(err instanceof MigrationRequiredError)); // managed は所有問題ではない
+      assert.match(err.message, /locked|unavailable/);
+      return true;
+    }
+  );
+  assert.ok(Date.now() - t0 < 10_000);
+  // fail-closed: レガシー段へは落ちない
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|MGHANG_KEY\n');
 });

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 let resolveKey;
 let keyExists;
+let resolveRefs;
 let MigrationRequiredError;
 let stubDir;
 let callsPath;
@@ -36,7 +37,7 @@ fi
 if [ "$svc" = "com.aieo.aikeychain" ]; then
   case "$acct" in
     MGERR_KEY) printf '%s\\n' "stale-gui-value"; exit 0 ;;
-    GUIHANG_KEY) sleep 60 ;;   # SecurityAgent プロンプト待ちを模す (#171)
+    GUIHANG_KEY|HANG?_KEY) sleep 60 ;;   # SecurityAgent プロンプト待ちを模す (#171)
   esac
 fi
 
@@ -69,6 +70,7 @@ before(async () => {
   // ハング経路のテストを 60s 待たずに検証する（テスト専用オーバーライド / #171）
   process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS = '500';
   ({ resolveKey, keyExists, MigrationRequiredError } = await import('../src/keychain.js'));
+  ({ resolveRefs } = await import('../src/run.js'));
 });
 
 beforeEach(async () => {
@@ -81,8 +83,10 @@ after(async () => {
   await rm(stubDir, { recursive: true, force: true });
 });
 
-test('resolveKey fails closed on a non-44 GUI lookup error (#147)', async () => {
-  assert.equal(await resolveKey('ERROR_KEY'), null);
+test('resolveKey fails closed on a non-44 GUI lookup error, with a reason (#147/#185 S4)', async () => {
+  // manual 段には攻撃者値が待ち構えているが、GUI 段の権威的失敗 (exit 51) で
+  // チェーンは止まる。null で「無い」と偽るのではなく理由を説明して throw する。
+  await assert.rejects(() => resolveKey('ERROR_KEY'), /legacy GUI store failed \(exit 51\)/);
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|ERROR_KEY\ncom.aieo.aikeychain|ERROR_KEY\n');
 });
@@ -114,7 +118,7 @@ test('resolveKey returns the managed value without touching legacy tiers (#167)'
 test('resolveKey fails closed on a non-44 managed lookup error (#179 review)', async () => {
   // GUI 段には stale な値が存在するが、managed 段の権威的失敗 (exit 51) で
   // チェーンは止まらなければならない（#150 の GUI 応答=権威と同じ原則）。
-  assert.equal(await resolveKey('MGERR_KEY'), null);
+  await assert.rejects(() => resolveKey('MGERR_KEY'), /managed namespace failed \(exit 51\)/);
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|MGERR_KEY\n');
 });
@@ -148,8 +152,11 @@ test('a prompt-blocked legacy read is killed and raises MigrationRequiredError (
       return true;
     }
   );
-  // 有界: 60s の stub ハングに対し timeout(500ms) + kill で返る
-  assert.ok(Date.now() - t0 < 10_000);
+  // 有界: 60s の stub ハングに対し timeout(500ms) + kill で返る。
+  // 下限も検証 — 即時失敗するようなら timeout ではなく別の壊れ方をしている
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed >= 400, `should actually wait for the timeout (took ${elapsed}ms)`);
+  assert.ok(elapsed < 5_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|GUIHANG_KEY\ncom.aieo.aikeychain|GUIHANG_KEY\n');
 });
@@ -164,8 +171,38 @@ test('a managed-tier timeout raises a locked-keychain error, not migration guida
       return true;
     }
   );
-  assert.ok(Date.now() - t0 < 10_000);
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed >= 400 && elapsed < 5_000, `bounded (took ${elapsed}ms)`);
   // fail-closed: レガシー段へは落ちない
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|MGHANG_KEY\n');
+});
+
+test('resolveRefs caches duplicate keys and enforces a command-level deadline (#185 S7)', async () => {
+  const t0 = Date.now();
+  const refs = [
+    { varName: 'V1', keyName: 'HANG1_KEY' },
+    { varName: 'V1B', keyName: 'HANG1_KEY' }, // 重複 — キャッシュで 2 回目は引かない
+    { varName: 'V2', keyName: 'HANG2_KEY' },
+    { varName: 'V3', keyName: 'HANG3_KEY' },
+    { varName: 'V4', keyName: 'HANG4_KEY' },
+    { varName: 'V5', keyName: 'HANG5_KEY' },
+  ];
+  const { resolved, failed } = await resolveRefs(refs);
+  const elapsed = Date.now() - t0;
+  assert.equal(Object.keys(resolved).length, 0);
+  assert.equal(failed.length, 6);
+  // deadline = timeout(500ms) x 3 = 1.5s が効き、5 キーを無制限に直列待ちしない
+  // （上限は並列テスト負荷のマージン込み。本質の検証は下の skip 理由の存在）
+  assert.ok(elapsed < 8_000, `command-level deadline bounds the scan (took ${elapsed}ms)`);
+  // 後半のキーは deadline 超過でスキップされ、その旨の理由を持つ
+  assert.ok(failed.some((f) => /deadline exceeded/.test(f.reason ?? '')));
+  // 重複キーは 1 回しか解決を試みない（キャッシュ）
+  const calls = await readFile(callsPath, 'utf8');
+  const hang1Calls = calls.split('\n').filter((l) => l.endsWith('|HANG1_KEY')).length;
+  assert.equal(hang1Calls, 2); // managed + GUI の 2 段 x 1 回のみ
+  // どちらの失敗も同じ理由を共有する
+  const v1 = failed.find((f) => f.varName === 'V1');
+  const v1b = failed.find((f) => f.varName === 'V1B');
+  assert.equal(v1.reason, v1b.reason);
 });

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -67,8 +67,10 @@ before(async () => {
   await writeFile(stubPath, STUB);
   await chmod(stubPath, 0o755);
   process.env.AIKEYCHAIN_SECURITY_BIN = stubPath;
-  // ハング経路のテストを 60s 待たずに検証する（テスト専用オーバーライド / #171）
-  process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS = '500';
+  // ハング経路のテストを 60s 待たずに検証する（テスト専用オーバーライド / #171）。
+  // 2000ms: 非ハングの stub 応答が並列テスト負荷でこの値を超えて fail-closed
+  // 検証が timeout 分類に化けるフレークを避ける余裕を取る（#185 再検証の指摘）。
+  process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS = '2000';
   ({ resolveKey, keyExists, MigrationRequiredError } = await import('../src/keychain.js'));
   ({ resolveRefs } = await import('../src/run.js'));
 });
@@ -156,7 +158,7 @@ test('a prompt-blocked legacy read is killed and raises MigrationRequiredError (
   // 下限も検証 — 即時失敗するようなら timeout ではなく別の壊れ方をしている
   const elapsed = Date.now() - t0;
   assert.ok(elapsed >= 400, `should actually wait for the timeout (took ${elapsed}ms)`);
-  assert.ok(elapsed < 5_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
+  assert.ok(elapsed < 10_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|GUIHANG_KEY\ncom.aieo.aikeychain|GUIHANG_KEY\n');
 });
@@ -172,7 +174,7 @@ test('a managed-tier timeout raises a locked-keychain error, not migration guida
     }
   );
   const elapsed = Date.now() - t0;
-  assert.ok(elapsed >= 400 && elapsed < 5_000, `bounded (took ${elapsed}ms)`);
+  assert.ok(elapsed >= 400 && elapsed < 10_000, `bounded (took ${elapsed}ms)`);
   // fail-closed: レガシー段へは落ちない
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|MGHANG_KEY\n');
@@ -192,9 +194,10 @@ test('resolveRefs caches duplicate keys and enforces a command-level deadline (#
   const elapsed = Date.now() - t0;
   assert.equal(Object.keys(resolved).length, 0);
   assert.equal(failed.length, 6);
-  // deadline = timeout(500ms) x 3 = 1.5s が効き、5 キーを無制限に直列待ちしない
-  // （上限は並列テスト負荷のマージン込み。本質の検証は下の skip 理由の存在）
-  assert.ok(elapsed < 8_000, `command-level deadline bounds the scan (took ${elapsed}ms)`);
+  // deadline = timeout(2000ms) x 3 = 6s が効き、5 キーを無制限に直列待ちしない。
+  // 最初のキー(managed+gui の 2 段ハング ~4s)後に deadline 超過し残りは skip。
+  // 上限は並列テスト負荷のマージン込み。本質の検証は下の skip 理由の存在
+  assert.ok(elapsed < 14_000, `command-level deadline bounds the scan (took ${elapsed}ms)`);
   // 後半のキーは deadline 超過でスキップされ、その旨の理由を持つ
   assert.ok(failed.some((f) => /deadline exceeded/.test(f.reason ?? '')));
   // 重複キーは 1 回しか解決を試みない（キャッシュ）

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -82,12 +82,13 @@ test('findUnmigratedKeys reports legacy-only keys and skips migrated ones (#171)
     { service: 'com.vendor.other', account: 'x' },
     { service: 'lowercase_svc', account: 'x' },
   ];
-  const result = findUnmigratedKeys(records);
-  assert.deepEqual(result, [
+  const { keys, unparseable } = findUnmigratedKeys(records);
+  assert.deepEqual(keys, [
     { name: 'BOTH_LEGACY_KEY', stores: ['gui', 'manual'] },
     { name: 'GUI_ONLY_KEY', stores: ['gui'] },
     { name: 'MANUAL_ONLY_KEY', stores: ['manual'] },
   ]);
+  assert.equal(unparseable, 0);
 });
 
 test('findUnmigratedKeys returns empty when everything is migrated', () => {
@@ -95,7 +96,31 @@ test('findUnmigratedKeys returns empty when everything is migrated', () => {
     { service: 'com.aieo.aikeychain.managed', account: 'A_KEY' },
     { service: 'com.aieo.aikeychain.managed', account: 'B_KEY' },
   ];
-  assert.deepEqual(findUnmigratedKeys(records), []);
+  assert.deepEqual(findUnmigratedKeys(records), { keys: [], unparseable: 0 });
+});
+
+test('findUnmigratedKeys never reports the app-reserved service names (#185 S10)', () => {
+  // KeyShareService の予約 service（共有秘密鍵/署名鍵）はドット+小文字を含み、
+  // MANUAL_NAME_PATTERN（大文字スネーク限定）が除外する。パターンが緩む回帰が
+  // 入ると「akc set com.aieo.aikeychain.sharekey しろ」と誤案内する事故になる。
+  const records = [
+    { service: 'com.aieo.aikeychain.sharekey', account: 'private_key' },
+    { service: 'com.aieo.aikeychain.signkey', account: 'signing_key' },
+  ];
+  assert.deepEqual(findUnmigratedKeys(records), { keys: [], unparseable: 0 });
+});
+
+test('findUnmigratedKeys counts unparseable store records instead of dropping them (#185 S8)', () => {
+  // GUI/managed store のレコードで acct が解析できない場合、そのキーが未移行か
+  // どうか判定できない。黙って捨てると「未移行なし」の false negative になる。
+  const records = [
+    { service: 'com.aieo.aikeychain', account: null },
+    { service: 'com.aieo.aikeychain.managed', account: null },
+    { service: 'com.aieo.aikeychain', account: 'GUI_ONLY_KEY' },
+  ];
+  const { keys, unparseable } = findUnmigratedKeys(records);
+  assert.equal(unparseable, 2);
+  assert.deepEqual(keys, [{ name: 'GUI_ONLY_KEY', stores: ['gui'] }]);
 });
 
 test('findAmbiguousDuplicates flags same-service multi-acct entries (issue #91)', () => {

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -4,6 +4,7 @@ import {
   parseDump,
   maskValue,
   findAmbiguousDuplicates,
+  findUnmigratedKeys,
   MANUAL_NAME_PATTERN,
   GUI_SERVICE,
 } from '../src/keychain.js';
@@ -63,6 +64,38 @@ test('maskValue never includes the value nor its length', () => {
   // 桁数が出力に含まれないこと
   assert.doesNotMatch(maskValue('super-secret'), /\d/);
   assert.doesNotMatch(maskValue('super-secret'), /chars/);
+});
+
+test('findUnmigratedKeys reports legacy-only keys and skips migrated ones (#171)', () => {
+  const records = [
+    // managed 済み → 対象外（GUI store に古いコピーが残っていても）
+    { service: 'com.aieo.aikeychain.managed', account: 'MIGRATED_KEY' },
+    { service: 'com.aieo.aikeychain', account: 'MIGRATED_KEY' },
+    // GUI store のみ → 未移行
+    { service: 'com.aieo.aikeychain', account: 'GUI_ONLY_KEY' },
+    // manual スキームのみ → 未移行
+    { service: 'MANUAL_ONLY_KEY', account: 'takehiro' },
+    // 両レガシーに存在 → 1 件にまとめて両 store を列挙
+    { service: 'com.aieo.aikeychain', account: 'BOTH_LEGACY_KEY' },
+    { service: 'BOTH_LEGACY_KEY', account: null },
+    // env 変数形でない service は manual と見なさない（他アプリのアイテム）
+    { service: 'com.vendor.other', account: 'x' },
+    { service: 'lowercase_svc', account: 'x' },
+  ];
+  const result = findUnmigratedKeys(records);
+  assert.deepEqual(result, [
+    { name: 'BOTH_LEGACY_KEY', stores: ['gui', 'manual'] },
+    { name: 'GUI_ONLY_KEY', stores: ['gui'] },
+    { name: 'MANUAL_ONLY_KEY', stores: ['manual'] },
+  ]);
+});
+
+test('findUnmigratedKeys returns empty when everything is migrated', () => {
+  const records = [
+    { service: 'com.aieo.aikeychain.managed', account: 'A_KEY' },
+    { service: 'com.aieo.aikeychain.managed', account: 'B_KEY' },
+  ];
+  assert.deepEqual(findUnmigratedKeys(records), []);
 });
 
 test('findAmbiguousDuplicates flags same-service multi-acct entries (issue #91)', () => {

--- a/scripts/akc
+++ b/scripts/akc
@@ -56,31 +56,67 @@ USAGE
 
 # security の有界実行 (#171): GUI 所有のレガシーキーの読取は SecurityAgent の
 # 同意プロンプトで無期限にブロックし得る。macOS に timeout(1) は無いため、
-# バックグラウンド起動 + ポーリング + SIGKILL で上限を設ける。
-# 戻り値: security の rc をそのまま。124 = タイムアウト（kill 済み）。
-# 値は stdout へ（一時ファイル経由。プロセス置換だと kill 後の回収が複雑になる）。
+# watchdog サブシェル + SIGKILL で上限を設ける。
+#
+# 設計上の不変条件 (#185 レビュー B1): シークレット値は**ディスクに書かない**。
+# 値は command substitution のパイプ内だけを流れる（一時ファイル方式は同一 UID
+# 攻撃者に平文を窃取される実証があり不採用）。watchdog の stdout は /dev/null に
+# 切り離してパイプを握らせない。
+#
+# 戻り値: security の rc。124 = タイムアウト（watchdog が SIGKILL 済み）。
+# 注: 非対話シェルの background job は自プロセスグループを共有するため、
+# グループ kill（kill -9 -PID）は自分ごと殺してしまい使えない。代わりに
+# 直接の子孫 1 世代を pkill -P で先に回収してから子 PID を kill する。
+# Swift 側 (SecurityCLIKeychainService) は別プロセスグループを持つため
+# グループ kill を使う — 意味論の差は意図的（#185 レビュー S2 参照）。
 AKC_SECURITY_TIMEOUT_SECS="${AKC_SECURITY_TIMEOUT_SECS:-10}"
+# 算術評価 $(( )) は変数展開時に配列添字のコマンド置換まで評価するため、
+# 未検証の環境変数を入れると env 注入 → 任意コマンド実行になる (#185 レビュー B2)。
+# 数字のみ・1〜600 秒に厳格制限し、それ以外は既定 10 秒に落とす。
+case "$AKC_SECURITY_TIMEOUT_SECS" in
+    ''|*[!0-9]*) AKC_SECURITY_TIMEOUT_SECS=10 ;;
+esac
+if [ "$AKC_SECURITY_TIMEOUT_SECS" -lt 1 ] || [ "$AKC_SECURITY_TIMEOUT_SECS" -gt 600 ]; then
+    AKC_SECURITY_TIMEOUT_SECS=10
+fi
 
 security_bounded() {
-    local tmp rc pid waited limit
-    tmp=$(mktemp "${TMPDIR:-/tmp}/akc-sec.XXXXXX") || return 1
-    "$SECURITY_BIN" "$@" >"$tmp" 2>/dev/null &
-    pid=$!
-    waited=0
-    limit=$((AKC_SECURITY_TIMEOUT_SECS * 10))
-    while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt "$limit" ]; do
-        sleep 0.1
-        waited=$((waited + 1))
-    done
-    if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null || true
-        wait "$pid" 2>/dev/null || true
-        rm -f "$tmp"
+    local out rc
+    out=$(
+        "$SECURITY_BIN" "$@" 2>/dev/null &
+        pid=$!
+        (
+            w=0
+            lim=$((AKC_SECURITY_TIMEOUT_SECS * 10))
+            while kill -0 "$pid" 2>/dev/null && [ "$w" -lt "$lim" ]; do
+                sleep 0.1
+                w=$((w + 1))
+            done
+            if kill -0 "$pid" 2>/dev/null; then
+                # 子孫(1世代)の PID を先に控えてから、親 → 子孫の順で kill する。
+                # 子孫を放置すると stdout パイプを握り続けてコマンド置換が
+                # パイプ閉鎖まで待たされ有界性が壊れる。親 kill 後は reparent
+                # されて -P で辿れないため、リストは kill 前に取る。親を先に
+                # 殺すのは rc=137 (timeout 判定) を確実にするため。
+                # (/usr/bin/security は単一プロセスなので通常は no-op)
+                kids=$(/usr/bin/pgrep -P "$pid" 2>/dev/null || true)
+                kill -9 "$pid" 2>/dev/null
+                if [ -n "$kids" ]; then
+                    # shellcheck disable=SC2086 — PID リストの word splitting は意図
+                    kill -9 $kids 2>/dev/null || true
+                fi
+            fi
+        ) >/dev/null 2>&1 &
+        wpid=$!
+        if wait "$pid"; then rc=0; else rc=$?; fi
+        kill "$wpid" 2>/dev/null || true
+        exit "$rc"
+    )
+    rc=$?
+    if [ "$rc" -eq 137 ]; then   # 128+SIGKILL = watchdog による timeout
         return 124
     fi
-    if wait "$pid"; then rc=0; else rc=$?; fi
-    cat "$tmp"
-    rm -f "$tmp"
+    printf '%s' "$out"
     return "$rc"
 }
 
@@ -91,13 +127,15 @@ resolve_keychain() {
 
     # managed namespace (#167, v1.9+): akc/GUI の新規保存は全てここ。
     # 44 (not found) のときだけ次の段へ落ちる（それ以外は権威的失敗 / #150）。
-    # 124 (timeout) は managed では「keychain ロック等」、レガシー段では
-    # 「GUI 所有キーのプロンプト待ち = migration required」(#171)。
+    # timeout の意味は段で異なる (#171/#185 S1): managed は security 所有で
+    # プロンプトし得ない → 124 は「keychain ロック等」= 125 に変換して区別。
+    # レガシー段の 124 は「GUI 所有キーのプロンプト待ち = migration required」。
     if value=$(security_bounded find-generic-password -s "com.aieo.aikeychain.managed" -a "$key_name" -w); then
         [ -n "$value" ] && { printf '%s' "$value"; return 0; }
         return 1
     else
         rc=$?
+        [ "$rc" -eq 124 ] && return 125
         [ "$rc" -eq 44 ] || return "$rc"
     fi
 
@@ -192,11 +230,16 @@ cmd_run() {
                 else
                     failed_count=$((failed_count + 1))
                     if [ "$rk_rc" -eq 124 ]; then
-                        # 有界失敗 (#171): プロンプト待ちを kill した。原因はレガシー
-                        # (GUI 所有) キー or ロック中 keychain。移行を明示的に案内する。
-                        echo "  ❌ $var_name — keychain://$key_name: read blocked on a keychain prompt and was killed (timeout). Legacy GUI-owned key? Migrate with: akc set $key_name" >&2
-                    else
+                        # 有界失敗 (#171): レガシー段がプロンプト待ちで kill された
+                        # = GUI 所有キー。移行を明示的に案内する。
+                        echo "  ❌ $var_name — keychain://$key_name: legacy GUI-owned key blocked on a keychain prompt (killed after timeout). Migrate with: akc set $key_name" >&2
+                    elif [ "$rk_rc" -eq 125 ]; then
+                        # managed 段の timeout = keychain ロック/不可用（移行では直らない）
+                        echo "  ❌ $var_name — keychain://$key_name: managed read timed out — keychain locked or unavailable. Unlock the login keychain and retry." >&2
+                    elif [ "$rk_rc" -eq 1 ] || [ "$rk_rc" -eq 44 ]; then
                         echo "  ❌ $var_name — keychain://$key_name not found in Keychain" >&2
+                    else
+                        echo "  ❌ $var_name — keychain://$key_name: keychain lookup failed (exit $rk_rc)" >&2
                     fi
                 fi
                 ;;

--- a/scripts/akc
+++ b/scripts/akc
@@ -54,14 +54,46 @@ Examples:
 USAGE
 }
 
+# security の有界実行 (#171): GUI 所有のレガシーキーの読取は SecurityAgent の
+# 同意プロンプトで無期限にブロックし得る。macOS に timeout(1) は無いため、
+# バックグラウンド起動 + ポーリング + SIGKILL で上限を設ける。
+# 戻り値: security の rc をそのまま。124 = タイムアウト（kill 済み）。
+# 値は stdout へ（一時ファイル経由。プロセス置換だと kill 後の回収が複雑になる）。
+AKC_SECURITY_TIMEOUT_SECS="${AKC_SECURITY_TIMEOUT_SECS:-10}"
+
+security_bounded() {
+    local tmp rc pid waited limit
+    tmp=$(mktemp "${TMPDIR:-/tmp}/akc-sec.XXXXXX") || return 1
+    "$SECURITY_BIN" "$@" >"$tmp" 2>/dev/null &
+    pid=$!
+    waited=0
+    limit=$((AKC_SECURITY_TIMEOUT_SECS * 10))
+    while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt "$limit" ]; do
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        rm -f "$tmp"
+        return 124
+    fi
+    if wait "$pid"; then rc=0; else rc=$?; fi
+    cat "$tmp"
+    rm -f "$tmp"
+    return "$rc"
+}
+
 resolve_keychain() {
     local key_name="$1"
     local value
     local rc
 
     # managed namespace (#167, v1.9+): akc/GUI の新規保存は全てここ。
-    # 44 (not found) のときだけ次の段へ落ちる（それ以外は権威的失敗 / #150）
-    if value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain.managed" -a "$key_name" -w 2>/dev/null); then
+    # 44 (not found) のときだけ次の段へ落ちる（それ以外は権威的失敗 / #150）。
+    # 124 (timeout) は managed では「keychain ロック等」、レガシー段では
+    # 「GUI 所有キーのプロンプト待ち = migration required」(#171)。
+    if value=$(security_bounded find-generic-password -s "com.aieo.aikeychain.managed" -a "$key_name" -w); then
         [ -n "$value" ] && { printf '%s' "$value"; return 0; }
         return 1
     else
@@ -69,7 +101,7 @@ resolve_keychain() {
         [ "$rc" -eq 44 ] || return "$rc"
     fi
 
-    if value=$("$SECURITY_BIN" find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w 2>/dev/null); then
+    if value=$(security_bounded find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w); then
         [ -n "$value" ] && { printf '%s' "$value"; return 0; }
         return 1
     else
@@ -79,8 +111,13 @@ resolve_keychain() {
 
     # 手動登録キーのフォールバック。-a はあえて指定しない: acct の値が
     # エントリごとに一定しないため、service 名のみで引く方が安定する (issue #91)
-    value=$("$SECURITY_BIN" find-generic-password -s "$key_name" -w 2>/dev/null) && [ -n "$value" ] && { printf '%s' "$value"; return 0; }
-    return 1
+    if value=$(security_bounded find-generic-password -s "$key_name" -w); then
+        [ -n "$value" ] && { printf '%s' "$value"; return 0; }
+        return 1
+    else
+        rc=$?
+        return "$rc"
+    fi
 }
 
 mask_value() {
@@ -154,7 +191,13 @@ cmd_run() {
                     fi
                 else
                     failed_count=$((failed_count + 1))
-                    echo "  ❌ $var_name — keychain://$key_name not found in Keychain" >&2
+                    if [ "$rk_rc" -eq 124 ]; then
+                        # 有界失敗 (#171): プロンプト待ちを kill した。原因はレガシー
+                        # (GUI 所有) キー or ロック中 keychain。移行を明示的に案内する。
+                        echo "  ❌ $var_name — keychain://$key_name: read blocked on a keychain prompt and was killed (timeout). Legacy GUI-owned key? Migrate with: akc set $key_name" >&2
+                    else
+                        echo "  ❌ $var_name — keychain://$key_name not found in Keychain" >&2
+                    fi
                 fi
                 ;;
         esac


### PR DESCRIPTION
Closes #171（親: #167）

## 概要
「新規/移行済み (managed) キーは無音成功、レガシーキーは**有界エラー**」という headless 契約を実装・明文化する。未移行の GUI 所有キーに対する `akc run`/`akc get` はこれまでプロンプト待ちでハングし得た（E6a/E6-5）。

## 変更
1. **timeout の意味分類**（npm CLI）: subprocess kill を `timedOut` として分類し、レガシー段のプロンプト待ちは **`MigrationRequiredError`**（`akc set <KEY>` での再登録 / 移行アシスタントを具体的に案内）、managed 段の timeout は「keychain ロック/不可用」エラーに（managed は security 所有でプロンプトし得ない — 所有問題と区別）
2. **`akc run` の一括報告**: 1 キーの有界失敗で走査を止めず、全 broken refs を理由付きで表示
3. **`akc doctor` の未移行キー検出**: `dump-keychain` の属性のみで「レガシー store にのみ存在し managed に無い」キーを非破壊列挙 + 移行ガイダンス。issue 原文の「ACL 情報による判定」は namespace 設計（managed 配下 = security 作成が不変条件）により不要になったため、namespace 比較に置換
4. **bash 版 `scripts/akc`**: `security_bounded`（background + poll + SIGKILL。macOS に timeout(1) は無い）を追加し、npm CLI と同じ有界性を確保。rc=124 で migration required を stderr 案内
5. **契約の明文化**: usage-guide に「Headless contract」節、README に要約
6. MCP は #179 の bounded `security()` + 本 PR の resolve 意味論を継承（`get_secret_reference`/`check_key` は属性プローブのみで値を読まないためプロンプト経路なし）

## テスト
- JS: stub の `sleep 60` ハングに対し、有界（<10s）・エラー種別（MigrationRequired vs locked）・fail-closed（レガシー段へ落ちない）・calls 検証。`AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS`（テスト専用）で 500ms に短縮して検証
- bash: `gui_hang` シナリオで rc=124・値の漏れなし・経路検証
- `findUnmigratedKeys` 単体テスト（移行済み skip / 両レガシー統合 / 非 env 形 service 除外）
- **CLI 91/91 × 3 連続 green・Swift 186/186（変更なし確認）**

E6-5（実機の GUI 所有キーでの有界動作）は spike #168 の実測に基づく設計で、リリース前の実機 smoke で最終確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPwWFBAo9d5u87LAAUb6WM
