### PR TITLE
feat!: v2.0 — managed 単一 namespace への完全リニューアル（legacy 互換撤去）

### DIFF
--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		17E984B7629D8CE3316EA863 /* ExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C09614C3D3E83949303EEAC /* ExportView.swift */; };
 		1991B82F1FDB41603BD80CEC /* KeyShareServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18270833BDFFEACBE8F6B44 /* KeyShareServiceTests.swift */; };
 		1AB9E049266DAB9AD0D35A3E /* ProxyLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570CC30E4C6DA6D972276E16 /* ProxyLog.swift */; };
+		1D01789D63D03F256B16DD7A /* LegacyKeyScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9337A8498BD6DA1B0AE6343C /* LegacyKeyScannerTests.swift */; };
 		1FBDB678ABCDB9503FE0DCEA /* ProxyServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2E88F59640366B8EE60C8 /* ProxyServer.swift */; };
 		25101CE19322B14D1988F7ED /* HTTPRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442E3D918DD99B2AC191CC0B /* HTTPRequestParser.swift */; };
 		29216A0485E26E52B089FD20 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6CE26B4571DA45A26B9C6E53 /* Assets.xcassets */; };
@@ -47,6 +48,7 @@
 		AF1D41DA4AC29AEE58B49FDF /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF474BC29A1530637DA89AB /* MenuBarView.swift */; };
 		B2F5D286112157097BF29416 /* KeyRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71C2E4D1617957A56CFF459 /* KeyRowView.swift */; };
 		BBEC55D1F836E307DE46B844 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B69E8B22FA2C8C00A6DF9A /* AppLanguage.swift */; };
+		BD6043825D59D62BDB272066 /* LegacyKeyScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1D9FC4A50AB922B9C1FD1A /* LegacyKeyScanner.swift */; };
 		C0048864B310D16BE77D460F /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AE0FFA12A5A654B81D2DBA /* OnboardingView.swift */; };
 		C4C7726A2BDC408D034DC23A /* RecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A96E32BD83312A5116D44E7 /* RecoveryView.swift */; };
 		C8354CC8F169967E2C4F8058 /* KeyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7B1F4D6E6116070ED7824F /* KeyCategory.swift */; };
@@ -59,6 +61,7 @@
 		E805C8A422ADCA7B2042DE29 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BBC08B62D864042131E96C /* AppState.swift */; };
 		E963094220E71C64DEA96121 /* FingerprintTOFUStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8C7190C24537528AD2B987 /* FingerprintTOFUStore.swift */; };
 		F0BB7FFD1936E579F9D65861 /* SecurityCLIKeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B529E3962BE2F851B2297B /* SecurityCLIKeychainServiceTests.swift */; };
+		F1F638CD03451687D1B92598 /* UpgradeTourView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523C0657000343A2582C98A4 /* UpgradeTourView.swift */; };
 		F1FCE802F6B8CD69C82050FD /* CategoryIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5564B99419540E50E1276D79 /* CategoryIcon.swift */; };
 		F600C34E56EF17E276B8E5B8 /* SecurityCLIKeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D2DFA56DC4FD7D699EC36 /* SecurityCLIKeychainService.swift */; };
 		F620D2BC08B405183D3732AB /* AppAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D3DCA2727A4F0E3B73623 /* AppAnimations.swift */; };
@@ -97,6 +100,7 @@
 		42FBF226CDBB7B16615DB078 /* AIkeychainApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIkeychainApp.swift; sourceTree = "<group>"; };
 		442E3D918DD99B2AC191CC0B /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		4A96E32BD83312A5116D44E7 /* RecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryView.swift; sourceTree = "<group>"; };
+		523C0657000343A2582C98A4 /* UpgradeTourView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeTourView.swift; sourceTree = "<group>"; };
 		524109D967A855636B5BECB8 /* SetupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupManager.swift; sourceTree = "<group>"; };
 		5564B99419540E50E1276D79 /* CategoryIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryIcon.swift; sourceTree = "<group>"; };
 		56404BDE58192F0E86AD8B7E /* AppFonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFonts.swift; sourceTree = "<group>"; };
@@ -116,6 +120,7 @@
 		86254B995FB20769DA53656A /* KeyListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyListViewModel.swift; sourceTree = "<group>"; };
 		8BAA59605A0988605BDA9071 /* APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKey.swift; sourceTree = "<group>"; };
 		92065103580C94C2BB99FB48 /* CustomKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomKeyStore.swift; sourceTree = "<group>"; };
+		9337A8498BD6DA1B0AE6343C /* LegacyKeyScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyKeyScannerTests.swift; sourceTree = "<group>"; };
 		956D2DFA56DC4FD7D699EC36 /* SecurityCLIKeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityCLIKeychainService.swift; sourceTree = "<group>"; };
 		99B69E8B22FA2C8C00A6DF9A /* AppLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguage.swift; sourceTree = "<group>"; };
 		9C17D41EA989227C3858DBEE /* AIkeychain.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AIkeychain.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,6 +139,7 @@
 		F2A3438BA6DB0A665C0E3D08 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		F69D54AA42B1FDEBB2AD036B /* ViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelTests.swift; sourceTree = "<group>"; };
 		FCD863D9D3D25902544E5FFC /* ShareKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareKeysView.swift; sourceTree = "<group>"; };
+		FE1D9FC4A50AB922B9C1FD1A /* LegacyKeyScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyKeyScanner.swift; sourceTree = "<group>"; };
 		FE82389E8C1EDD586872750A /* IconPickerGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerGrid.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -159,6 +165,7 @@
 				28DC4BEF20A119E940433F3A /* KeychainServiceTests.swift */,
 				0CE42D145C1D539331367E03 /* KeyShareHardeningTests.swift */,
 				E18270833BDFFEACBE8F6B44 /* KeyShareServiceTests.swift */,
+				9337A8498BD6DA1B0AE6343C /* LegacyKeyScannerTests.swift */,
 				0F4D6C9DC84B322FB385ACE3 /* ModelTests.swift */,
 				BBB424D42EDE63D9E03A86DD /* ProxyTests.swift */,
 				1EDF5F4F543FDCFEAE87669B /* SecretRefTests.swift */,
@@ -197,6 +204,7 @@
 				2939F10EF6CE9C4D059904DC /* ModeSelectView.swift */,
 				4A96E32BD83312A5116D44E7 /* RecoveryView.swift */,
 				FCD863D9D3D25902544E5FFC /* ShareKeysView.swift */,
+				523C0657000343A2582C98A4 /* UpgradeTourView.swift */,
 				3583B31A559FCC2A23E29BC3 /* Components */,
 				C166B224999EEA1A66870FC9 /* Editor */,
 				A9A45D381E261DC40D05F3B2 /* Export */,
@@ -322,6 +330,7 @@
 				F1CFA57EED2AEC2489060E17 /* KeychainService.swift */,
 				2F4FD4DB8058AD798CC211E6 /* KeyShareService.swift */,
 				7DF81328B72F2A8A703BEFF2 /* L10n.swift */,
+				FE1D9FC4A50AB922B9C1FD1A /* LegacyKeyScanner.swift */,
 				DDE2E88F59640366B8EE60C8 /* ProxyServer.swift */,
 				E18E322C52277BDBD022D701 /* SecretHygiene.swift */,
 				956D2DFA56DC4FD7D699EC36 /* SecurityCLIKeychainService.swift */,
@@ -444,6 +453,7 @@
 				3A56CD00EE4C3F00A9F4D0AD /* KeyShareService.swift in Sources */,
 				2B3A4963FF166104314944CF /* KeychainService.swift in Sources */,
 				E4121F90426AFDC4BD032F3A /* L10n.swift in Sources */,
+				BD6043825D59D62BDB272066 /* LegacyKeyScanner.swift in Sources */,
 				5254F9E77B6A8E4D94CD4EA2 /* MainView.swift in Sources */,
 				AF1D41DA4AC29AEE58B49FDF /* MenuBarView.swift in Sources */,
 				57E4627622F0FE9A65F945C1 /* ModeSelectView.swift in Sources */,
@@ -462,6 +472,7 @@
 				0780507AB54B25A9A3398422 /* ShareKeysView.swift in Sources */,
 				A5417351BB72385534D8B9B7 /* SidebarView.swift in Sources */,
 				329AFAC717680A8389A1B15A /* StatusBadge.swift in Sources */,
+				F1F638CD03451687D1B92598 /* UpgradeTourView.swift in Sources */,
 				57F88F187AB1107A3629A2BA /* ZshrcExporter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -473,6 +484,7 @@
 				CD72365EE2B860B242D89708 /* KeyShareHardeningTests.swift in Sources */,
 				1991B82F1FDB41603BD80CEC /* KeyShareServiceTests.swift in Sources */,
 				A2F1064807E933FE345F8063 /* KeychainServiceTests.swift in Sources */,
+				1D01789D63D03F256B16DD7A /* LegacyKeyScannerTests.swift in Sources */,
 				CC6B7823B5DCA500A9A20A4D /* ModelTests.swift in Sources */,
 				434F7D7FEE37A6CDED3AD084 /* ProxyTests.swift in Sources */,
 				4013BBEA241CC555169FCF65 /* SecretRefTests.swift in Sources */,

--- a/AIkeychain.xcodeproj/project.pbxproj
+++ b/AIkeychain.xcodeproj/project.pbxproj
@@ -591,7 +591,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;
@@ -689,7 +689,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aieo.aikeychain;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.9;

--- a/AIkeychain/Models/APIKey.swift
+++ b/AIkeychain/Models/APIKey.swift
@@ -1,15 +1,6 @@
 import Foundation
 import SwiftUI
 
-/// キー値が Keychain のどちらのスキームに保存されているか (#160)。
-/// .app    = service=com.aieo.aikeychain, account=<キー名>（GUI / akc set 新規）
-/// .manual = service=<キー名>（`security add-generic-password -s KEY` の手動登録）
-/// 両スキームに存在する場合は 2 段ルックアップの優先順に従い .app とする。
-enum StorageScheme {
-    case app
-    case manual
-}
-
 struct APIKey: Identifiable, Equatable, Hashable {
     static func == (lhs: APIKey, rhs: APIKey) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
@@ -19,28 +10,23 @@ struct APIKey: Identifiable, Equatable, Hashable {
     let customKey: CustomKey?        // カスタムの場合
     var envVarName: String
     var isConfigured: Bool
-    var storage: StorageScheme
 
     /// プリセットキー
-    init(id: UUID = UUID(), service: ServiceType, envVarName: String? = nil, isConfigured: Bool = false,
-         storage: StorageScheme = .app) {
+    init(id: UUID = UUID(), service: ServiceType, envVarName: String? = nil, isConfigured: Bool = false) {
         self.id = id
         self.service = service
         self.customKey = nil
         self.envVarName = envVarName ?? service.envVarName
         self.isConfigured = isConfigured
-        self.storage = storage
     }
 
     /// カスタムキー
-    init(id: UUID = UUID(), customKey: CustomKey, isConfigured: Bool = false,
-         storage: StorageScheme = .app) {
+    init(id: UUID = UUID(), customKey: CustomKey, isConfigured: Bool = false) {
         self.id = id
         self.service = nil
         self.customKey = customKey
         self.envVarName = customKey.envVarName
         self.isConfigured = isConfigured
-        self.storage = storage
     }
 
     var isCustom: Bool { customKey != nil }

--- a/AIkeychain/Services/KeychainService.swift
+++ b/AIkeychain/Services/KeychainService.swift
@@ -30,16 +30,10 @@ protocol KeychainServiceProtocol {
     func retrieveNoninteractive(for account: String) throws -> String?
     func delete(for account: String) throws
     func exists(for account: String) -> Bool
-    /// 主ストア（managed namespace, com.aieo.aikeychain.managed / #167）に存在する
+    /// 主ストア（managed namespace, com.aieo.aikeychain.managed / #167/#188）に存在する
     /// 全アカウント名を列挙する。CLI (`akc set`) で追加され GUI 索引に無いキーを
     /// 発見するために使う (#153)。秘密値は読まない（アカウント名のみ）。
     func allAccounts() -> [String]
-    /// レガシー manual スキーム (service=<キー名>) で保存されているキー名を列挙する
-    /// (#160)。`security add-generic-password -s KEY_NAME` による手動登録アイテムが
-    /// 対象（#179 以降、akc set の書込先は managed であり manual には書かない）。
-    /// npm CLI の判定規則と同じく env 変数名形式の service のみを manual と見なす。
-    /// 秘密値は読まない。C5 (#172) の移行完了とともに廃止予定。
-    func manualServices() -> [String]
 }
 
 // NOTE: 旧 in-process 実装 (`final class KeychainService`) は C3 #170 で削除した。
@@ -53,35 +47,28 @@ protocol KeychainServiceProtocol {
 
 final class MockKeychainService: KeychainServiceProtocol {
     var store: [String: String] = [:]
-    /// manual スキーム (service=<キー名>) 相当のアイテム (#160)
-    var manualStore: [String: String] = [:]
 
     func save(value: String, for account: String) throws {
         store[account] = value
     }
 
     func retrieve(for account: String) throws -> String? {
-        store[account] ?? manualStore[account]
+        store[account]
     }
 
     func retrieveNoninteractive(for account: String) throws -> String? {
-        store[account] ?? manualStore[account]
+        store[account]
     }
 
     func delete(for account: String) throws {
         store.removeValue(forKey: account)
-        manualStore.removeValue(forKey: account)
     }
 
     func exists(for account: String) -> Bool {
-        store[account] != nil || manualStore[account] != nil
+        store[account] != nil
     }
 
     func allAccounts() -> [String] {
         Array(store.keys)
-    }
-
-    func manualServices() -> [String] {
-        Array(manualStore.keys)
     }
 }

--- a/AIkeychain/Services/LegacyKeyScanner.swift
+++ b/AIkeychain/Services/LegacyKeyScanner.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Security
+
+/// v1.x で作られた「取り残しキー」を**読み取り専用・無音**で検出する (v2.0 #188)。
+///
+/// v2.0 は managed namespace のみを読む。アップグレードしたユーザーの旧キー
+/// （旧 GUI store `com.aieo.aikeychain` の account / manual スキームの
+/// service=<KEY>）は参照されなくなるため、初回起動でこれらを検出して
+/// 「再登録してください」のツアーを出す判断材料にする。
+///
+/// **値は一切読まない**（`kSecReturnAttributes` のみ・`kSecReturnData` は使わない）
+/// ので所有者に関係なくプロンプトは出ない。CLI の `findUnmigratedKeys`
+/// （cli/src/keychain.js）と同一の判定規則。
+enum LegacyKeyScanner {
+    private static let managedService = SecurityCLIKeychainService.managedService  // com.aieo.aikeychain.managed
+    private static let legacyGUIService = "com.aieo.aikeychain"
+    // KeyShareService のアプリ内部鍵（移行/検出の対象外）
+    private static let reservedServices: Set<String> = [
+        "com.aieo.aikeychain.sharekey", "com.aieo.aikeychain.signkey",
+    ]
+    // manual スキーム判定: 大文字スネークケース限定（CLI の MANUAL_NAME_PATTERN と同一）。
+    // 緩いと iCloud / AirPort 等のシステムアイテムを誤検出する。
+    private static let manualNamePattern = #"^[A-Z][A-Z0-9_]*$"#
+
+    /// managed に無い旧 v1 キー名を昇順で返す（無ければ空）。実 Keychain を無音照会。
+    static func unmigratedKeyNames() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,  // 属性のみ = 無音
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let items = result as? [[String: Any]] else {
+            return []
+        }
+        let records = items.map {
+            (service: $0[kSecAttrService as String] as? String,
+             account: $0[kSecAttrAccount as String] as? String)
+        }
+        return unmigratedKeyNames(from: records)
+    }
+
+    /// 分類ロジック（純粋関数・テスト可能）。CLI の `findUnmigratedKeys` と同一規則:
+    /// 旧 GUI store の account / manual スキームの service 名で、managed に無いもの。
+    static func unmigratedKeyNames(from records: [(service: String?, account: String?)]) -> [String] {
+        var managed = Set<String>()
+        var legacy = Set<String>()
+        for (service, account) in records {
+            guard let service else { continue }
+            if service == managedService {
+                if let account { managed.insert(account) }
+            } else if service == legacyGUIService {
+                if let account { legacy.insert(account) }
+            } else if !reservedServices.contains(service),
+                      service.range(of: manualNamePattern, options: .regularExpression) != nil {
+                legacy.insert(service)  // manual スキームは service 名がキー名
+            }
+        }
+        return legacy.subtracting(managed).sorted()
+    }
+}

--- a/AIkeychain/Services/LegacyKeyScanner.swift
+++ b/AIkeychain/Services/LegacyKeyScanner.swift
@@ -3,26 +3,22 @@ import Security
 
 /// v1.x で作られた「取り残しキー」を**読み取り専用・無音**で検出する (v2.0 #188)。
 ///
-/// v2.0 は managed namespace のみを読む。アップグレードしたユーザーの旧キー
-/// （旧 GUI store `com.aieo.aikeychain` の account / manual スキームの
-/// service=<KEY>）は参照されなくなるため、初回起動でこれらを検出して
-/// 「再登録してください」のツアーを出す判断材料にする。
+/// v2.0 は managed namespace (`com.aieo.aikeychain.managed`) のみを読む。旧 GUI
+/// store (`com.aieo.aikeychain`) に作られたキー（GUI 作成・v1.8.1 までの `akc set`
+/// はここに書いていた）は参照されなくなるため、初回起動で検出して「再登録して
+/// ください」のツアーを出す判断材料にする。
+///
+/// **旧 GUI store（= AI KeyChain が確実に所有する service 名）のみを対象にする。**
+/// manual スキーム（service=任意のキー名）は他アプリのアイテムと区別できず、
+/// 新規インストールでの誤発火や取りこぼしを生むため対象外（#189 レビュー D-Q）。
 ///
 /// **値は一切読まない**（`kSecReturnAttributes` のみ・`kSecReturnData` は使わない）
-/// ので所有者に関係なくプロンプトは出ない。CLI の `findUnmigratedKeys`
-/// （cli/src/keychain.js）と同一の判定規則。
+/// ので所有者に関係なくプロンプトは出ない。
 enum LegacyKeyScanner {
     private static let managedService = SecurityCLIKeychainService.managedService  // com.aieo.aikeychain.managed
     private static let legacyGUIService = "com.aieo.aikeychain"
-    // KeyShareService のアプリ内部鍵（移行/検出の対象外）
-    private static let reservedServices: Set<String> = [
-        "com.aieo.aikeychain.sharekey", "com.aieo.aikeychain.signkey",
-    ]
-    // manual スキーム判定: 大文字スネークケース限定（CLI の MANUAL_NAME_PATTERN と同一）。
-    // 緩いと iCloud / AirPort 等のシステムアイテムを誤検出する。
-    private static let manualNamePattern = #"^[A-Z][A-Z0-9_]*$"#
 
-    /// managed に無い旧 v1 キー名を昇順で返す（無ければ空）。実 Keychain を無音照会。
+    /// managed に無い旧 GUI store キー名を昇順で返す（無ければ空）。実 Keychain を無音照会。
     static func unmigratedKeyNames() -> [String] {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -41,20 +37,19 @@ enum LegacyKeyScanner {
         return unmigratedKeyNames(from: records)
     }
 
-    /// 分類ロジック（純粋関数・テスト可能）。CLI の `findUnmigratedKeys` と同一規則:
-    /// 旧 GUI store の account / manual スキームの service 名で、managed に無いもの。
+    /// 分類ロジック（純粋関数・テスト可能）: 旧 GUI store（service=com.aieo.aikeychain）
+    /// の account で、managed に同名が無いものを返す。account が空/nil のレコードは
+    /// キー名として扱えないので除外する（ツアーに空行を出さない）。
     static func unmigratedKeyNames(from records: [(service: String?, account: String?)]) -> [String] {
         var managed = Set<String>()
         var legacy = Set<String>()
         for (service, account) in records {
             guard let service else { continue }
+            guard let account, !account.isEmpty else { continue }
             if service == managedService {
-                if let account { managed.insert(account) }
+                managed.insert(account)
             } else if service == legacyGUIService {
-                if let account { legacy.insert(account) }
-            } else if !reservedServices.contains(service),
-                      service.range(of: manualNamePattern, options: .regularExpression) != nil {
-                legacy.insert(service)  // manual スキームは service 名がキー名
+                legacy.insert(account)
             }
         }
         return legacy.subtracting(managed).sorted()

--- a/AIkeychain/Services/SecretHygiene.swift
+++ b/AIkeychain/Services/SecretHygiene.swift
@@ -44,17 +44,4 @@ enum EnvVarName {
         guard !name.isEmpty else { return false }
         return name.range(of: pattern, options: .regularExpression) != nil
     }
-
-    /// manual スキーム (service=<キー名>) の対象と見なす名前かどうか (#160)。
-    ///
-    /// `isValid` より厳しい**大文字スネークケース限定** — npm CLI の
-    /// `MANUAL_NAME_PATTERN` (cli/src/keychain.js) と同一規則。緩い判定だと
-    /// `iCloud` / `AirPort` / `BluetoothGlobal` 等の macOS システムアイテムや
-    /// 他アプリの service 名を「キー」と誤認し、一覧を汚すだけでなく GUI からの
-    /// 削除・fallback 読取が無関係なアイテムに波及するため、ここで厳格に絞る。
-    private static let manualPattern = #"^[A-Z][A-Z0-9_]*$"#
-
-    static func isManualSchemeCandidate(_ name: String) -> Bool {
-        name.range(of: manualPattern, options: .regularExpression) != nil
-    }
 }

--- a/AIkeychain/Services/SecurityCLIKeychainService.swift
+++ b/AIkeychain/Services/SecurityCLIKeychainService.swift
@@ -14,7 +14,8 @@ import Security
 /// ## managed namespace
 /// 書き込み先 service は `com.aieo.aikeychain.managed` に固定。「managed の下のキー =
 /// security が作成」という不変条件により、所有者判別（マーカー等）そのものを不要にする。
-/// 旧 service（com.aieo.aikeychain / manual スキーム）へは一切書かない。
+/// v2.0 (#188): managed namespace が唯一の保管場所。旧 service（com.aieo.aikeychain /
+/// manual スキーム）は読み書きしない（旧 v1.x ユーザーはキーを再登録する）。
 ///
 /// ## セキュリティ規約（#94/#117 踏襲）
 /// - security は**絶対パス**で起動（PATH ハイジャック防止）
@@ -26,9 +27,6 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
     /// managed namespace（#167 オーナー決定）。旧 com.aieo.aikeychain とは別名にすることで
     /// 復元/同期/旧アプリ由来の GUI 所有アイテムが混入しても不変条件が壊れない。
     static let managedService = "com.aieo.aikeychain.managed"
-
-    /// 旧 GUI ストアの service 名（読み取り fallback / 削除時の掃除にのみ使う）。
-    static let legacyGUIService = "com.aieo.aikeychain"
 
     /// 値の最大長。stdin 一括書き込みのパイプバッファ束縛（save() 参照）。
     static let maxValueLength = 8192
@@ -167,51 +165,7 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
 
     func delete(for account: String) throws {
         try ensureKeychainUnlocked()
-        // 掃除の順序が要（#179 二段レビュー B3）: fallback ストア（manual → 旧 GUI）を
-        // **先に**消し、権威コピー（managed）を最後に消す。逆順で legacy 掃除が失敗すると
-        // 「削除成功と報告したのに `akc get` の fallback が古い値を解決し続ける」状態になる。
-        // fallback 掃除が失敗した場合は managed に触らず throw する — キーは無傷のまま
-        // 解決可能で、ユーザーには削除失敗が見える（half-deleted 状態を作らない）。
-
-        if EnvVarName.isManualSchemeCandidate(account) {
-            // manual スキームは厳格名（大文字スネーク）のみ対象（#163 と同じガード —
-            // 他アプリの小文字/ドット付き service 名アイテムを巻き添えにしない）。
-            // `delete-generic-password -s NAME` は最初に一致した 1 件しか消さないため、
-            // 重複エントリ（#100）が残らないよう 44 (not found) まで繰り返す。
-            var remaining = 10 // 暴走防止の上限（実キーチェーンで重複が 10 超は想定外）
-            while remaining > 0 {
-                remaining -= 1
-                switch runSecurity(arguments: ["delete-generic-password", "-s", account],
-                                   stdin: nil, timeout: writeTimeout) {
-                case .exited(0, _, _):
-                    continue
-                case .exited(44, _, _):
-                    remaining = 0
-                case .exited(let status, _, _):
-                    throw KeychainError.unexpectedStatus(OSStatus(status))
-                case .timedOut:
-                    throw KeychainError.interactionRequired
-                case .failedToLaunch:
-                    throw KeychainError.unexpectedStatus(errSecIO)
-                }
-            }
-        }
-
-        // 旧 GUI ストアの同名コピー。旧 GUI 所有はプロンプトになり得るが、削除は
-        // headed 前提の操作なので許容（timeout なら throw し、managed は無傷）。
-        switch runSecurity(arguments: ["delete-generic-password", "-s", Self.legacyGUIService, "-a", account],
-                           stdin: nil, timeout: writeTimeout) {
-        case .exited(0, _, _), .exited(44, _, _):
-            break
-        case .exited(let status, _, _):
-            throw KeychainError.unexpectedStatus(OSStatus(status))
-        case .timedOut:
-            throw KeychainError.interactionRequired
-        case .failedToLaunch:
-            throw KeychainError.unexpectedStatus(errSecIO)
-        }
-
-        // 最後に権威コピー（managed）。44 は冪等成功扱い（従来の delete と同じ意味論）。
+        // v2.0 (#188): managed namespace が唯一の保管場所。44 は冪等成功扱い。
         switch runSecurity(arguments: ["delete-generic-password", "-s", Self.managedService, "-a", account],
                            stdin: nil, timeout: writeTimeout) {
         case .exited(0, _, _), .exited(44, _, _):
@@ -257,34 +211,6 @@ final class SecurityCLIKeychainService: KeychainServiceProtocol {
         }
     }
 
-    func manualServices() -> [String] {
-        // manual スキーム (service=<キー名>) の発見。値は読まない属性列挙なので
-        // 所有者に関係なく無音（旧 KeychainService と同じ実装 / #160）。
-        // #167 では最終的に manual スキーム自体を廃止するが、その置き換えは
-        // C5 (#172) 移行アシスタント / C7 (#174) の担当。C2 で列挙まで止めると
-        // (a) 既存 manual キーが GUI から突然消える、(b) delete() は manual コピーを
-        // 掃除するのに KeyEditorViewModel.deletesManualEntryToo の巻き添え警告が
-        // 恒久 false になり無警告削除が走る（#179 二段レビュー B4）。
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
-            return []
-        }
-        var seen = Set<String>()
-        return items.compactMap { item -> String? in
-            guard let svc = item[kSecAttrService as String] as? String,
-                  svc != Self.managedService,
-                  svc != Self.legacyGUIService,
-                  EnvVarName.isManualSchemeCandidate(svc),
-                  seen.insert(svc).inserted else { return nil }
-            return svc
-        }
-    }
 
     // MARK: - ロック検出 (#170: #169 チェックリストの残)
 

--- a/AIkeychain/Services/SetupManager.swift
+++ b/AIkeychain/Services/SetupManager.swift
@@ -327,44 +327,6 @@ enum SetupManager {
         try result.write(toFile: zshrcPath, atomically: true, encoding: .utf8)
     }
 
-    /// macOS Keychain (システム) から指定キーの値を読み取る。
-    ///
-    /// scripts/akc / npm CLI (cli/src/keychain.js) と同じ 2 段ルックアップに整合させる:
-    ///   1. GUI 保存形式 `-s "com.aieo.aikeychain" -a "<KEY>"` を厳密一致で引く
-    ///   2. 見つからなければ手動登録キーとして `-s "<KEY>"`（service 名のみ）で引く
-    /// 手動登録キーは acct (-a) の値が一定しないため account は指定しない
-    /// （acct 不整合による古い/無効な値の誤取得を防止 / issue #91）。
-    static func readSystemKeychainValue(for account: String) -> String? {
-        func lookup(_ arguments: [String]) -> String? {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-            process.arguments = arguments
-
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = Pipe()
-
-            do {
-                try process.run()
-                process.waitUntilExit()
-                guard process.terminationStatus == 0 else { return nil }
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let value = String(data: data, encoding: .utf8)?
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                return (value?.isEmpty == false) ? value : nil
-            } catch {
-                return nil
-            }
-        }
-
-        // 1. GUI 保存形式（service + account を厳密一致）
-        if let value = lookup(["find-generic-password", "-s", "com.aieo.aikeychain", "-a", account, "-w"]) {
-            return value
-        }
-        // 2. 手動登録キー（service 名のみ / -a は付けない）
-        return lookup(["find-generic-password", "-s", account, "-w"])
-    }
-
     /// .zshrc から AI KeyChain 管理ブロック全体を削除（マーカー間 + レガシー行）。
     /// マーカー構造が壊れている場合は 0600 のバックアップだけを作り、元ファイルを変更せず throw する。
     static func unconfigure() throws {

--- a/AIkeychain/Services/ZshrcExporter.swift
+++ b/AIkeychain/Services/ZshrcExporter.swift
@@ -9,18 +9,12 @@ enum ExportFormat: String, CaseIterable, Identifiable {
 }
 
 struct ZshrcExporter {
-    /// - Parameter managedExists: managed namespace (com.aieo.aikeychain.managed) に
-    ///   キーが存在するかの判定。既定は実 Keychain への属性照会（値は読まないため
-    ///   承認 UI は出ない）。テストからは差し替える。
-    static func export(keys: [APIKey], format: ExportFormat,
-                       managedExists: (String) -> Bool = {
-                           SecurityCLIKeychainService.shared.exists(for: $0)
-                       }) -> String {
+    static func export(keys: [APIKey], format: ExportFormat) -> String {
         let configured = keys.filter(\.isConfigured)
 
         switch format {
         case .zshrc:
-            return generateZshrc(keys: configured, managedExists: managedExists)
+            return generateZshrc(keys: configured)
         case .secretRef:
             return generateSecretRef(keys: configured)
         case .env:
@@ -28,7 +22,7 @@ struct ZshrcExporter {
         }
     }
 
-    private static func generateZshrc(keys: [APIKey], managedExists: (String) -> Bool) -> String {
+    private static func generateZshrc(keys: [APIKey]) -> String {
         var lines: [String] = [
             "# AI KeyChain - Generated exports",
             "# Tokens are stored in macOS Keychain (not plaintext)",
@@ -45,21 +39,10 @@ struct ZshrcExporter {
             lines.append("# --- \(category.rawValue) ---")
             for key in categoryKeys {
                 lines.append("# [AI KeyChain] \(key.displayName)")
-                // キーの実保存スキームに厳密一致する lookup だけを出す (#91, #160)。
-                // シェル側の `||` フォールバックは使わない — 承認拒否や一時エラーでも
-                // 別スキームの古い/無関係な値へ静かに落ちてしまうため。
-                // -a "$USER" は acct のずれ/重複で古い値を掴む恐れがあるため使わない。
-                // .app キーは export 時点の実在場所で判定する: GUI の新規保存は
-                // managed namespace (#167/#169) へ行くため、旧 service 固定のままだと
-                // 保存直後のキーが新しいシェルで空になる（#179 二段レビュー B1）。
-                switch key.storage {
-                case .app where managedExists(key.envVarName):
-                    lines.append("export \(key.envVarName)=$(/usr/bin/security find-generic-password -s \"\(SecurityCLIKeychainService.managedService)\" -a \"\(key.envVarName)\" -w)")
-                case .app:
-                    lines.append("export \(key.envVarName)=$(/usr/bin/security find-generic-password -s \"com.aieo.aikeychain\" -a \"\(key.envVarName)\" -w)")
-                case .manual:
-                    lines.append("export \(key.envVarName)=$(/usr/bin/security find-generic-password -s \"\(key.envVarName)\" -w)")
-                }
+                // v2.0 (#188): 全キーは managed namespace。厳密一致の lookup を出す
+                // （シェル側 `||` フォールバックは承認拒否/一時エラーで別値へ静かに
+                //   落ちるため使わない。-a "$USER" も使わない）。
+                lines.append("export \(key.envVarName)=$(/usr/bin/security find-generic-password -s \"\(SecurityCLIKeychainService.managedService)\" -a \"\(key.envVarName)\" -w)")
             }
             lines.append("")
         }

--- a/AIkeychain/ViewModels/KeyEditorViewModel.swift
+++ b/AIkeychain/ViewModels/KeyEditorViewModel.swift
@@ -202,16 +202,6 @@ final class KeyEditorViewModel {
         customStore.setIconOverride(envVarName: key.envVarName, icon: nil)
     }
 
-    /// 削除確認に manual スキームの巻き添え警告を出すべきか (#163 レビュー指摘)。
-    /// delete() は manual エントリ（他ツールが作成した可能性がある
-    /// service=<キー名> のアイテム）も併せて削除するため、存在する場合は
-    /// ダイアログで事前に知らせる。
-    var deletesManualEntryToo: Bool {
-        guard let key = editingKey,
-              EnvVarName.isManualSchemeCandidate(key.envVarName) else { return false }
-        return keychainService.manualServices().contains(key.envVarName)
-    }
-
     // MARK: - Private
 
     /// 選択カテゴリをプリセット上書き文字列に変換する。

--- a/AIkeychain/ViewModels/KeyListViewModel.swift
+++ b/AIkeychain/ViewModels/KeyListViewModel.swift
@@ -77,41 +77,27 @@ final class KeyListViewModel {
     }
 
     func loadKeys() {
-        // スキーム判定用の集合（値は読まないので承認 UI は出ない）。
-        // 両スキームに存在する場合は 2 段ルックアップの優先順どおり .app 扱い。
-        let guiAccounts = Set(keychainService.allAccounts())
-        let manualOnly = Set(keychainService.manualServices()).subtracting(guiAccounts)
-
-        func storage(for name: String) -> StorageScheme {
-            manualOnly.contains(name) ? .manual : .app
-        }
+        // managed namespace の全アカウント（値は読まないので承認 UI は出ない / #188）。
+        let managedAccounts = Set(keychainService.allAccounts())
 
         // プリセットキー
         var allKeys: [APIKey] = ServiceType.allCases.map { service in
-            APIKey(
-                service: service,
-                isConfigured: keychainService.exists(for: service.envVarName),
-                storage: storage(for: service.envVarName)
-            )
+            APIKey(service: service, isConfigured: keychainService.exists(for: service.envVarName))
         }
 
         // カスタムキー
         for customKey in customStore.keys {
             allKeys.append(APIKey(
                 customKey: customKey,
-                isConfigured: keychainService.exists(for: customKey.envVarName),
-                storage: storage(for: customKey.envVarName)
+                isConfigured: keychainService.exists(for: customKey.envVarName)
             ))
         }
 
-        // CLI (`akc set`) で追加され、プリセットにもカスタム索引にも無い Keychain キーを
+        // CLI (`akc set`) で追加され、プリセットにもカスタム索引にも無い managed キーを
         // 発見して「コマンド追加」カテゴリに出す（種別不明のためまとめて表示 / #153）。
-        // env 変数名の形（EnvVarName.isValid）のみ採用し、内部用アイテムや
-        // シェル export で壊れる名前は除外する。
-        // known は発見ループ中も更新する。guiAccounts は Set なので同名アカウントの
-        // 重複は既に畳まれているが、insert の成否での二重追加防止は維持（Codex #2）。
+        // env 変数名の形（EnvVarName.isValid）のみ採用し、シェル export で壊れる名前は除外。
         var known = Set(allKeys.map(\.envVarName))
-        for account in guiAccounts
+        for account in managedAccounts
         where EnvVarName.isValid(account) && known.insert(account).inserted {
             let discovered = CustomKey(
                 envVarName: account,
@@ -119,24 +105,6 @@ final class KeyListViewModel {
                 categoryId: KeyCategory.cliAdded.stableId
             )
             allKeys.append(APIKey(customKey: discovered, isConfigured: true))
-        }
-
-        // manual スキーム (service=<キー名>) のキーも同様に発見する (#160)。
-        // `security add-generic-password -s KEY_NAME` による手動登録のアイテムが対象。
-        // 値の解決は akc の 3 段ルックアップ (managed → 旧GUI → manual) が引き受ける。
-        // GUI の値読取（SecurityCLIKeychainService）は managed のみを見るため、
-        // manual キーの値はエディタでは空になる — C5 (#172) 移行アシスタントで
-        // managed へ移行するまでの過渡状態（akc run では従来どおり解決可能）。
-        // 名前は厳格形（大文字スネークケース）のみ採用 — 緩くすると iCloud 等の
-        // システムアイテムを誤検出する。
-        for svc in keychainService.manualServices()
-        where EnvVarName.isManualSchemeCandidate(svc) && known.insert(svc).inserted {
-            let discovered = CustomKey(
-                envVarName: svc,
-                displayName: svc,
-                categoryId: KeyCategory.cliAdded.stableId
-            )
-            allKeys.append(APIKey(customKey: discovered, isConfigured: true, storage: .manual))
         }
 
         keys = allKeys

--- a/AIkeychain/Views/Editor/KeyEditorView.swift
+++ b/AIkeychain/Views/Editor/KeyEditorView.swift
@@ -172,13 +172,8 @@ struct KeyEditorView: View {
                 }
             }
         } message: {
-            if viewModel.deletesManualEntryToo {
-                Text(L10n.s(ja: "このキーを Keychain から削除します。手動登録されたエントリ（service=キー名。他のツールが作成したものの可能性があります）も併せて削除されます。この操作は取り消せません。",
-                            en: "This will remove the key from Keychain, including the manually registered entry (service=key name, possibly created by another tool). This action cannot be undone."))
-            } else {
-                Text(L10n.s(ja: "このキーを Keychain から削除します。この操作は取り消せません。",
-                            en: "This will remove the key from Keychain. This action cannot be undone."))
-            }
+            Text(L10n.s(ja: "このキーを Keychain から削除します。この操作は取り消せません。",
+                        en: "This will remove the key from Keychain. This action cannot be undone."))
         }
     }
 

--- a/AIkeychain/Views/Main/MainView.swift
+++ b/AIkeychain/Views/Main/MainView.swift
@@ -4,7 +4,11 @@ struct MainView: View {
     @State private var viewModel = KeyListViewModel()
     @State private var showingShare = false
     @State private var showingHelp = false
-    @State private var showingOnboarding = !OnboardingViewModel.hasCompleted
+    // v2.0 (#188): アップグレードで取り残された v1 キーがあれば、通常の onboarding より
+    // 先に再登録ツアーを出す。新規インストール（旧キー無し）は従来どおり onboarding。
+    @State private var legacyKeys = LegacyKeyScanner.unmigratedKeyNames()
+    @State private var showingUpgradeTour = false
+    @State private var showingOnboarding = false
     @State private var showingCleanup = false
     @State private var showingModeSelect = false
     @State private var showingRecovery = false
@@ -146,6 +150,9 @@ struct MainView: View {
         .sheet(isPresented: $showingOnboarding) {
             OnboardingView()
         }
+        .sheet(isPresented: $showingUpgradeTour) {
+            UpgradeTourView(legacyKeyNames: legacyKeys)
+        }
         .sheet(isPresented: $showingCleanup) {
             CleanupView()
         }
@@ -156,6 +163,15 @@ struct MainView: View {
             RecoveryView()
         }
         .frame(minWidth: 750, minHeight: 500)
+        .onAppear {
+            // アップグレードで取り残された v1 キーがあればツアーを最優先。
+            // 無ければ（新規インストール等）通常の onboarding を従来条件で。
+            if UpgradeTourView.shouldShow(legacyKeyNames: legacyKeys) {
+                showingUpgradeTour = true
+            } else if !OnboardingViewModel.hasCompleted {
+                showingOnboarding = true
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .showOnboarding)) { _ in
             showingOnboarding = true
         }

--- a/AIkeychain/Views/Main/MainView.swift
+++ b/AIkeychain/Views/Main/MainView.swift
@@ -6,7 +6,10 @@ struct MainView: View {
     @State private var showingHelp = false
     // v2.0 (#188): アップグレードで取り残された v1 キーがあれば、通常の onboarding より
     // 先に再登録ツアーを出す。新規インストール（旧キー無し）は従来どおり onboarding。
-    @State private var legacyKeys = LegacyKeyScanner.unmigratedKeyNames()
+    // スキャンは onAppear で 1 回だけ（@State のデフォルト式は struct 再構築のたびに
+    // 評価され、全 keychain 列挙をメインスレッドで反復してしまうため空で初期化する）。
+    @State private var legacyKeys: [String] = []
+    @State private var didScanLegacy = false
     @State private var showingUpgradeTour = false
     @State private var showingOnboarding = false
     @State private var showingCleanup = false
@@ -164,12 +167,20 @@ struct MainView: View {
         }
         .frame(minWidth: 750, minHeight: 500)
         .onAppear {
-            // アップグレードで取り残された v1 キーがあればツアーを最優先。
-            // 無ければ（新規インストール等）通常の onboarding を従来条件で。
-            if UpgradeTourView.shouldShow(legacyKeyNames: legacyKeys) {
-                showingUpgradeTour = true
-            } else if !OnboardingViewModel.hasCompleted {
-                showingOnboarding = true
+            // 起動時に 1 回だけ: 取り残された v1 キーをバックグラウンドで無音スキャンし、
+            // あればツアーを最優先。無ければ（新規インストール等）通常の onboarding。
+            guard !didScanLegacy else { return }
+            didScanLegacy = true
+            Task.detached(priority: .utility) {
+                let found = LegacyKeyScanner.unmigratedKeyNames()
+                await MainActor.run {
+                    legacyKeys = found
+                    if UpgradeTourView.shouldShow(legacyKeyNames: found) {
+                        showingUpgradeTour = true
+                    } else if !OnboardingViewModel.hasCompleted {
+                        showingOnboarding = true
+                    }
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .showOnboarding)) { _ in

--- a/AIkeychain/Views/ShareKeysView.swift
+++ b/AIkeychain/Views/ShareKeysView.swift
@@ -273,7 +273,7 @@ private struct SendTab: View {
                     Text(L10n.s(ja: "Keychain からキーを読み込みます", en: "Load keys from Keychain"))
                         .font(.system(size: 14))
                         .foregroundStyle(.secondary)
-                    Text(L10n.s(ja: "Keychain の承認ダイアログがキーごとに表示されることがあります。\n「常に許可」を選んだキーは次回以降ダイアログが出ません。", en: "A Keychain authorization dialog may appear for each key.\nKeys you \"Always Allow\" won't ask again next time."))
+                    Text(L10n.s(ja: "managed namespace のキーは承認ダイアログ無しで読み込まれます。", en: "Keys in the managed namespace load without an authorization dialog."))
                         .font(.system(size: 11))
                         .foregroundStyle(.tertiary)
                         .multilineTextAlignment(.center)

--- a/AIkeychain/Views/UpgradeTourView.swift
+++ b/AIkeychain/Views/UpgradeTourView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+/// v1.x → v2.0 アップグレード時に、取り残しキーの再登録と新しい使い方を案内する
+/// ツアー (#188)。旧キーが検出され、まだ表示していない場合にのみ出す。
+struct UpgradeTourView: View {
+    /// 検出された旧 v1 キー名（managed に無いもの）。
+    let legacyKeyNames: [String]
+    @Environment(\.dismiss) private var dismiss
+    @State private var page = 0
+
+    private static let seenKey = "v2_upgrade_tour_seen"
+
+    /// 旧キーが在り、かつ未表示のとき true。表示条件の単一の入口。
+    static func shouldShow(legacyKeyNames: [String]) -> Bool {
+        !legacyKeyNames.isEmpty && !UserDefaults.standard.bool(forKey: seenKey)
+    }
+
+    static func markSeen() {
+        UserDefaults.standard.set(true, forKey: seenKey)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    header
+                    switch page {
+                    case 0: whatChanged
+                    case 1: reregister
+                    default: howItWorks
+                    }
+                }
+                .padding(28)
+            }
+
+            Divider()
+            footer
+        }
+        .frame(width: 560, height: 560)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 30))
+                .foregroundStyle(AppColors.aiPurple)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.s(ja: "AI KeyChain 2.0 へようこそ", en: "Welcome to AI KeyChain 2.0"))
+                    .font(.system(size: 20, weight: .bold))
+                Text(L10n.s(ja: "保存方式が新しくなりました", en: "The way keys are stored has changed"))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Page 0: 何が変わったか
+    private var whatChanged: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            tourRow(icon: "arrow.triangle.2.circlepath", color: AppColors.aiPurple,
+                    title: L10n.s(ja: "単一の保管場所に統一", en: "One unified store"),
+                    body: L10n.s(
+                        ja: "2.0 では全てのキーを新しい managed namespace に保存します。AI エージェント（Claude Code / Codex 等）が `akc run` でヘッドレスに読める、確認ダイアログの出ない方式です。",
+                        en: "2.0 stores every key in a new managed namespace — one that AI agents (Claude Code, Codex, …) can read headlessly via `akc run`, with no consent dialogs."))
+            tourRow(icon: "exclamationmark.triangle.fill", color: .orange,
+                    title: L10n.s(ja: "以前のキーは再登録が必要", en: "Your earlier keys need re-registering"),
+                    body: L10n.s(
+                        ja: "1.x で登録したキーは自動では読み込まれなくなりました（削除はされていません）。次のページで対象のキーを確認できます。",
+                        en: "Keys you registered in 1.x are no longer read automatically (they are not deleted). The next page lists which ones."))
+        }
+    }
+
+    // MARK: - Page 1: 再登録
+    private var reregister: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(L10n.s(ja: "再登録が必要なキー（\(legacyKeyNames.count) 件）",
+                        en: "Keys to re-register (\(legacyKeyNames.count))"))
+                .font(.system(size: 15, weight: .semibold))
+            Text(L10n.s(ja: "以前の保存場所に見つかったキーです。同じ名前で登録し直すと 2.0 で使えるようになります。",
+                        en: "These were found in the old location. Re-register each with the same name to use it in 2.0."))
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(legacyKeyNames, id: \.self) { name in
+                    HStack(spacing: 8) {
+                        Image(systemName: "key.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                        Text(name).font(.system(size: 12, design: .monospaced))
+                    }
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L10n.s(ja: "登録方法", en: "How to re-register"))
+                    .font(.system(size: 13, weight: .medium))
+                Label(L10n.s(ja: "このアプリの「+」から追加する", en: "Add from the “+” in this app"), systemImage: "plus.circle")
+                    .font(.system(size: 12))
+                Label(L10n.s(ja: "またはターミナルで  akc set <KEY>", en: "Or in a terminal:  akc set <KEY>"), systemImage: "terminal")
+                    .font(.system(size: 12))
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    // MARK: - Page 2: 新しい使い方
+    private var howItWorks: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            tourRow(icon: "link", color: AppColors.cloudBlue,
+                    title: L10n.s(ja: "keychain:// 参照 + akc run", en: "keychain:// references + akc run"),
+                    body: L10n.s(
+                        ja: "`export OPENAI_API_KEY=keychain://OPENAI_API_KEY` として `akc run -- <command>` で起動すると、実際の値は子プロセスにだけ注入され、親シェルには出ません。",
+                        en: "Set `export OPENAI_API_KEY=keychain://OPENAI_API_KEY`, then launch via `akc run -- <command>`. The real value is injected into the child process only."))
+            tourRow(icon: "checkmark.seal.fill", color: AppColors.configured,
+                    title: L10n.s(ja: "エージェント設定は akc init", en: "Set up agents with akc init"),
+                    body: L10n.s(
+                        ja: "`akc init` を一度実行すると、Claude Code / Codex がこのマシンで AI KeyChain を自動的に使えるようになります。",
+                        en: "Run `akc init` once so Claude Code / Codex discover and use AI KeyChain on this machine."))
+        }
+    }
+
+    private func tourRow(icon: String, color: Color, title: String, body: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundStyle(color)
+                .frame(width: 26)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(.system(size: 14, weight: .semibold))
+                Text(body).font(.system(size: 12)).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Footer nav
+    private var footer: some View {
+        HStack {
+            ForEach(0..<3, id: \.self) { i in
+                Circle()
+                    .fill(i == page ? AppColors.aiPurple : Color.secondary.opacity(0.3))
+                    .frame(width: 7, height: 7)
+            }
+            Spacer()
+            if page > 0 {
+                Button(L10n.s(ja: "戻る", en: "Back")) { withAnimation { page -= 1 } }
+            }
+            if page < 2 {
+                Button(L10n.s(ja: "次へ", en: "Next")) { withAnimation { page += 1 } }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            } else {
+                Button(L10n.s(ja: "はじめる", en: "Get started")) {
+                    Self.markSeen()
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(16)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to AI KeyChain are documented in this file.
 
+## [2.0.0] - 2026-08-17
+
+完全リニューアル。単一の managed namespace (`com.aieo.aikeychain.managed`) を唯一の保管場所に絞り、v1.x の後方互換（旧 GUI store / manual スキーム）を全撤去した。
+
+### ⚠️ 破壊的変更（BREAKING）
+- **v1.x で登録したキーは読まれなくなります。** GUI アプリまたは `akc set <KEY>` で**キーを登録し直してください**。旧キーは削除されず macOS Keychain に残りますが、AI KeyChain / `akc` からは参照しません。
+- `akc set --manual` / MCP の `manual` フィールドを廃止（すべて managed namespace に書き込む）。
+
+### Changed
+- **単一 namespace 化** — resolver を 3 段ルックアップ（managed → 旧 GUI → manual）から **managed 単一**に簡素化。`security` 所有なのでヘッドレス読取はプロンプト/ハングしない。fail-closed 契約（exit 44 のみ not-found、それ以外は権威的失敗）は維持 (#188)
+- CLI（`cli/`）・bash 版（`scripts/akc`）・GUI（Swift）すべてを managed 単一に統一。GUI のキー発見・`.zshrc` エクスポート・削除も managed のみを対象に
+
+### Removed
+- 旧 GUI store / manual スキームの読み取り fallback・書き込み・削除掃除
+- `akc doctor` の「未移行キー検出」/ 曖昧重複検出（legacy 前提の診断）
+- `findUnmigratedKeys` / `findAmbiguousDuplicates` / `MigrationRequiredError`（CLI）、`manualServices()` / `StorageScheme` / legacy 値読取（Swift）
+- これに伴い legacy 由来の既知バグ（#186 manual 重複削除・#187 doctor の managed 行誤解析）は経路ごと解消
+
+### 注記
+- 移行アシスタント（旧 #172 C5）は、旧バージョンの利用実績がほぼ無いこと（DL 実測）を踏まえ**作らない判断**とした。互換の複雑さ（secret oracle・移行の crash-safe 化など）を丸ごと回避している。
+
 ## [1.8.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to AI KeyChain are documented in this file.
 - **v1.x で登録したキーは読まれなくなります。** GUI アプリまたは `akc set <KEY>` で**キーを登録し直してください**。旧キーは削除されず macOS Keychain に残りますが、AI KeyChain / `akc` からは参照しません。
 - `akc set --manual` / MCP の `manual` フィールドを廃止（すべて managed namespace に書き込む）。
 
+### Added
+- **アップグレード・ツアー** — v1.x から更新したユーザーの初回起動時、旧方式（旧 GUI store / manual スキーム）にしか無いキーを**読み取り専用・無音で検出**し、「再登録が必要なキー一覧」と v2.0 の使い方を案内するツアーを表示。新規インストール（旧キー無し）は従来の onboarding のまま。検出は `dump-keychain` 相当の属性照会のみで値は読まない（プロンプトゼロ）(#188)
+
 ### Changed
 - **単一 namespace 化** — resolver を 3 段ルックアップ（managed → 旧 GUI → manual）から **managed 単一**に簡素化。`security` 所有なのでヘッドレス読取はプロンプト/ハングしない。fail-closed 契約（exit 44 のみ not-found、それ以外は権威的失敗）は維持 (#188)
 - CLI（`cli/`）・bash 版（`scripts/akc`）・GUI（Swift）すべてを managed 単一に統一。GUI のキー発見・`.zshrc` エクスポート・削除も managed のみを対象に

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Download the latest release from [Releases](https://github.com/aieo-product/AIke
 
 > **Note:** Since v1.8.0, releases are signed with a Developer ID certificate (Team `34J49FY7U7`), notarized by Apple, and stapled, so Gatekeeper accepts the app without any manual `xattr` workaround. If macOS warns that the app is damaged or from an unidentified developer, do **not** bypass Gatekeeper — verify the asset with `spctl --assess --type open --context context:primary-signature -vv AIKeyChain-vX.Y.Z.dmg` (expect `accepted / Notarized Developer ID`) and re-download the latest release.
 >
-> **Upgrading from v1.7.x or earlier:** the signing identity changed from ad-hoc to Developer ID, so macOS asks for Keychain approval once per stored key on first access. Choose **"Always Allow"** — after that, approvals persist across all future updates.
+> **Upgrading from v1.x:** v2.0 stores keys in a new single namespace and no longer reads keys registered by older versions (they are not deleted). On first launch the app shows an upgrade tour listing the keys to re-register — re-add each with the app's **+** or `akc set <KEY>`.
 
 ### Verify your download
 
@@ -116,8 +116,8 @@ Terminal                                                          API Server
 > **Common AI-agent mistake:** looking up a stored key with the bare
 > `/usr/bin/security find-generic-password -s "API_KEY" -w` (service name only, no `-a`)
 > returns "could not be found" (exit 44). That is **not** proof the key is
-> unregistered — it just means the wrong lookup form was used for a GUI-store
-> key. Use `akc get API_KEY` / `akc check API_KEY` (see [CLI & MCP
+> unregistered — it just means the wrong lookup form was used. Use `akc get
+> API_KEY` / `akc check API_KEY` (see [CLI & MCP
 > Server](#cli--mcp-server-npm) below), or the two-attribute `security` form
 > shown above, instead of concluding the key is missing.
 

--- a/README.md
+++ b/README.md
@@ -105,15 +105,15 @@ swift build -c release
 ```
 Terminal                                                          API Server
   │  export API_KEY=$(/usr/bin/security find-generic-password \   │
-  │    -s "com.aieo.aikeychain" -a "API_KEY" -w)                   │
+  │    -s "com.aieo.aikeychain.managed" -a "API_KEY" -w)           │
   │────────────────────── API key in request ────────────────────▶│
 ```
 
-> The generated `.zshrc` line pins **both** the service (`com.aieo.aikeychain`) and
-> the account (the key name), matching exactly how the GUI stores the entry — this
-> avoids the `-a "$USER"` pitfall of stale or duplicate `acct` values.
+> The generated `.zshrc` line pins **both** the service (`com.aieo.aikeychain.managed`)
+> and the account (the key name), matching how every key is stored — this avoids the
+> `-a "$USER"` pitfall of stale or duplicate `acct` values.
 
-> **Common AI-agent mistake:** looking up a GUI-stored key with the bare
+> **Common AI-agent mistake:** looking up a stored key with the bare
 > `/usr/bin/security find-generic-password -s "API_KEY" -w` (service name only, no `-a`)
 > returns "could not be found" (exit 44). That is **not** proof the key is
 > unregistered — it just means the wrong lookup form was used for a GUI-store
@@ -143,9 +143,9 @@ akc init                     # set up AI-agent discovery machine-wide (Claude + 
 # Secret Reference workflow
 export OPENAI_API_KEY=keychain://OPENAI_API_KEY
 akc run -- claude            # real value injected into the child process only
-# Headless contract: managed keys resolve silently; a legacy GUI-owned key
-# never hangs akc — the read times out with an explicit "migration required"
-# error (migrate with `akc set <KEY>`; `akc doctor` lists unmigrated keys)
+# Headless contract: every key is in the managed namespace and resolves silently
+# — no prompts, no hangs. (v2.0 dropped the v1.x GUI store / manual scheme; if you
+# upgraded, re-register your keys with `akc set <KEY>`.)
 
 akc list                     # key names (never prints values)
 akc set GITHUB_TOKEN         # hidden prompt, overwrites in place
@@ -236,12 +236,12 @@ AI 開発では多数の API キーを扱います。多くの開発者はこれ
 | セキュリティレベル | ★☆☆ | ★★☆ | ★★★ |
 | 向いている用途 | シンプルに使いたい | 1Password 方式（`op://` 同等） | セキュリティ重視の環境 |
 
-> **AI エージェントによくある誤り:** GUI ストアに保存したキーを `/usr/bin/security
+> **AI エージェントによくある誤り:** 保存したキーを `/usr/bin/security
 > find-generic-password -s "API_KEY" -w`（サービス名のみ、`-a` なし）で引くと
 > "could not be found"（exit 44）になりますが、これは**「未登録」の証拠ではありません**。
-> GUI ストアのキーには誤ったルックアップ方法を使っているだけです。
+> managed namespace のキーには誤ったルックアップ方法を使っているだけです。
 > `akc get API_KEY` / `akc check API_KEY`（後述の「CLI & MCP サーバー」）か、
-> `/usr/bin/security find-generic-password -s "com.aieo.aikeychain" -a "API_KEY" -w`
+> `/usr/bin/security find-generic-password -s "com.aieo.aikeychain.managed" -a "API_KEY" -w`
 > （service + account の両方を指定する形）を使ってください。
 
 ### インストール

--- a/Tests/AIkeychainTests/LegacyKeyScannerTests.swift
+++ b/Tests/AIkeychainTests/LegacyKeyScannerTests.swift
@@ -2,7 +2,8 @@ import Testing
 @testable import AIkeychain
 
 /// v1 取り残しキー検出（アップグレードツアー用 / #188）の分類ロジック。
-/// CLI の findUnmigratedKeys（cli/test/unit.test.js）と同一規則であることを保証する。
+/// 対象は旧 GUI store（service=com.aieo.aikeychain）のみ = AI KeyChain が確実に
+/// 所有していた service。managed に無いものを返す。
 @Suite("LegacyKeyScanner Tests")
 struct LegacyKeyScannerTests {
 
@@ -10,21 +11,29 @@ struct LegacyKeyScannerTests {
         LegacyKeyScanner.unmigratedKeyNames(from: records)
     }
 
-    @Test("Reports legacy-only keys and skips those already in managed")
-    func reportsLegacyOnly() {
+    @Test("Reports legacy GUI-store keys not yet in managed, sorted")
+    func reportsLegacyGuiOnly() {
         let names = scan([
             // managed 済み → 対象外（旧 GUI にコピーが残っていても）
             (service: "com.aieo.aikeychain.managed", account: "MIGRATED_KEY"),
             (service: "com.aieo.aikeychain", account: "MIGRATED_KEY"),
-            // 旧 GUI store のみ → 対象
-            (service: "com.aieo.aikeychain", account: "GUI_ONLY_KEY"),
-            // manual スキームのみ → 対象（service 名がキー名）
-            (service: "MANUAL_ONLY_KEY", account: "takehiro"),
-            // env 変数形でない service は対象外（他アプリ）
-            (service: "com.vendor.other", account: "x"),
-            (service: "lowercase_svc", account: "x"),
+            // 旧 GUI store のみ → 対象（ソート確認のため複数）
+            (service: "com.aieo.aikeychain", account: "ZEBRA_KEY"),
+            (service: "com.aieo.aikeychain", account: "ALPHA_KEY"),
         ])
-        #expect(names == ["GUI_ONLY_KEY", "MANUAL_ONLY_KEY"])
+        #expect(names == ["ALPHA_KEY", "ZEBRA_KEY"])
+    }
+
+    @Test("Does NOT report manual-scheme / other-app services (avoids false positives)")
+    func ignoresManualAndOtherApps() {
+        // v1 の manual スキームや他アプリの UPPER_SNAKE service は所有が曖昧なので
+        // 対象にしない（新規インストールでの誤発火を防ぐ / #189 レビュー D-Q）。
+        #expect(scan([
+            (service: "MANUAL_TOKEN", account: "takehiro"),   // manual スキーム
+            (service: "VPN_TOKEN", account: "user"),          // 他アプリ
+            (service: "com.apple.something", account: "x"),
+            (service: "iCloud", account: "x"),
+        ]).isEmpty)
     }
 
     @Test("Returns empty when everything is already managed")
@@ -43,13 +52,12 @@ struct LegacyKeyScannerTests {
         ]).isEmpty)
     }
 
-    @Test("Ignores manual-shape false positives (lowercase / dotted / leading digit)")
-    func ignoresNonEnvVarNames() {
+    @Test("Skips records with nil/empty account and nil service (no blank tour rows)")
+    func skipsUnusableRecords() {
         #expect(scan([
-            (service: "iCloud", account: "x"),
-            (service: "com.apple.something", account: "x"),
-            (service: "9INVALID", account: "x"),
-            (service: "lower_token", account: "x"),
+            (service: "com.aieo.aikeychain", account: nil),
+            (service: "com.aieo.aikeychain", account: ""),
+            (service: nil, account: "ORPHAN"),
         ]).isEmpty)
     }
 

--- a/Tests/AIkeychainTests/LegacyKeyScannerTests.swift
+++ b/Tests/AIkeychainTests/LegacyKeyScannerTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import AIkeychain
+
+/// v1 取り残しキー検出（アップグレードツアー用 / #188）の分類ロジック。
+/// CLI の findUnmigratedKeys（cli/test/unit.test.js）と同一規則であることを保証する。
+@Suite("LegacyKeyScanner Tests")
+struct LegacyKeyScannerTests {
+
+    private func scan(_ records: [(service: String?, account: String?)]) -> [String] {
+        LegacyKeyScanner.unmigratedKeyNames(from: records)
+    }
+
+    @Test("Reports legacy-only keys and skips those already in managed")
+    func reportsLegacyOnly() {
+        let names = scan([
+            // managed 済み → 対象外（旧 GUI にコピーが残っていても）
+            (service: "com.aieo.aikeychain.managed", account: "MIGRATED_KEY"),
+            (service: "com.aieo.aikeychain", account: "MIGRATED_KEY"),
+            // 旧 GUI store のみ → 対象
+            (service: "com.aieo.aikeychain", account: "GUI_ONLY_KEY"),
+            // manual スキームのみ → 対象（service 名がキー名）
+            (service: "MANUAL_ONLY_KEY", account: "takehiro"),
+            // env 変数形でない service は対象外（他アプリ）
+            (service: "com.vendor.other", account: "x"),
+            (service: "lowercase_svc", account: "x"),
+        ])
+        #expect(names == ["GUI_ONLY_KEY", "MANUAL_ONLY_KEY"])
+    }
+
+    @Test("Returns empty when everything is already managed")
+    func emptyWhenAllManaged() {
+        #expect(scan([
+            (service: "com.aieo.aikeychain.managed", account: "A_KEY"),
+            (service: "com.aieo.aikeychain.managed", account: "B_KEY"),
+        ]).isEmpty)
+    }
+
+    @Test("Never reports the app-reserved share/sign keys")
+    func excludesReservedServices() {
+        #expect(scan([
+            (service: "com.aieo.aikeychain.sharekey", account: "private_key"),
+            (service: "com.aieo.aikeychain.signkey", account: "signing_key"),
+        ]).isEmpty)
+    }
+
+    @Test("Ignores manual-shape false positives (lowercase / dotted / leading digit)")
+    func ignoresNonEnvVarNames() {
+        #expect(scan([
+            (service: "iCloud", account: "x"),
+            (service: "com.apple.something", account: "x"),
+            (service: "9INVALID", account: "x"),
+            (service: "lower_token", account: "x"),
+        ]).isEmpty)
+    }
+
+    @Test("shouldShow is false with no legacy keys")
+    func shouldShowFalseWhenEmpty() {
+        // 旧キーが無ければ UserDefaults を読むまでもなく false（新規インストール）
+        #expect(UpgradeTourView.shouldShow(legacyKeyNames: []) == false)
+    }
+}

--- a/Tests/AIkeychainTests/ProxyTests.swift
+++ b/Tests/AIkeychainTests/ProxyTests.swift
@@ -166,7 +166,6 @@ final class BlockingKeychainService: KeychainServiceProtocol {
     func delete(for account: String) throws {}
     func exists(for account: String) -> Bool { false }
     func allAccounts() -> [String] { [] }
-    func manualServices() -> [String] { [] }
 }
 
 /// Keychain double that reports the read needs user interaction.
@@ -179,7 +178,6 @@ final class InteractionRequiredKeychainService: KeychainServiceProtocol {
     func delete(for account: String) throws {}
     func exists(for account: String) -> Bool { false }
     func allAccounts() -> [String] { [] }
-    func manualServices() -> [String] { [] }
 }
 
 /// Minimal raw-TCP HTTP client for talking to the local proxy in tests.

--- a/Tests/AIkeychainTests/SecretRefTests.swift
+++ b/Tests/AIkeychainTests/SecretRefTests.swift
@@ -25,49 +25,19 @@ struct ZshrcExporterSecretRefTests {
         #expect(output.contains("akc run"))
     }
 
-    @Test("Standard format includes service name comments")
-    func standardComments() {
-        let keys = [makeKey(service: .github)]
-        // managed に未移行のキー（旧 GUI store に実在）を模す
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in false })
-        #expect(output.contains("# [AI KeyChain]"))
-        #expect(output.contains("/usr/bin/security find-generic-password"))
-        // 生成される .zshrc 行が GUI 保存形式 (service=com.aieo.aikeychain, account=KEY) に
-        // 厳密一致していること。acct 不整合による古い/無効な値の誤取得を防ぐ (issue #91)。
-        // シェル側 `||` fallback は使わない — 承認拒否や一時エラーでも別スキームの
-        // 値へ静かに落ちるため (#160 レビュー指摘)。
-        #expect(output.contains(
-            "export GITHUB_TOKEN=$(/usr/bin/security find-generic-password -s \"com.aieo.aikeychain\" -a \"GITHUB_TOKEN\" -w)"
-        ))
-        #expect(!output.contains("-a \"$USER\""))
-        #expect(!output.contains("||"))
-    }
-
-    @Test("Standard format emits the managed lookup for keys living in the managed namespace")
+    @Test("Standard format emits the managed lookup (v2.0 #188)")
     func standardManagedScheme() {
-        // GUI の新規保存は managed namespace (#167/#169) に行く。旧 service 固定の
-        // export だと保存直後のキーが新しいシェルで空になる（#179 二段レビュー B1）。
+        // v2.0: 全キーは managed namespace。厳密一致の lookup を出す（`||` fallback
+        // や -a "$USER" は使わない）。
         let keys = [makeKey(service: .github)]
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in true })
+        let output = ZshrcExporter.export(keys: keys, format: .zshrc)
+        #expect(output.contains("# [AI KeyChain]"))
         #expect(output.contains(
             "export GITHUB_TOKEN=$(/usr/bin/security find-generic-password -s \"com.aieo.aikeychain.managed\" -a \"GITHUB_TOKEN\" -w)"
         ))
-        #expect(!output.contains("-s \"com.aieo.aikeychain\" -a \"GITHUB_TOKEN\""))
+        #expect(!output.contains("-s \"com.aieo.aikeychain\" -a \"GITHUB_TOKEN\"")) // legacy service は出さない
+        #expect(!output.contains("-a \"$USER\""))
         #expect(!output.contains("||"))
-    }
-
-    @Test("Standard format emits the manual-scheme lookup for manual-scheme keys")
-    func standardManualScheme() {
-        // manual スキーム (service=KEY_NAME) のキーは、そのスキームに厳密一致する
-        // lookup (-s "KEY_NAME"、-a ピン留めなし) だけを出す (#160)。
-        let custom = CustomKey(envVarName: "MANUAL_ONLY_KEY", displayName: "MANUAL_ONLY_KEY",
-                               categoryId: KeyCategory.cliAdded.stableId)
-        let keys = [APIKey(customKey: custom, isConfigured: true, storage: .manual)]
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in false })
-        #expect(output.contains(
-            "export MANUAL_ONLY_KEY=$(/usr/bin/security find-generic-password -s \"MANUAL_ONLY_KEY\" -w)"
-        ))
-        #expect(!output.contains("com.aieo.aikeychain\" -a \"MANUAL_ONLY_KEY\""))
     }
 
     @Test("Standard format uses absolute security path")
@@ -76,7 +46,7 @@ struct ZshrcExporterSecretRefTests {
             makeKey(service: .github),
             makeKey(service: .openAI),
         ]
-        let output = ZshrcExporter.export(keys: keys, format: .zshrc, managedExists: { _ in false })
+        let output = ZshrcExporter.export(keys: keys, format: .zshrc)
         let lookupLines = output.split(separator: "\n").filter {
             $0.contains("find-generic-password")
         }

--- a/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
+++ b/Tests/AIkeychainTests/SecurityCLIKeychainServiceTests.swift
@@ -229,31 +229,24 @@ struct SecurityCLIKeychainServiceTests {
         #expect(callLog(stateDir) == ["find com.aieo.aikeychain.managed|SOME_KEY"])
     }
 
-    @Test("Delete cleans legacy copies first (manual loop -> legacy GUI -> managed)")
-    func deleteCleansLegacyCopies() throws {
+    @Test("Delete only ever touches the managed namespace (v2.0 #188)")
+    func deleteManagedOnly() throws {
         let (service, stateDir) = try makeStub()
         try service.save(value: "v1", for: "CLEAN_KEY")
+        // 旧 namespace にゴミが残っていても触れない（v2.0 は legacy を読み書きしない）
         try seed(stateDir, service: "com.aieo.aikeychain", name: "CLEAN_KEY")
-        try seed(stateDir, service: "CLEAN_KEY", name: "CLEAN_KEY") // manual スキーム
 
         try service.delete(for: "CLEAN_KEY")
 
-        // 全 namespace から消えている（残すと akc の legacy fallback が復活させる / B3）
+        // managed の本体だけが消える
         #expect(!FileManager.default.fileExists(
             atPath: statePath(stateDir, service: SecurityCLIKeychainService.managedService, name: "CLEAN_KEY").path))
-        #expect(!FileManager.default.fileExists(
+        // legacy は触られない
+        #expect(FileManager.default.fileExists(
             atPath: statePath(stateDir, service: "com.aieo.aikeychain", name: "CLEAN_KEY").path))
-        #expect(!FileManager.default.fileExists(
-            atPath: statePath(stateDir, service: "CLEAN_KEY", name: "CLEAN_KEY").path))
 
-        // 順序: manual（44 まで反復）→ 旧 GUI → managed
         let deletes = callLog(stateDir).filter { $0.hasPrefix("delete ") }
-        #expect(deletes == [
-            "delete CLEAN_KEY|CLEAN_KEY",            // 1件目を削除 (exit 0)
-            "delete CLEAN_KEY|CLEAN_KEY",            // 重複掃除の反復 → 44 で終端 (#100)
-            "delete com.aieo.aikeychain|CLEAN_KEY",
-            "delete com.aieo.aikeychain.managed|CLEAN_KEY",
-        ])
+        #expect(deletes == ["delete com.aieo.aikeychain.managed|CLEAN_KEY"])
     }
 
     @Test("A locked keychain fails fast without spawning and without quarantining (#170)")
@@ -286,19 +279,10 @@ struct SecurityCLIKeychainServiceTests {
         #expect(try service.retrieveNoninteractive(for: "LOCK_KEY") == "v2")
     }
 
-    @Test("Delete propagates a legacy cleanup failure and leaves the managed copy intact")
-    func deleteLegacyFailureIsPropagated() throws {
-        let (service, stateDir) = try makeStub()
-        try service.save(value: "v1", for: "LEGACY_FAIL_KEY")
-
-        // 旧 GUI store の削除が拒否される（stub: exit 51）→ throw し、
-        // 権威コピー（managed）には触れない — 「削除成功と報告して fallback から
-        // 復活」という half-deleted 状態を作らない（#179 二段レビュー B3）
-        #expect(throws: KeychainError.self) {
-            try service.delete(for: "LEGACY_FAIL_KEY")
-        }
-        #expect(try service.retrieve(for: "LEGACY_FAIL_KEY") == "v1")
-        let deletes = callLog(stateDir).filter { $0.hasPrefix("delete ") }
-        #expect(!deletes.contains("delete com.aieo.aikeychain.managed|LEGACY_FAIL_KEY"))
+    @Test("Delete of a missing key is idempotent (rc=44)")
+    func deleteIdempotentMissing() throws {
+        let (service, _) = try makeStub()
+        // 保存していないキーの削除は throw しない（44 冪等）
+        try service.delete(for: "NEVER_SAVED_KEY")
     }
 }

--- a/Tests/AIkeychainTests/ViewModelTests.swift
+++ b/Tests/AIkeychainTests/ViewModelTests.swift
@@ -159,95 +159,6 @@ struct KeyListViewModelTests {
         #expect(!vm.keys.contains { $0.envVarName == "has-hyphen" })
     }
 
-    @Test("Manual-scheme keys (service=<name>) are discovered under the CLI Added category")
-    func discoversManualSchemeKeys() {
-        let (vm, mock) = makeSUT()
-        let name = uniqueEnvName()
-        // `security add-generic-password -s KEY_NAME` 等で登録された manual スキームのキー (#160)
-        mock.manualStore[name] = "secret"
-        vm.loadKeys()
-
-        let discovered = vm.keys.first { $0.envVarName == name }
-        #expect(discovered != nil)
-        #expect(discovered?.isConfigured == true)
-        #expect(discovered?.builtinCategory == .cliAdded)
-        #expect(discovered?.storage == .manual)
-    }
-
-    @Test("Editing a manual-only key writes a managed copy without touching the manual item (#170)")
-    func savingManualKeyWritesManagedCopy() throws {
-        // 旧 #177 の fail-closed は managed namespace 移行（C2/C3）で構造的に不要化:
-        // GUI の書込は subprocess security による managed への新規コピー作成であり、
-        // manual アイテム自体には触れない（毒化が起きない）。akc の解決順は
-        // managed が優先なので、新しい値が正しく勝つ。
-        let (vm, mock) = makeSUT()
-        let name = uniqueEnvName()
-        mock.manualStore[name] = "old-value"
-        vm.loadKeys()
-        let discovered = try #require(vm.keys.first { $0.envVarName == name })
-
-        try vm.save(value: "new-value", for: discovered)
-        #expect(mock.manualStore[name] == "old-value") // manual アイテムは無傷
-        #expect(mock.store[name] == "new-value")       // managed 相当に新コピー
-    }
-
-    @Test("Deleting a dual-scheme key removes both copies")
-    func deletingRemovesBothSchemes() throws {
-        let (vm, mock) = makeSUT()
-        let name = uniqueEnvName()
-        try mock.save(value: "app-value", for: name)
-        mock.manualStore[name] = "manual-value"
-        vm.loadKeys()
-        let key = vm.keys.first { $0.envVarName == name }
-
-        try vm.delete(key: key!)
-
-        // 片方だけ残ると 2 段ルックアップで「復活」するため両方消える (#160)
-        #expect(mock.store[name] == nil)
-        #expect(mock.manualStore[name] == nil)
-    }
-
-    @Test("A key present in both schemes is not duplicated")
-    func bothSchemesNotDuplicated() throws {
-        let (vm, mock) = makeSUT()
-        let name = uniqueEnvName()
-        try mock.save(value: "app-value", for: name)
-        mock.manualStore[name] = "manual-value"
-        vm.loadKeys()
-        #expect(vm.keys.filter { $0.envVarName == name }.count == 1)
-    }
-
-    @Test("A preset key backed only by a manual-scheme item shows as configured")
-    func presetBackedByManualScheme() {
-        let (vm, mock) = makeSUT()
-        // プリセット名のキーが manual スキームにだけ存在する場合、2 段ルックアップで
-        // configured になり、発見キーとして二重表示もされない (#160)。
-        mock.manualStore["ANTHROPIC_API_KEY"] = "secret"
-        vm.loadKeys()
-        let matches = vm.keys.filter { $0.envVarName == "ANTHROPIC_API_KEY" }
-        #expect(matches.count == 1)
-        #expect(matches.first?.service == .some(.anthropic))
-        #expect(matches.first?.isConfigured == true)
-        #expect(matches.first?.builtinCategory != .cliAdded)
-    }
-
-    @Test("Manual-scheme names that are not strict upper-snake-case are not surfaced")
-    func invalidManualNamesNotSurfaced() {
-        let (vm, mock) = makeSUT()
-        // 他アプリ/システムのアイテムは対象外。EnvVarName.isValid が許す小文字混じり
-        //（iCloud / AirPort 等の実在システム service 名）も manual 発見では弾く。
-        // MockKeychainService.manualServices() は無条件で返すため、ViewModel 側の
-        // EnvVarName.isManualSchemeCandidate ガードを検証する。
-        mock.manualStore["com.example.app"] = "v"
-        mock.manualStore["9INVALID"] = "v"
-        mock.manualStore["iCloud"] = "v"
-        mock.manualStore["BluetoothGlobal"] = "v"
-        vm.loadKeys()
-        #expect(!vm.keys.contains { $0.envVarName == "com.example.app" })
-        #expect(!vm.keys.contains { $0.envVarName == "9INVALID" })
-        #expect(!vm.keys.contains { $0.envVarName == "iCloud" })
-        #expect(!vm.keys.contains { $0.envVarName == "BluetoothGlobal" })
-    }
 
     @Test("Editing an existing key does not rename it (no orphaned duplicate)")
     func editingDoesNotRenameKey() throws {
@@ -326,5 +237,4 @@ final class DupAccountsKeychainService: KeychainServiceProtocol {
     func delete(for account: String) throws {}
     func exists(for account: String) -> Bool { true }
     func allAccounts() -> [String] { accounts }
-    func manualServices() -> [String] { [] }
 }

--- a/cli/README.md
+++ b/cli/README.md
@@ -60,8 +60,7 @@ akc set GITHUB_TOKEN      # hidden prompt (or pipe via stdin); the value never
                           # via stdin as hex. Overwrites in place, no duplicates
 akc delete GITHUB_TOKEN
 
-# Diagnose your setup (env + ~/.zshrc), the -a "$USER" pitfall, and
-# ambiguous duplicate keychain entries (same service name, multiple accounts)
+# Diagnose your setup: keychain access + keychain:// references in env and ~/.zshrc
 akc doctor
 
 # Print the usage guide for AI agents

--- a/cli/README.md
+++ b/cli/README.md
@@ -68,12 +68,12 @@ akc doctor
 akc guide
 ```
 
-### Keychain lookup order
+### Keychain lookup (v2.0)
 
-1. `service="com.aieo.aikeychain"`, `account=<KEY>` — the AI KeyChain GUI store
-2. `service=<KEY>` with **no account** — manually-registered keys
-
-Manual keys are looked up by service only because `acct` attributes are inconsistent across entries; pinning `-a` can return a stale duplicate ([issue #91](https://github.com/aieo-product/AIkeychain/issues/91)).
+Every key lives at `service="com.aieo.aikeychain.managed"`, `account=<KEY>` — the
+single managed namespace, created by `/usr/bin/security` so headless reads never
+prompt. The old v1.x GUI store / manual scheme are no longer read; upgrading users
+re-register their keys with `akc set <KEY>`.
 
 ## MCP server
 

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -44,11 +44,11 @@ Commands:
            --print previews, --no-register skips MCP registration.
   run      Resolve keychain:// env references and execute a command
   list     List known key names (never prints values)
-  check    Check whether a key exists and in which store
+  check    Check whether a key exists in the managed namespace
   get      Print the keychain:// reference for a key (--reveal prints the raw value)
   set      Store/update a key (value via hidden prompt, or piped stdin)
   delete   Delete a key from the Keychain
-  doctor   Diagnose env + ~/.zshrc refs + unmigrated legacy keys (values masked)
+  doctor   Diagnose env + ~/.zshrc keychain references (values masked)
   guide    Print the AI KeyChain usage guide
   mcp      Start the MCP server on stdio (for Claude Code / Codex etc.)
 

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -12,7 +12,6 @@ import {
   deleteKey,
   maskValue,
   KeychainError,
-  GUI_SERVICE,
   MANAGED_SERVICE,
 } from '../src/keychain.js';
 import { cmdRun } from '../src/run.js';
@@ -114,8 +113,8 @@ async function cmdList() {
     process.stdout.write('No keys found.\n');
     return 0;
   }
-  for (const { name, sources } of keys) {
-    process.stdout.write(`  ${name}  [${sources.join(', ')}]\n`);
+  for (const { name } of keys) {
+    process.stdout.write(`  ${name}\n`);
   }
   return 0;
 }
@@ -123,22 +122,12 @@ async function cmdList() {
 async function cmdCheck(name) {
   const result = await keyExists(name);
   if (result.exists) {
-    const stores = [
-      result.managed && 'managed store',
-      result.app && 'AI KeyChain store (legacy)',
-      result.manual && 'manual entry',
-    ]
-      .filter(Boolean)
-      .join(', ');
-    process.stdout.write(`✅ ${name} exists (${stores})\n`);
-    if ((result.managed || result.app) && !result.manual) {
-      // Namespaced key: the bare `security -s <KEY> -w` form (no -a) returns
-      // exit 44 for these — a false "not registered" signal (issue #137).
-      const svc = result.managed ? MANAGED_SERVICE : GUI_SERVICE;
-      process.stdout.write(
-        `   ↳ security CLI: use -s "${svc}" -a "${name}" -w  (or: akc get ${name})\n`
-      );
-    }
+    process.stdout.write(`✅ ${name} exists (managed store)\n`);
+    // The bare `security -s <KEY> -w` form (no -a) returns exit 44 for managed
+    // items — a false "not registered" signal (issue #137). Show the right form.
+    process.stdout.write(
+      `   ↳ security CLI: use -s "${MANAGED_SERVICE}" -a "${name}" -w  (or: akc get ${name})\n`
+    );
     return 0;
   }
   process.stdout.write(`❌ ${name} not found in Keychain\n`);
@@ -181,12 +170,12 @@ async function cmdSet(name) {
 }
 
 async function cmdDelete(name) {
-  const deleted = await deleteKey(name);
-  if (deleted.length === 0) {
+  const removed = await deleteKey(name);
+  if (!removed) {
     process.stderr.write(`akc: ${name} not found in Keychain\n`);
     return 1;
   }
-  process.stdout.write(`✅ Deleted ${name} (${deleted.join(', ')})\n`);
+  process.stdout.write(`✅ Deleted ${name}\n`);
   return 0;
 }
 

--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "aikeychain",
-  "version": "0.5.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aikeychain",
-      "version": "0.5.1",
+      "version": "2.0.0",
       "license": "MIT",
       "os": [
         "darwin"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aikeychain",
-  "version": "0.5.1",
+  "version": "2.0.0",
   "description": "AI KeyChain CLI & MCP server — resolve keychain:// secret references from macOS Keychain and let AI agents (Claude, Codex) use them safely. Run `akc init` to set up discovery.",
   "type": "module",
   "bin": {

--- a/cli/src/agent-setup.js
+++ b/cli/src/agent-setup.js
@@ -20,23 +20,16 @@ value into \`.env\`, source code, logs, or commits.
   export OPENAI_API_KEY=keychain://OPENAI_API_KEY
   akc run -- <command>            # resolves keychain:// refs into the child process only
   \`\`\`
-- Check / read a key — prefer \`akc get <KEY>\`: it checks both stores (AI
-  KeyChain GUI + manually-registered) and by default prints only the
+- Check / read a key — prefer \`akc get <KEY>\`: it by default prints only the
   \`keychain://\` reference (never the value). Add \`--reveal\` only when you
   truly need the raw value on stdout; to inject it into a process instead, use
-  \`akc run -- <command>\`. If you must use the raw \`security\` CLI, pick the
-  form that matches where the key lives:
+  \`akc run -- <command>\`. If you must use the raw \`security\` CLI:
   \`\`\`bash
-  # [app] store keys (saved via the AI KeyChain GUI):
-  /usr/bin/security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w
-  # [manual] keys (registered by hand) — service name only, do NOT pin
-  # -a "$USER" (account attributes are inconsistent; pinning can return a
-  # stale value):
-  /usr/bin/security find-generic-password -s "<KEY>" -w
+  /usr/bin/security find-generic-password -s "com.aieo.aikeychain.managed" -a "<KEY>" -w
   \`\`\`
-  ⚠️ The bare \`-s "<KEY>"\` form returns "could not be found" (exit 44) for
-  [app] store keys — that is NOT proof the key is unregistered. Confirm with
-  \`akc check <KEY>\` / \`akc get <KEY>\` before concluding a key is missing.
+  ⚠️ The bare \`-s "<KEY>"\` form (no -a) returns "could not be found" (exit 44)
+  — that is NOT proof the key is unregistered. Confirm with \`akc check <KEY>\` /
+  \`akc get <KEY>\`.
 - Store/update a key without exposing it in argv or shell history:
   \`\`\`bash
   akc set ENV_VAR_NAME          # hidden prompt (or pipe via stdin)

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -14,7 +14,6 @@ import { resolveKey, dumpRecords, KeychainError, MANAGED_SERVICE } from './keych
  */
 export function scanShellConfig(text) {
   const keys = new Set();
-  const warnings = [];
   for (const m of text.matchAll(/keychain:\/\/([A-Za-z0-9_.-]+)/g)) {
     keys.add(m[1]);
   }
@@ -30,7 +29,7 @@ export function scanShellConfig(text) {
       if (acct) keys.add(acct[1]);
     }
   }
-  return { keys: [...keys].sort(), warnings };
+  return { keys: [...keys].sort() };
 }
 
 // --- MCP registration path-independence (issue #131) ---
@@ -109,7 +108,7 @@ async function checkClaudeMcpRegistration(check, claudeJsonPath) {
 }
 
 export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, claudeJsonPath } = {}) {
-  const report = { platform: process.platform, checks: [], warnings: [], ok: true };
+  const report = { platform: process.platform, checks: [], ok: true };
   const check = (name, ok, detail) => {
     report.checks.push({ name, ok, detail });
     if (!ok) report.ok = false;
@@ -170,8 +169,7 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
     check('shell config', true, `${path} not found (skipped)`);
   }
   if (text !== null) {
-    const { keys, warnings } = scanShellConfig(text);
-    report.warnings.push(...warnings);
+    const { keys } = scanShellConfig(text);
     if (keys.length === 0) {
       check('shell config', true, `no keychain references in ${path}`);
     } else {
@@ -201,9 +199,6 @@ export function formatReport(report) {
   const lines = [];
   for (const { name, ok, detail } of report.checks) {
     lines.push(`  ${ok ? '✅' : '❌'} ${name}: ${detail}`);
-  }
-  for (const warning of report.warnings) {
-    lines.push(`  ⚠️  ${warning}`);
   }
   lines.push('');
   lines.push(report.ok ? 'All checks passed.' : 'Some checks failed. See above.');

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -6,18 +6,12 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, isAbsolute } from 'node:path';
 import { collectRefs, resolveRefs } from './run.js';
-import {
-  resolveKey,
-  dumpRecords,
-  findAmbiguousDuplicates,
-  findUnmigratedKeys,
-  KeychainError,
-  GUI_SERVICE,
-  MANAGED_SERVICE,
-  MANUAL_NAME_PATTERN,
-} from './keychain.js';
+import { resolveKey, dumpRecords, KeychainError, MANAGED_SERVICE } from './keychain.js';
 
-/** Extract keychain://KEY and `security find-generic-password -s "KEY"` keys from shell config text. */
+/**
+ * Extract keychain://KEY and `security find-generic-password -s "..." -a "KEY"`
+ * keys from shell config text (v2.0: managed namespace only).
+ */
 export function scanShellConfig(text) {
   const keys = new Set();
   const warnings = [];
@@ -29,23 +23,11 @@ export function scanShellConfig(text) {
     const find = line.match(/security\s+find-generic-password\s+([^\n]*)/);
     if (!find) continue;
     const svc = find[1].match(/-s\s+"?([A-Za-z0-9_.-]+)"?/);
-    if (svc) {
-      if (svc[1] === 'com.aieo.aikeychain') {
-        // GUI 保存形式で pin された行 (`-s "com.aieo.aikeychain" -a "KEY"`) では
-        // 実際のキー名は -a 側にある。-s の値 (共通サービス名) ではなく -a を採る。
-        const acct = find[1].match(/-a\s+"?([A-Za-z_][A-Za-z0-9_]*)"?/);
-        if (acct) keys.add(acct[1]);
-      } else {
-        keys.add(svc[1]);
-      }
-    }
-    if (/-a\s+"\$USER"|-a\s+\$USER/.test(find[1])) {
-      // Report the service name only — never echo the raw shell line, which
-      // could contain inline secrets or other sensitive content.
-      warnings.push(
-        `${svc ? svc[1] : '(unknown key)'}: lookup uses -a "$USER" — account attributes are ` +
-          'inconsistent; look up by service only (issue #91)'
-      );
+    if (svc && svc[1] === MANAGED_SERVICE) {
+      // managed export line: `-s "com.aieo.aikeychain.managed" -a "KEY"` — the
+      // real key name is on -a, not the shared service name.
+      const acct = find[1].match(/-a\s+"?([A-Za-z_][A-Za-z0-9_]*)"?/);
+      if (acct) keys.add(acct[1]);
     }
   }
   return { keys: [...keys].sort(), warnings };
@@ -139,82 +121,19 @@ export async function runDoctor({ env = process.env, zshrcPath, codexTomlPath, c
   }
   check('platform', true, 'macOS');
 
-  // Keychain enumeration — ONE bounded dump-keychain call shared by the three
-  // checks below (#185 S7: three independent dumps would stack three timeouts
-  // when the enumeration hangs). Names/accts only; values are never read.
-  let records = null;
+  // Keychain enumeration (v2.0: managed namespace only). Names/accts only;
+  // values are never read.
   try {
-    records = await dumpRecords();
-    const names = new Set();
-    for (const { service, account } of records) {
-      if ((service === MANAGED_SERVICE || service === GUI_SERVICE) && account) names.add(account);
-      else if (service && MANUAL_NAME_PATTERN.test(service)) names.add(service);
-    }
-    const managedCount = new Set(
+    const records = await dumpRecords();
+    const names = new Set(
       records.filter((r) => r.service === MANAGED_SERVICE && r.account).map((r) => r.account)
-    ).size;
-    check('keychain access', true, `${names.size} key(s) visible (${managedCount} in the managed namespace)`);
+    );
+    check('keychain access', true, `${names.size} key(s) in the managed namespace`);
   } catch (err) {
     if (err instanceof KeychainError) {
       check('keychain access', false, err.message);
     } else {
       throw err;
-    }
-  }
-
-  if (records !== null) {
-    // Ambiguous duplicate entries (issue #91): same service name, multiple accts.
-    const dups = findAmbiguousDuplicates(records);
-    if (dups.length === 0) {
-      check('duplicate entries', true, 'no ambiguous duplicate keychain entries');
-    } else {
-      check(
-        'duplicate entries',
-        false,
-        `${dups.length} service(s) have duplicate entries — \`security -s NAME -w\` is ambiguous:\n` +
-          dups
-            .map(
-              (d) =>
-                `       - ${d.service}: acct=[${d.accounts.map((a) => `"${a}"`).join(', ')}]` +
-                ` → remove the stale one: security delete-generic-password -s "${d.service}" -a "<acct>"`
-            )
-            .join('\n')
-      );
-    }
-
-    // Unmigrated legacy keys (#171): exist only in the GUI store / manual scheme
-    // with no managed copy. Headless reads of GUI-owned ones prompt/hang (bounded
-    // to a timeout since #171). Detection is non-destructive — dump attributes
-    // only, no `find -w` probes (those would rain consent dialogs). Manual-scheme
-    // hits are candidates by name shape — an unrelated app's UPPER_SNAKE service
-    // would match too (#185 D-Q1; same rule as `akc list` since #160).
-    const { keys: unmigrated, unparseable } = findUnmigratedKeys(records);
-    if (unparseable > 0) {
-      report.warnings.push(
-        `${unparseable} AI KeyChain store record(s) could not be parsed from dump-keychain — ` +
-          'migration status may be incomplete'
-      );
-    }
-    if (unmigrated.length === 0) {
-      check(
-        'migration',
-        true,
-        unparseable > 0
-          ? 'no unmigrated legacy keys detected (but see the unparseable-records warning)'
-          : 'no unmigrated legacy keys (all keys have a managed copy)'
-      );
-    } else {
-      check(
-        'migration',
-        false,
-        `${unmigrated.length} key(s) exist only in legacy stores — headless reads may be ` +
-          'bounded-failed (migration required):' + '\n' +
-          unmigrated
-            .map((k) => `       - ${k.name} [${k.stores.join(', ')}] → migrate: akc set ${k.name}`)
-            .join('\n') +
-          '\n       (or use the AI KeyChain app to migrate; legacy copies are cleaned up on delete.' +
-          '\n        [manual] entries are name-shape candidates and may belong to another tool)'
-      );
     }
   }
 

--- a/cli/src/keychain.js
+++ b/cli/src/keychain.js
@@ -1,13 +1,10 @@
 // Thin wrapper around the macOS `security` CLI.
-// Lookup order matches scripts/akc (issues #91, #167):
-//   1. service="com.aieo.aikeychain.managed" account="<KEY>"  (managed namespace, v1.9+)
-//   2. service="com.aieo.aikeychain" account="<KEY>"          (legacy GUI store)
-//   3. service="<KEY>" with NO account                        (legacy manual scheme)
-// Each tier falls through ONLY on exit 44 (not found) — any other failure is
-// authoritative and fails closed (#147/#150 semantics).
-// Manual keys are looked up by service only because their `acct` attribute is
-// not consistent ($USER or the service name) — pinning -a can grab a stale
-// duplicate entry and return an invalid value.
+// v2.0 (#188): a single managed namespace is the ONLY store. Every key lives at
+//   service="com.aieo.aikeychain.managed" account="<KEY>"
+// created by /usr/bin/security, so headless reads never prompt or hang. The
+// legacy GUI store / manual scheme from v1.x are no longer read or written —
+// pre-v2 users re-register their keys (`akc set <KEY>`). This drops the old
+// 3-tier lookup, migration-required errors, and all legacy fallbacks.
 
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -39,34 +36,11 @@ export const SECURITY_BIN =
 
 export const KEY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
-export const GUI_SERVICE = 'com.aieo.aikeychain';
-// v1.9+ managed namespace (#167): every key under it was created by
-// /usr/bin/security, so headless reads never prompt. New writes go here;
-// GUI_SERVICE and the manual scheme remain read-only legacy fallbacks.
+// v2.0 (#188): the single managed namespace. Every key created by
+// /usr/bin/security lives here and is headless-readable without prompts.
 export const MANAGED_SERVICE = 'com.aieo.aikeychain.managed';
-// Manual entries are identified by env-var-shaped service names (e.g. GITHUB_TOKEN).
-export const MANUAL_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 
 export class KeychainError extends Error {}
-
-/**
- * A legacy (GUI-owned or manual) item blocked the headless read on a keychain
- * consent prompt and the subprocess was killed (#171). The contract is
- * "new/migrated (managed) keys succeed silently; legacy keys fail bounded" —
- * NOT "mixed stores always succeed". The fix is migration, so say so.
- */
-export class MigrationRequiredError extends KeychainError {
-  constructor(name, store) {
-    super(
-      `"${name}" is stored as a legacy ${store} item that cannot be read headlessly ` +
-        `(the read blocked on a keychain prompt and was killed after ${SUBPROCESS_TIMEOUT_MS / 1000}s). ` +
-        `Migrate it to the managed namespace: re-register with \`akc set ${name}\`, ` +
-        `or use the AI KeyChain app's migration assistant.`
-    );
-    this.keyName = name;
-    this.store = store;
-  }
-}
 
 export function assertMacOS() {
   if (process.platform !== 'darwin') {
@@ -122,80 +96,40 @@ function stripTrailingNewline(s) {
 }
 
 /**
- * Resolve a key to its secret value, or null if not found.
- * Throws MigrationRequiredError when a legacy tier blocks on a prompt (#171),
- * and KeychainError when the managed tier times out (managed items are
- * security-owned and never prompt — a timeout there means a locked/unavailable
- * keychain, not an ownership problem).
+ * Resolve a key to its secret value, or null if not found (v2.0: managed only).
+ * Managed items are security-owned and never prompt — a timeout means the
+ * keychain is locked/unavailable; a non-44 error fails closed with a reason.
  */
 export async function resolveKey(name) {
-  // Lookup order: managed (v1.9+, always headless-readable) -> legacy GUI -> manual.
-  const managed = await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name, '-w']);
-  if (managed.ok) {
-    const value = stripTrailingNewline(managed.stdout);
+  const r = await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name, '-w']);
+  if (r.ok) {
+    const value = stripTrailingNewline(r.stdout);
     return value || null;
   }
-  if (managed.timedOut) {
+  if (r.code === 44) return null;
+  if (r.timedOut) {
     throw new KeychainError(
-      `reading "${name}" from the managed namespace timed out — the keychain is likely locked ` +
-        'or unavailable. Unlock the login keychain and retry.'
+      `reading "${name}" timed out — the keychain is likely locked or unavailable. ` +
+        'Unlock the login keychain and retry.'
     );
   }
-  if (managed.code !== 44) {
-    // fail closed on unexpected errors (#147 semantics) — but say why (#185 S4)
-    throw new KeychainError(
-      `reading "${name}" from the managed namespace failed (exit ${managed.code}): ` +
-        `${managed.stderr.trim() || 'unknown error'}`
-    );
-  }
-  const gui = await security(['find-generic-password', '-s', GUI_SERVICE, '-a', name, '-w']);
-  if (gui.ok) {
-    const value = stripTrailingNewline(gui.stdout);
-    return value || null;
-  }
-  if (gui.timedOut) throw new MigrationRequiredError(name, 'GUI-store');
-  if (gui.code !== 44) {
-    throw new KeychainError(
-      `reading "${name}" from the legacy GUI store failed (exit ${gui.code}): ` +
-        `${gui.stderr.trim() || 'unknown error'}`
-    );
-  }
-
-  const manual = await security(['find-generic-password', '-s', name, '-w']);
-  if (manual.ok) {
-    const value = stripTrailingNewline(manual.stdout);
-    if (value) return value;
-  }
-  if (manual.timedOut) throw new MigrationRequiredError(name, 'manual');
-  if (!manual.ok && manual.code !== 44) {
-    throw new KeychainError(
-      `reading "${name}" from the manual scheme failed (exit ${manual.code}): ` +
-        `${manual.stderr.trim() || 'unknown error'}`
-    );
-  }
-  return null;
+  // fail closed on unexpected errors (#147/#150 semantics), with a reason (#185 S4)
+  throw new KeychainError(
+    `reading "${name}" failed (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
+  );
 }
 
 /**
- * Check where a key exists without reading its secret value.
- * Fails closed (#150 semantics, same as resolveKey): only exit 44 means
- * "not in this store" — any other failure throws instead of being silently
- * treated as absent, so `akc check`/`akc get` never report a key as usable
- * (or missing) based on a store we could not actually query.
+ * Check whether a key exists without reading its secret value (v2.0: managed only).
+ * Fails closed (#150): only exit 44 means "not found" — any other failure throws.
  */
 export async function keyExists(name) {
-  const probe = async (args) => {
-    const r = await security(args);
-    if (r.ok) return true;
-    if (r.code === 44) return false;
-    throw new KeychainError(
-      `keychain probe failed (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
-    );
-  };
-  const managed = await probe(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name]);
-  const app = await probe(['find-generic-password', '-s', GUI_SERVICE, '-a', name]);
-  const manual = await probe(['find-generic-password', '-s', name]);
-  return { name, managed, app, manual, exists: managed || app || manual };
+  const r = await security(['find-generic-password', '-s', MANAGED_SERVICE, '-a', name]);
+  if (r.ok) return { name, exists: true };
+  if (r.code === 44) return { name, exists: false };
+  throw new KeychainError(
+    `keychain probe failed (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
+  );
 }
 
 /** Redact hex-encoded secret material from text destined for errors/logs. */
@@ -291,45 +225,17 @@ export async function setKey(name, value) {
 }
 
 /**
- * Delete a key from every store it lives in. Returns which stores were deleted.
- *
- * Order matters (#179 review): fallback stores (manual -> legacy GUI) are
- * cleaned up BEFORE the authoritative managed copy. If a fallback delete
- * fails, we throw with the managed copy intact — the key still resolves and
- * the user sees the failure, instead of "deleted" being reported while a
- * stale fallback copy keeps resolving. Exit 44 (not found) is the only benign
- * failure; anything else throws.
+ * Delete a key from the managed namespace (v2.0: managed only).
+ * Returns true if an item was removed, false if it was not found (exit 44 is
+ * benign/idempotent); any other failure throws.
  */
 export async function deleteKey(name) {
-  const deleted = [];
-  const del = async (args) => {
-    const r = await security(args);
-    if (r.ok) return true;
-    if (r.code === 44) return false;
-    throw new KeychainError(
-      `failed to delete "${name}" (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
-    );
-  };
-
-  // Manual scheme: strict env-var-shaped names only — KEY_NAME_PATTERN also
-  // allows dots/lowercase, and deleting service="com.vendor.foo" would remove
-  // an unrelated app's item. `delete-generic-password -s NAME` removes only
-  // the first match, so loop until exit 44 to clear duplicates (#100).
-  if (MANUAL_NAME_PATTERN.test(name)) {
-    let removedAny = false;
-    for (let i = 0; i < 10; i++) {
-      if (!(await del(['delete-generic-password', '-s', name]))) break;
-      removedAny = true;
-    }
-    if (removedAny) deleted.push('manual');
-  }
-  if (await del(['delete-generic-password', '-s', GUI_SERVICE, '-a', name])) {
-    deleted.push('app');
-  }
-  if (await del(['delete-generic-password', '-s', MANAGED_SERVICE, '-a', name])) {
-    deleted.push('managed');
-  }
-  return deleted;
+  const r = await security(['delete-generic-password', '-s', MANAGED_SERVICE, '-a', name]);
+  if (r.ok) return true;
+  if (r.code === 44) return false;
+  throw new KeychainError(
+    `failed to delete "${name}" (exit ${r.code}): ${r.stderr.trim() || 'unknown error'}`
+  );
 }
 
 /** Parse `security dump-keychain` output into { service, account } records. */
@@ -345,120 +251,30 @@ export function parseDump(dump) {
 }
 
 /**
- * List known keys (names only — secret values are never read).
- * Returns [{ name, sources: ['app'|'manual', ...] }] sorted by name.
+ * List known keys (names only — secret values are never read; v2.0: managed only).
+ * Returns [{ name }] sorted by name.
  */
 export async function listKeys() {
   const r = await security(['dump-keychain']);
   if (!r.ok) {
     throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
   }
-  const keys = new Map();
-  const add = (name, source) => {
-    if (!keys.has(name)) keys.set(name, new Set());
-    keys.get(name).add(source);
-  };
+  const names = new Set();
   for (const { service, account } of parseDump(r.stdout)) {
-    if (service === MANAGED_SERVICE && account) {
-      add(account, 'app');
-    } else if (service === GUI_SERVICE && account) {
-      add(account, 'app');
-    } else if (service && service !== GUI_SERVICE && MANUAL_NAME_PATTERN.test(service)) {
-      add(service, 'manual');
-    }
+    if (service === MANAGED_SERVICE && account) names.add(account);
   }
-  return [...keys.entries()]
-    .map(([name, sources]) => ({ name, sources: [...sources].sort() }))
+  return [...names]
+    .map((name) => ({ name }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-/**
- * Detect ambiguous duplicate entries: env-var-shaped service names that have
- * more than one generic-password item with distinct `acct` values. For such a
- * service, `security find-generic-password -s NAME -w` returns an unspecified
- * one of them — the root cause of issue #91 ("registered but invalid token").
- *
- * Secret values are never read; only the `acct` attribute (from dump-keychain)
- * is reported so the user can identify and remove the stale entry.
- *
- * Returns [{ service, accounts: [...] }] sorted by service, accounts sorted.
- */
-export function findAmbiguousDuplicates(records) {
-  const byService = new Map();
-  for (const { service, account } of records) {
-    if (!service || service === GUI_SERVICE || service === MANAGED_SERVICE) continue;
-    if (!MANUAL_NAME_PATTERN.test(service)) continue;
-    if (!byService.has(service)) byService.set(service, new Set());
-    byService.get(service).add(account ?? '');
-  }
-  return [...byService.entries()]
-    .filter(([, accts]) => accts.size > 1)
-    .map(([service, accts]) => ({ service, accounts: [...accts].sort() }))
-    .sort((a, b) => a.service.localeCompare(b.service));
-}
-
-/**
- * Detect keys that exist only in legacy namespaces (GUI store / manual scheme)
- * with no managed copy (#171). These are exactly the keys whose headless reads
- * can prompt/hang; the doctor surfaces them with migration guidance.
- * Non-destructive: derived from dump-keychain attributes — no values are read
- * and no `find -w` probes run (a probe would rain consent dialogs when headed).
- */
-export function findUnmigratedKeys(records) {
-  const managed = new Set(
-    records.filter((r) => r.service === MANAGED_SERVICE && r.account).map((r) => r.account)
-  );
-  // GUI/managed store のレコードで account が解析できなかったものは、未移行判定の
-  // 信頼性を落とす（false negative の芽）。黙って捨てず件数を返して doctor が
-  // 「判定不能あり」と警告できるようにする (#185 S8)。
-  let unparseable = 0;
-  const byName = new Map();
-  for (const { service, account } of records) {
-    if ((service === GUI_SERVICE || service === MANAGED_SERVICE) && !account) {
-      unparseable += 1;
-      continue;
-    }
-    let name = null;
-    let store = null;
-    if (service === GUI_SERVICE && account) {
-      name = account;
-      store = 'gui';
-    } else if (service && service !== MANAGED_SERVICE && MANUAL_NAME_PATTERN.test(service)) {
-      name = service;
-      store = 'manual';
-    }
-    if (!name || managed.has(name)) continue;
-    if (!byName.has(name)) byName.set(name, new Set());
-    byName.get(name).add(store);
-  }
-  const keys = [...byName.entries()]
-    .map(([name, stores]) => ({ name, stores: [...stores].sort() }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-  return { keys, unparseable };
-}
-
-/** One dump-keychain call, parsed. Shared by doctor so a hanging enumeration
- *  costs one bounded subprocess, not three (#185 S7). Names/accts only. */
+/** One dump-keychain call, parsed into { service, account } records (names/accts only). */
 export async function dumpRecords() {
   const r = await security(['dump-keychain']);
   if (!r.ok) {
     throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
   }
   return parseDump(r.stdout);
-}
-
-/** Convenience wrapper around the live keychain dump (names/accts only). */
-export async function listUnmigratedKeys() {
-  return findUnmigratedKeys(await dumpRecords());
-}
-
-/** Convenience wrapper around the live keychain dump (names/accts only). */
-export async function listAmbiguousDuplicates() {
-  const r = await security(['dump-keychain']);
-  if (!r.ok) {
-    throw new KeychainError(`failed to enumerate keychain items: ${r.stderr.trim()}`);
-  }
-  return findAmbiguousDuplicates(parseDump(r.stdout));
 }
 
 // 固定長マスク。桁数（value.length）は出さない: 正確な長さは総当たりコストを

--- a/cli/src/mcp-server.js
+++ b/cli/src/mcp-server.js
@@ -39,8 +39,7 @@ export function buildServer() {
     'list_keys',
     {
       description:
-        'List key names stored in the macOS Keychain (AI KeyChain GUI store + manually-registered ' +
-        'env-var-style keys). Returns names and where they live — never secret values.',
+        'List key names stored in the AI KeyChain managed namespace. Returns names only — never secret values.',
       inputSchema: {},
     },
     async () => json(await listKeys())
@@ -50,8 +49,7 @@ export function buildServer() {
     'check_key',
     {
       description:
-        'Check whether a key exists in the Keychain and in which store (app = AI KeyChain GUI, ' +
-        'manual = service-name entry). Does not read the secret value.',
+        'Check whether a key exists in the AI KeyChain managed namespace. Does not read the secret value.',
       inputSchema: { name: keyNameSchema },
     },
     async ({ name }) => json(await keyExists(name))
@@ -102,7 +100,7 @@ export function buildServer() {
     'delete_secret',
     {
       description:
-        'Delete a key from the Keychain (managed namespace plus legacy AI KeyChain store / manual copies). ' +
+        'Delete a key from the AI KeyChain managed namespace. ' +
         'Destructive — requires confirm=true, and you should confirm with the user first.',
       inputSchema: {
         name: keyNameSchema,
@@ -111,7 +109,7 @@ export function buildServer() {
     },
     async ({ name, confirm }) => {
       if (!confirm) {
-        return json({ deleted: [], note: 'confirm=true is required to delete' });
+        return json({ deleted: false, note: 'confirm=true is required to delete' });
       }
       const removed = await deleteKey(name);
       return json({ deleted: removed, found: removed });

--- a/cli/src/mcp-server.js
+++ b/cli/src/mcp-server.js
@@ -72,7 +72,6 @@ export function buildServer() {
       return json({
         reference: `keychain://${name}`,
         exists: exists.exists,
-        stores: { managed: exists.managed, app: exists.app, manual: exists.manual },
         usage: exportable
           ? `export ${name}=keychain://${name} && akc run -- <command>`
           : `env '${name}=keychain://${name}' akc run -- <command>`,
@@ -114,8 +113,8 @@ export function buildServer() {
       if (!confirm) {
         return json({ deleted: [], note: 'confirm=true is required to delete' });
       }
-      const deleted = await deleteKey(name);
-      return json({ deleted, found: deleted.length > 0 });
+      const removed = await deleteKey(name);
+      return json({ deleted: removed, found: removed });
     }
   );
 

--- a/cli/src/mcp-server.js
+++ b/cli/src/mcp-server.js
@@ -120,8 +120,8 @@ export function buildServer() {
     'doctor',
     {
       description:
-        'Diagnose the local setup: keychain access, keychain:// references in the current ' +
-        'environment, and ~/.zshrc patterns (including the -a "$USER" pitfall). Values are masked.',
+        'Diagnose the local setup: keychain access and keychain:// references in the current ' +
+        'environment and ~/.zshrc. Values are masked.',
       inputSchema: {},
     },
     async () => {

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -15,24 +15,14 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
    - Launch tools through akc:                  akc run -- <command>
    - akc resolves the references from the macOS Keychain and injects the real
      values ONLY into the child process. The parent shell never sees them.
-3. To check/read a key, prefer \`akc get <KEY>\`: it checks both stores and by
-   default prints only the keychain:// reference (never the value). Add
-   --reveal only when you truly need the raw value on stdout; to inject it into
-   a process instead, use \`akc run -- <command>\`. If you must use the raw
-   security CLI directly, use the form that matches where the key lives:
-     [managed] keys (saved by akc or the AI KeyChain GUI, v1.9+):
+3. To check/read a key, prefer \`akc get <KEY>\`: by default it prints only the
+   keychain:// reference (never the value). Add --reveal only when you truly
+   need the raw value on stdout; to inject it into a process instead, use
+   \`akc run -- <command>\`. If you must use the raw security CLI directly:
        /usr/bin/security find-generic-password -s "com.aieo.aikeychain.managed" -a "<KEY>" -w
-     [app] legacy store keys (saved via an older AI KeyChain GUI):
-       /usr/bin/security find-generic-password -s "com.aieo.aikeychain" -a "<KEY>" -w
-     [manual] legacy keys (registered by hand) — service name only, do NOT pin
-     the account with -a "$USER":
-       /usr/bin/security find-generic-password -s "<KEY>" -w
-   ⚠️ The bare -s "<KEY>" form (no -a) returns "could not be found" (exit 44)
-   for [managed]/[app] keys — that is NOT proof the key is unregistered.
-   Confirm with \`akc check <KEY>\` / \`akc get <KEY>\` before concluding a key
-   is missing. (Account attributes on [manual] entries are inconsistent across
-   entries; pinning -a there can return a stale/invalid duplicate — AIkeychain
-   issue #91.)
+   ⚠️ The bare -s "<KEY>" form (no -a) returns "could not be found" (exit 44) —
+   that is NOT proof the key is unregistered. Confirm with \`akc check <KEY>\` /
+   \`akc get <KEY>\`.
 4. To save/update a key, use \`akc set KEY_NAME\`: it writes to the managed
    namespace with -U (no duplicate entries), and the value is read from a
    hidden prompt or stdin and handed to \`security -i\` via stdin as hex — it
@@ -43,27 +33,16 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
 
 ## Headless contract (what akc promises)
 
-- Keys in the **managed namespace** (saved by \`akc set\` or the AI KeyChain app
-  v1.9+) resolve **silently** — no prompts, no hangs, ever.
-- **Legacy keys** (old GUI store / manually registered) may be readable, but a
-  GUI-owned item can block on a keychain consent prompt. akc **never hangs**:
-  the read is killed after a timeout and you get an explicit
-  "migration required" error telling you to re-register the key
-  (\`akc set <KEY>\`) or use the app's migration assistant.
-- The promise is "new/migrated keys succeed silently; legacy keys fail bounded"
-  — NOT "mixed stores always succeed". Run \`akc doctor\` to list unmigrated
-  keys before relying on headless execution.
+Every key lives in the **managed namespace** (\`com.aieo.aikeychain.managed\`,
+created by \`akc set\` or the AI KeyChain app). These resolve **silently** — no
+prompts, no hangs, ever. (v2.0 dropped the old v1.x GUI store / manual scheme;
+if you upgraded from v1.x, re-register your keys with \`akc set <KEY>\`.)
 
 ## Where keys live
 
 | Store | service attribute | account attribute |
 |---|---|---|
-| Managed namespace (v1.9+, all new writes) | com.aieo.aikeychain.managed | <KEY_NAME> |
-| AI KeyChain GUI store (legacy, read-only) | com.aieo.aikeychain | <KEY_NAME> |
-| Manually-registered keys (legacy, read-only) | <KEY_NAME> | (varies — do not rely on it) |
-
-\`akc\` looks up managed first, then the legacy GUI store, then the service-only
-manual lookup — falling through ONLY when a tier reports "not found" (exit 44).
+| Managed namespace (the only store) | com.aieo.aikeychain.managed | <KEY_NAME> |
 
 ## CLI quick reference
 
@@ -73,7 +52,7 @@ manual lookup — falling through ONLY when a tier reports "not found" (exit 44)
   akc check <KEY>             check whether a key exists and where
   akc set <KEY>               store/update a key (value via hidden prompt or stdin)
   akc delete <KEY>            delete a key
-  akc doctor                  diagnose env + ~/.zshrc refs + unmigrated legacy keys
+  akc doctor                  diagnose env + ~/.zshrc keychain references
   akc mcp                     start the MCP server (stdio)
 
 ## MCP setup (Claude Code)

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -16,11 +16,11 @@ const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js')
 
 let stubDir;
 
-// The stub knows one GUI-store key (GOOD_KEY) and one manual key (MANUAL_KEY).
-// Interactive (-i) add-generic-password is accepted only with -X hex via stdin
-// (never argv): NEW_KEY round-trips through a state file so read-back
-// verification sees the value actually written; ECHO_KEY simulates a failure
-// whose stderr leaks the full command line including the hex value.
+// v2.0 (#188): the managed namespace is the ONLY store. The stub knows one
+// managed key (GOOD_KEY). Interactive (-i) add-generic-password is accepted only
+// with -X hex via stdin (never argv): NEW_KEY round-trips through a state file so
+// read-back verification sees the value actually written; ECHO_KEY simulates a
+// failure whose stderr leaks the full command line including the hex value.
 const STUB = `#!/bin/bash
 state_dir="$(cd "$(dirname "$0")" && pwd)"
 cmd="$1"; shift
@@ -54,14 +54,12 @@ while [ $# -gt 0 ]; do
 done
 case "$cmd" in
   find-generic-password)
-    if [ "$svc" = "com.aieo.aikeychain" ] && [ "$acct" = "GOOD_KEY" ]; then
+    # v2.0: only the managed service resolves; every other service exits 44.
+    if [ "$svc" = "com.aieo.aikeychain.managed" ] && [ "$acct" = "GOOD_KEY" ]; then
       $want_value && echo "stub-good-value"; exit 0
     fi
     if [ "$svc" = "com.aieo.aikeychain.managed" ] && [ "$acct" = "NEW_KEY" ] && [ -f "$state_dir/state-NEW_KEY" ]; then
       $want_value && { cat "$state_dir/state-NEW_KEY"; echo; }; exit 0
-    fi
-    if [ "$svc" = "MANUAL_KEY" ]; then
-      $want_value && echo "stub-manual-value"; exit 0
     fi
     exit 44 ;;
   add-generic-password)
@@ -144,13 +142,13 @@ test('a `security` stub on PATH is ignored when the override is unset (issue #11
   assert.equal(stubWasInvoked, false, 'PATH `security` stub was executed — absolute path not enforced');
 });
 
-test('run resolves GUI-store and manual refs into the child env only', async () => {
+test('run resolves managed refs into the child env only', async () => {
   const r = await runAkc(
-    ['run', '--', process.execPath, '-e', 'console.log(process.env.MY_TOKEN, process.env.OTHER)'],
-    { MY_TOKEN: 'keychain://GOOD_KEY', OTHER: 'keychain://MANUAL_KEY' }
+    ['run', '--', process.execPath, '-e', 'console.log(process.env.MY_TOKEN)'],
+    { MY_TOKEN: 'keychain://GOOD_KEY' }
   );
   assert.equal(r.code, 0);
-  assert.match(r.stdout, /stub-good-value stub-manual-value/);
+  assert.match(r.stdout, /stub-good-value/);
 });
 
 test('run fails with exit 1 when a ref cannot be resolved', async () => {
@@ -187,33 +185,23 @@ test('run maps a signal-terminated child to 128+signum', async () => {
   assert.equal(r.code, 143); // 128 + SIGTERM(15)
 });
 
-test('check reports store and missing keys', async () => {
+test('check reports the managed store and missing keys', async () => {
   const good = await runAkc(['check', 'GOOD_KEY']);
   assert.equal(good.code, 0);
-  assert.match(good.stdout, /AI KeyChain store/);
+  assert.match(good.stdout, /managed store/);
 
   const missing = await runAkc(['check', 'NOPE_KEY']);
   assert.equal(missing.code, 1);
 });
 
-test('check on a store-only key hints the correct `security` form (issue #137)', async () => {
-  // GOOD_KEY exists only under service="com.aieo.aikeychain" account="GOOD_KEY"
-  // (the stub reports it found ONLY for that query, not for the bare -s
-  // GOOD_KEY form). That mismatch is exactly the #137 false-negative: an agent
-  // running `security find-generic-password -s "GOOD_KEY" -w` gets exit 44 and
-  // wrongly concludes the key is unregistered. `akc check` must append a hint
-  // so the correct two-attribute form (or `akc get`) is discoverable.
+test('check hints the correct managed `security` form (issue #137)', async () => {
+  // The bare `security find-generic-password -s "GOOD_KEY" -w` form returns exit
+  // 44 for a managed item — a #137 false-negative. `akc check` appends a hint so
+  // the correct two-attribute managed form (or `akc get`) is discoverable.
   const good = await runAkc(['check', 'GOOD_KEY']);
   assert.equal(good.code, 0);
-  assert.match(good.stdout, /-s "com\.aieo\.aikeychain" -a "GOOD_KEY" -w/);
+  assert.match(good.stdout, /-s "com\.aieo\.aikeychain\.managed" -a "GOOD_KEY" -w/);
   assert.match(good.stdout, /akc get GOOD_KEY/);
-
-  // A manual-only key must NOT get the hint — the bare `-s <KEY>` form already
-  // works for it, so the extra line would be noise.
-  const manual = await runAkc(['check', 'MANUAL_KEY']);
-  assert.equal(manual.code, 0);
-  assert.match(manual.stdout, /manual entry/);
-  assert.doesNotMatch(manual.stdout, /security CLI: use/);
 });
 
 test('get prints a reference by default, raw value only with --reveal', async () => {

--- a/cli/test/delete-keychain.test.js
+++ b/cli/test/delete-keychain.test.js
@@ -1,8 +1,7 @@
-// deleteKey semantics (#179 second-stage review B3/B4):
-//   - fallback stores (manual -> legacy GUI) are cleaned BEFORE the managed copy
-//   - manual duplicates are deleted until exit 44 (first-match-only otherwise, #100)
-//   - a non-44 failure aborts with the managed copy intact (no resurrection)
-//   - non-env-var-shaped names never touch the manual tier (other apps' items)
+// deleteKey semantics (v2.0 #188): managed namespace only.
+//   - returns true when an item was removed
+//   - returns false on exit 44 (not found / idempotent)
+//   - throws on any other failure
 import { after, before, beforeEach, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdtemp, readFile, rm, writeFile, access } from 'node:fs/promises';
@@ -13,8 +12,6 @@ let deleteKey;
 let stubDir;
 let callsPath;
 
-// State model: file "managed-<acct>" / "gui-<acct>" exists -> one deletable
-// item; file "manual-<svc>" holds a duplicate counter (issue #100 scenario).
 const STUB = `#!/bin/bash
 dir="$(cd "$(dirname "$0")" && pwd)"
 cmd="$1"; shift
@@ -26,25 +23,12 @@ while [ $# -gt 0 ]; do case "$1" in
 esac; done
 [ "$cmd" = "delete-generic-password" ] || exit 1
 printf '%s|%s\\n' "$svc" "$acct" >> "$dir/calls"
-case "$svc" in
-  com.aieo.aikeychain)
-    case "$acct" in
-      LEGACY_FAIL_KEY) echo "denied" >&2; exit 51 ;;
-    esac
-    if [ -f "$dir/gui-$acct" ]; then rm "$dir/gui-$acct"; exit 0; fi
-    exit 44 ;;
-  com.aieo.aikeychain.managed)
-    if [ -f "$dir/managed-$acct" ]; then rm "$dir/managed-$acct"; exit 0; fi
-    exit 44 ;;
-  *)
-    f="$dir/manual-$svc"
-    if [ -f "$f" ]; then
-      n=$(cat "$f")
-      if [ "$n" -gt 1 ]; then echo $((n-1)) > "$f"; else rm "$f"; fi
-      exit 0
-    fi
-    exit 44 ;;
+[ "$svc" = "com.aieo.aikeychain.managed" ] || exit 1
+case "$acct" in
+  FAIL_KEY) echo "denied" >&2; exit 51 ;;
 esac
+if [ -f "$dir/managed-$acct" ]; then rm "$dir/managed-$acct"; exit 0; fi
+exit 44
 `;
 
 before(async () => {
@@ -68,52 +52,24 @@ after(async () => {
 
 const exists = (name) => access(join(stubDir, name)).then(() => true, () => false);
 
-test('deleteKey removes manual duplicates until 44, then legacy, then managed', async () => {
-  await writeFile(join(stubDir, 'manual-DUP_KEY'), '3');
-  await writeFile(join(stubDir, 'gui-DUP_KEY'), '');
-  await writeFile(join(stubDir, 'managed-DUP_KEY'), '');
+test('deleteKey removes the managed item and returns true', async () => {
+  await writeFile(join(stubDir, 'managed-MY_KEY'), '');
+  assert.equal(await deleteKey('MY_KEY'), true);
+  assert.equal(await exists('managed-MY_KEY'), false);
+  assert.equal((await readFile(callsPath, 'utf8')).trim(), 'com.aieo.aikeychain.managed|MY_KEY');
+});
 
-  const deleted = await deleteKey('DUP_KEY');
-  assert.deepEqual(deleted, ['manual', 'app', 'managed']);
-  assert.equal(await exists('manual-DUP_KEY'), false);
-  assert.equal(await exists('gui-DUP_KEY'), false);
-  assert.equal(await exists('managed-DUP_KEY'), false);
+test('deleteKey returns false when the key is not found (idempotent, exit 44)', async () => {
+  assert.equal(await deleteKey('NOT_THERE_KEY'), false);
+});
 
+test('deleteKey throws on a non-44 failure', async () => {
+  await assert.rejects(() => deleteKey('FAIL_KEY'), /failed to delete/);
+});
+
+test('deleteKey only ever touches the managed namespace', async () => {
+  await writeFile(join(stubDir, 'managed-K'), '');
+  await deleteKey('K');
   const calls = (await readFile(callsPath, 'utf8')).trim().split('\n');
-  // manual x3 (削除) + manual x1 (44 で終端) → legacy GUI → managed の順
-  assert.deepEqual(calls, [
-    'DUP_KEY|', 'DUP_KEY|', 'DUP_KEY|', 'DUP_KEY|',
-    'com.aieo.aikeychain|DUP_KEY',
-    'com.aieo.aikeychain.managed|DUP_KEY',
-  ]);
-});
-
-test('deleteKey aborts on a legacy failure and leaves the managed copy intact', async () => {
-  await writeFile(join(stubDir, 'managed-LEGACY_FAIL_KEY'), '');
-
-  await assert.rejects(() => deleteKey('LEGACY_FAIL_KEY'), /failed to delete/);
-  // 権威コピーは無傷（「削除成功」報告後に fallback から復活、を構造的に防ぐ）
-  assert.equal(await exists('managed-LEGACY_FAIL_KEY'), true);
-  const calls = await readFile(callsPath, 'utf8');
-  assert.doesNotMatch(calls, /com\.aieo\.aikeychain\.managed/);
-});
-
-test('deleteKey never touches the manual tier for non-env-var-shaped names', async () => {
-  // KEY_NAME_PATTERN はドット/小文字を許すが、service="com.vendor.foo" の削除は
-  // 無関係アプリのアイテム破壊になる — manual 掃除は厳格名のみ (#179 B4)
-  await writeFile(join(stubDir, 'manual-com.vendor.foo'), '1');
-
-  const deleted = await deleteKey('com.vendor.foo');
-  assert.deepEqual(deleted, []);
-  assert.equal(await exists('manual-com.vendor.foo'), true);
-  const calls = (await readFile(callsPath, 'utf8')).trim().split('\n');
-  assert.deepEqual(calls, [
-    'com.aieo.aikeychain|com.vendor.foo',
-    'com.aieo.aikeychain.managed|com.vendor.foo',
-  ]);
-});
-
-test('deleteKey is idempotent when nothing exists anywhere', async () => {
-  const deleted = await deleteKey('NOT_THERE_KEY');
-  assert.deepEqual(deleted, []);
+  assert.deepEqual(calls, ['com.aieo.aikeychain.managed|K']);
 });

--- a/cli/test/init.test.js
+++ b/cli/test/init.test.js
@@ -34,22 +34,18 @@ test('AGENT_INSTRUCTIONS teaches the core rules', () => {
   assert.match(AGENT_INSTRUCTIONS, /usage_guide/);
 });
 
-test('AGENT_INSTRUCTIONS recommends `akc get` and presents both security lookup forms (#137)', () => {
-  // Root cause of #137: the old guidance taught a single `-s ENV_VAR_NAME -w`
-  // form. That form only works for [manual] keys; for AI KeyChain GUI ("app"
-  // store) keys it returns exit 44, so agents falsely concluded the key was
-  // unregistered. `akc get` handles both stores and must be the primary
-  // recommendation; if raw `security` is shown, both forms must be present
-  // and labeled, with a warning that exit 44 on the bare -s form is not proof
-  // of "unregistered".
+test('AGENT_INSTRUCTIONS recommends `akc get` and the managed security form (v2.0 #188)', () => {
+  // v2.0: a single managed namespace. `akc get` is the primary method; the raw
+  // security form uses the managed service, and exit 44 on the bare -s form is
+  // not proof of "unregistered" (#137). Legacy GUI/manual forms must be gone.
   assert.match(AGENT_INSTRUCTIONS, /akc get <KEY>/);
-  assert.match(AGENT_INSTRUCTIONS, /-s "com\.aieo\.aikeychain" -a "<KEY>" -w/); // [app] store form
-  assert.match(AGENT_INSTRUCTIONS, /-s "<KEY>" -w/); // [manual] form
+  assert.match(AGENT_INSTRUCTIONS, /-s "com\.aieo\.aikeychain\.managed" -a "<KEY>" -w/);
   assert.match(AGENT_INSTRUCTIONS, /exit 44/);
   assert.match(AGENT_INSTRUCTIONS, /akc check <KEY>/);
-  assert.match(AGENT_INSTRUCTIONS, /do NOT pin[\s\S]*-a "\$USER"/);
-  // The bare single-service form must no longer be presented as the sole method.
-  assert.doesNotMatch(AGENT_INSTRUCTIONS, /-s "ENV_VAR_NAME" -w/);
+  // legacy forms must NOT be taught anymore
+  assert.doesNotMatch(AGENT_INSTRUCTIONS, /-s "com\.aieo\.aikeychain" -a/); // 旧 GUI store
+  assert.doesNotMatch(AGENT_INSTRUCTIONS, /-s "<KEY>" -w/); // 旧 manual scheme
+  assert.doesNotMatch(AGENT_INSTRUCTIONS, /both stores/);
 });
 
 test('upsertManagedBlock creates a block in empty content', () => {
@@ -266,14 +262,11 @@ test('akc init --print previews machine-wide setup without writing, using absolu
   assert.match(claudeLine, /\bmcp$/);
   assert.ok(r.stdout.includes(`command = "${REAL_LAUNCH.nodeBin}"`));
   assert.ok(r.stdout.includes(`args = ["${REAL_LAUNCH.akcJs}", "mcp"]`));
-  // End-to-end: the rendered template shows BOTH security lookup forms
-  // (store + manual) and recommends `akc get`, so the #137 correction is
-  // guaranteed at the CLI-output level, not just in the AGENT_INSTRUCTIONS
-  // constant.
-  assert.match(r.stdout, /-s "com\.aieo\.aikeychain" -a "<KEY>" -w/); // [app] store form
-  assert.match(r.stdout, /-s "<KEY>" -w/); // [manual] form
+  // End-to-end: the rendered template shows the managed security form and
+  // recommends `akc get`, guaranteed at the CLI-output level (v2.0 #188).
+  assert.match(r.stdout, /-s "com\.aieo\.aikeychain\.managed" -a "<KEY>" -w/);
   assert.match(r.stdout, /akc get <KEY>/);
-  assert.doesNotMatch(r.stdout, /-s "ENV_VAR_NAME" -w/); // old sole-method form is gone
+  assert.doesNotMatch(r.stdout, /-s "com\.aieo\.aikeychain" -a/); // 旧 GUI store は消えた
 });
 
 test('akc init (default machine-wide) writes ~/.claude + ~/.codex under HOME, idempotently', async () => {

--- a/cli/test/resolve-keychain-bash.test.js
+++ b/cli/test/resolve-keychain-bash.test.js
@@ -12,6 +12,8 @@ let securityPath;
 let envPath;
 let callsPath;
 
+// v2.0 (#188): scripts/akc resolves ONLY the managed namespace. The stub logs a
+// "managed" line for the managed service and exits 44 for anything else.
 const SECURITY_STUB = `#!/bin/bash
 svc=""; acct=""
 shift
@@ -30,38 +32,11 @@ if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
     managed_value) printf '%s\\n' managed-value; exit 0 ;;
     managed_51) exit 51 ;;
     managed_empty) exit 0 ;;
-    gui_hang) exit 44 ;;
     managed_hang) sleep 60 ;;
   esac
   exit 44
 fi
-
-if [ "$svc" = "com.aieo.aikeychain" ] && [ "$SCENARIO" = "gui_hang" ]; then
-  printf '%s\\n' gui >> "$CALLS_PATH"
-  sleep 60   # SecurityAgent プロンプト待ちを模す (#171)
-  exit 0
-fi
-
-if [ "$svc" = "com.aieo.aikeychain" ]; then
-  printf '%s\\n' gui >> "$CALLS_PATH"
-  case "$SCENARIO" in
-    managed_51) printf '%s\\n' stale-gui-value; exit 0 ;;
-    gui_51) exit 51 ;;
-    gui_empty) exit 0 ;;
-    gui_44_manual) exit 44 ;;
-    gui_44_manual_empty) exit 44 ;;
-    manual_output_error) exit 44 ;;
-    gui_value) printf '%s\\n' gui-value; exit 0 ;;
-  esac
-fi
-
-printf '%s\\n' manual >> "$CALLS_PATH"
-case "$SCENARIO" in
-  gui_44_manual) printf '%s\\n' manual-value; exit 0 ;;
-  gui_44_manual_empty) exit 0 ;;
-  manual_output_error) printf '%s\\n' rejected-value; exit 52 ;;
-  *) printf '%s\\n' manual-must-not-be-used; exit 0 ;;
-esac
+exit 44
 `;
 
 const ENV_STUB = `#!/bin/bash
@@ -70,8 +45,8 @@ printf '%s\\n' 'TEST_REF=keychain://TEST_KEY'
 
 before(async () => {
   const script = await readFile(new URL('../../scripts/akc', import.meta.url), 'utf8');
-  // security_bounded (#171) が resolve_keychain の依存になったため、有界実行の
-  // 定義（タイムアウト変数から）ごと切り出す。
+  // security_bounded (#171) が resolve_keychain の依存なので、有界実行の定義
+  // （タイムアウト変数から）ごと切り出す。
   const start = script.indexOf('AKC_SECURITY_TIMEOUT_SECS=');
   const end = script.indexOf('\n}\n\nmask_value()', start);
   assert.notEqual(start, -1, 'security_bounded prelude must exist');
@@ -121,90 +96,50 @@ async function assertScenario(scenario, expected) {
   assert.equal(await readFile(callsPath, 'utf8'), expected.calls);
 }
 
-test('scripts/akc resolve_keychain fails closed on GUI exit 51', async () => {
-  await assertScenario('gui_51', {
-    result: { status: 51, stdout: '', stderr: '' },
-    calls: 'managed\ngui\n',
-  });
-});
-
-test('scripts/akc resolve_keychain fails closed on successful empty GUI value', async () => {
-  await assertScenario('gui_empty', {
-    result: { status: 1, stdout: '', stderr: '' },
-    calls: 'managed\ngui\n',
-  });
-});
-
-test('scripts/akc resolve_keychain falls back to manual only on GUI exit 44', async () => {
-  await assertScenario('gui_44_manual', {
-    result: { status: 0, stdout: 'manual-value', stderr: '' },
-    calls: 'managed\ngui\nmanual\n',
-  });
-});
-
-test('scripts/akc resolve_keychain returns nonzero on GUI exit 44 and successful empty manual value', async () => {
-  await assertScenario('gui_44_manual_empty', {
-    result: { status: 1, stdout: '', stderr: '' },
-    calls: 'managed\ngui\nmanual\n',
-  });
-});
-
-test('scripts/akc resolve_keychain returns a nonempty GUI value without manual fallback', async () => {
-  await assertScenario('gui_value', {
-    result: { status: 0, stdout: 'gui-value', stderr: '' },
-    calls: 'managed\ngui\n',
-  });
-});
-
-test('scripts/akc resolve_keychain returns a managed value without legacy fallback (#167)', async () => {
+test('scripts/akc resolve_keychain returns the managed value (single tier, #188)', async () => {
   await assertScenario('managed_value', {
     result: { status: 0, stdout: 'managed-value', stderr: '' },
     calls: 'managed\n',
   });
 });
 
-test('scripts/akc resolve_keychain fails closed on managed exit 51 (#179 review B1)', async () => {
-  // GUI 段は stale な値を返せる状態だが、managed の権威的失敗で止まること
+test('scripts/akc resolve_keychain fails closed on managed exit 51', async () => {
   await assertScenario('managed_51', {
     result: { status: 51, stdout: '', stderr: '' },
     calls: 'managed\n',
   });
 });
 
-test('scripts/akc resolve_keychain fails closed on successful empty managed value', async () => {
+test('scripts/akc resolve_keychain returns nonzero on a successful empty value', async () => {
   await assertScenario('managed_empty', {
     result: { status: 1, stdout: '', stderr: '' },
     calls: 'managed\n',
   });
 });
 
-test('scripts/akc resolve_keychain kills a prompt-blocked legacy read and returns 124 (#171)', async () => {
+test('scripts/akc resolve_keychain returns 44 when not found', async () => {
+  await assertScenario('none', {
+    result: { status: 44, stdout: '', stderr: '' },
+    calls: 'managed\n',
+  });
+});
+
+test('scripts/akc resolve_keychain maps a managed timeout to 125 (locked keychain, #188)', async () => {
   await writeFile(callsPath, '');
-  // シークレットを一時ファイル経由で運ばないことの検証 (#185 B1): 専用 TMPDIR を
-  // 与え、実行後に何も残っていない（そもそも作られない）ことを確認する
+  // シークレットを一時ファイル経由で運ばないことも検証 (#185 B1): 専用 TMPDIR に
+  // 何も作られないこと。
   const isolatedTmp = await mkdtemp(join(tmpdir(), 'akc-b1-check-'));
   const t0 = Date.now();
-  const result = runResolver('gui_hang', { AKC_SECURITY_TIMEOUT_SECS: '1', TMPDIR: isolatedTmp });
+  const result = runResolver('managed_hang', { AKC_SECURITY_TIMEOUT_SECS: '1', TMPDIR: isolatedTmp });
   const elapsed = Date.now() - t0;
-  assert.equal(result.status, 124); // 有界失敗（ハングもプロンプトもしない）
+  assert.equal(result.status, 125); // 有界失敗（ハングもプロンプトもしない）
   assert.equal(result.stdout, ''); // 値は漏れない
   assert.ok(elapsed >= 900, `should actually wait for the 1s timeout (took ${elapsed}ms)`);
   assert.ok(elapsed < 10_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
-  assert.equal(await readFile(callsPath, 'utf8'), 'managed\ngui\n');
+  assert.equal(await readFile(callsPath, 'utf8'), 'managed\n');
   const leftover = await readdir(isolatedTmp);
   assert.deepEqual(leftover, [], 'no temp files may be created on the secret path (#185 B1)');
   await rm(isolatedTmp, { recursive: true, force: true });
-});
-
-test('scripts/akc resolve_keychain maps a managed-tier timeout to 125 (locked keychain, #185 S1)', async () => {
-  await writeFile(callsPath, '');
-  const t0 = Date.now();
-  const result = runResolver('managed_hang', { AKC_SECURITY_TIMEOUT_SECS: '1' });
-  const elapsed = Date.now() - t0;
-  assert.equal(result.status, 125); // managed timeout は移行案内ではなくロック扱い
-  assert.equal(result.stdout, '');
-  assert.ok(elapsed >= 900 && elapsed < 10_000, `bounded (took ${elapsed}ms)`);
-  assert.equal(await readFile(callsPath, 'utf8'), 'managed\n'); // fail-closed: レガシー段へ落ちない
 });
 
 test('scripts/akc neutralizes a hostile AKC_SECURITY_TIMEOUT_SECS (#185 B2: arithmetic injection)', async () => {
@@ -213,7 +148,6 @@ test('scripts/akc neutralizes a hostile AKC_SECURITY_TIMEOUT_SECS (#185 B2: arit
   // $(( )) は配列添字のコマンド置換まで評価する — 検証が無いと任意コマンド実行
   const payload = `PATH[$(touch ${canary})]`;
   const result = runResolver('managed_value', { AKC_SECURITY_TIMEOUT_SECS: payload });
-  // 注入は無害化され（既定 10s に fallback）、正常解決する
   assert.equal(result.status, 0);
   assert.equal(result.stdout, 'managed-value');
   let executed = true;
@@ -230,14 +164,12 @@ test('scripts/akc cmd_run rejects nonempty resolver output when its exit status 
   await writeFile(callsPath, '');
   const result = spawnSync(
     '/bin/bash',
-    [cmdHarnessPath, securityPath, callsPath, 'manual_output_error', envPath],
+    [cmdHarnessPath, securityPath, callsPath, 'managed_51', envPath],
     { encoding: 'utf8' }
   );
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Resolved: 0, Failed: 1/);
-  assert.doesNotMatch(result.stdout, /rejected-value/);
-  assert.doesNotMatch(result.stderr, /rejected-value/);
   // 非 44 の失敗は「not found」ではなく exit code 付きで報告する (#185 S4)
-  assert.match(result.stderr, /TEST_REF .* keychain lookup failed \(exit 52\)/);
-  assert.equal(await readFile(callsPath, 'utf8'), 'managed\ngui\nmanual\n');
+  assert.match(result.stderr, /TEST_REF .* keychain lookup failed \(exit 51\)/);
+  assert.equal(await readFile(callsPath, 'utf8'), 'managed\n');
 });

--- a/cli/test/resolve-keychain.test.js
+++ b/cli/test/resolve-keychain.test.js
@@ -7,10 +7,11 @@ import { join } from 'node:path';
 let resolveKey;
 let keyExists;
 let resolveRefs;
-let MigrationRequiredError;
 let stubDir;
 let callsPath;
 
+// v2.0 (#188): the managed namespace is the ONLY store. The stub answers only
+// for service="com.aieo.aikeychain.managed"; every other service exits 44.
 const STUB = `#!/bin/bash
 stub_dir="$(cd "$(dirname "$0")" && pwd)"
 svc=""; acct=""
@@ -30,33 +31,9 @@ if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
     MANAGED_KEY) printf '%s\\n' "managed-value"; exit 0 ;;
     MANAGED_EMPTY_KEY) exit 0 ;;
     MGERR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
-    MGHANG_KEY) sleep 60 ;;
+    MGHANG_KEY|HANG?_KEY) sleep 60 ;;
   esac
 fi
-
-if [ "$svc" = "com.aieo.aikeychain" ]; then
-  case "$acct" in
-    MGERR_KEY) printf '%s\\n' "stale-gui-value"; exit 0 ;;
-    GUIHANG_KEY|HANG?_KEY) sleep 60 ;;   # SecurityAgent プロンプト待ちを模す (#171)
-  esac
-fi
-
-if [ "$svc" = "com.aieo.aikeychain" ]; then
-  case "$acct" in
-    ERROR_KEY) echo "interaction not allowed" >&2; exit 51 ;;
-    EMPTY_KEY) exit 0 ;;
-    MISSING_KEY) exit 44 ;;
-    MANUAL_EMPTY_KEY) exit 44 ;;
-    GUI_KEY) printf '%s\\n' "gui-value"; exit 0 ;;
-  esac
-fi
-
-case "$svc" in
-  ERROR_KEY) printf '%s\\n' "attacker-manual-value"; exit 0 ;;
-  EMPTY_KEY) printf '%s\\n' "manual-must-not-be-used"; exit 0 ;;
-  MISSING_KEY) printf '%s\\n' "manual-value"; exit 0 ;;
-  MANUAL_EMPTY_KEY) exit 0 ;;
-esac
 exit 44
 `;
 
@@ -67,11 +44,10 @@ before(async () => {
   await writeFile(stubPath, STUB);
   await chmod(stubPath, 0o755);
   process.env.AIKEYCHAIN_SECURITY_BIN = stubPath;
-  // ハング経路のテストを 60s 待たずに検証する（テスト専用オーバーライド / #171）。
-  // 2000ms: 非ハングの stub 応答が並列テスト負荷でこの値を超えて fail-closed
-  // 検証が timeout 分類に化けるフレークを避ける余裕を取る（#185 再検証の指摘）。
+  // 2000ms: 非ハング応答が並列テスト負荷でこの値を超えて timeout に誤分類される
+  // フレークを避ける余裕（#185 再検証）。ハングテストは 60s stub を早く畳む。
   process.env.AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS = '2000';
-  ({ resolveKey, keyExists, MigrationRequiredError } = await import('../src/keychain.js'));
+  ({ resolveKey, keyExists } = await import('../src/keychain.js'));
   ({ resolveRefs } = await import('../src/run.js'));
 });
 
@@ -85,97 +61,45 @@ after(async () => {
   await rm(stubDir, { recursive: true, force: true });
 });
 
-test('resolveKey fails closed on a non-44 GUI lookup error, with a reason (#147/#185 S4)', async () => {
-  // manual 段には攻撃者値が待ち構えているが、GUI 段の権威的失敗 (exit 51) で
-  // チェーンは止まる。null で「無い」と偽るのではなく理由を説明して throw する。
-  await assert.rejects(() => resolveKey('ERROR_KEY'), /legacy GUI store failed \(exit 51\)/);
-  const calls = await readFile(callsPath, 'utf8');
-  assert.equal(calls, 'com.aieo.aikeychain.managed|ERROR_KEY\ncom.aieo.aikeychain|ERROR_KEY\n');
-});
-
-test('resolveKey falls back to manual storage when GUI lookup exits 44', async () => {
-  assert.equal(await resolveKey('MISSING_KEY'), 'manual-value');
-});
-
-test('resolveKey returns null when GUI lookup exits 44 and manual value is empty', async () => {
-  assert.equal(await resolveKey('MANUAL_EMPTY_KEY'), null);
-});
-
-test('resolveKey treats an empty successful GUI value as authoritative failure', async () => {
-  assert.equal(await resolveKey('EMPTY_KEY'), null);
-  const calls = await readFile(callsPath, 'utf8');
-  assert.equal(calls, 'com.aieo.aikeychain.managed|EMPTY_KEY\ncom.aieo.aikeychain|EMPTY_KEY\n');
-});
-
-test('resolveKey returns the GUI storage value without manual fallback', async () => {
-  assert.equal(await resolveKey('GUI_KEY'), 'gui-value');
-});
-
-test('resolveKey returns the managed value without touching legacy tiers (#167)', async () => {
+test('resolveKey returns the managed value (single-tier lookup, #188)', async () => {
   assert.equal(await resolveKey('MANAGED_KEY'), 'managed-value');
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|MANAGED_KEY\n');
 });
 
-test('resolveKey fails closed on a non-44 managed lookup error (#179 review)', async () => {
-  // GUI 段には stale な値が存在するが、managed 段の権威的失敗 (exit 51) で
-  // チェーンは止まらなければならない（#150 の GUI 応答=権威と同じ原則）。
-  await assert.rejects(() => resolveKey('MGERR_KEY'), /managed namespace failed \(exit 51\)/);
+test('resolveKey returns null when the key is not found (exit 44)', async () => {
+  assert.equal(await resolveKey('NOPE_KEY'), null);
+  const calls = await readFile(callsPath, 'utf8');
+  assert.equal(calls, 'com.aieo.aikeychain.managed|NOPE_KEY\n');
+});
+
+test('resolveKey treats an empty successful value as authoritative failure', async () => {
+  assert.equal(await resolveKey('MANAGED_EMPTY_KEY'), null);
+});
+
+test('resolveKey fails closed on a non-44 lookup error, with a reason (#147/#185 S4)', async () => {
+  await assert.rejects(() => resolveKey('MGERR_KEY'), /reading "MGERR_KEY" failed \(exit 51\)/);
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|MGERR_KEY\n');
 });
 
-test('resolveKey treats an empty successful managed value as authoritative failure', async () => {
-  assert.equal(await resolveKey('MANAGED_EMPTY_KEY'), null);
-  const calls = await readFile(callsPath, 'utf8');
-  assert.equal(calls, 'com.aieo.aikeychain.managed|MANAGED_EMPTY_KEY\n');
-});
-
-test('keyExists reports the managed store', async () => {
+test('keyExists reports existence for a managed key', async () => {
   const r = await keyExists('MANAGED_KEY');
-  assert.equal(r.managed, true);
-  assert.equal(r.app, false);
-  assert.equal(r.manual, false);
   assert.equal(r.exists, true);
+  assert.equal((await keyExists('NOPE_KEY')).exists, false);
 });
 
 test('keyExists fails closed (throws) on a non-44 probe error (#179 review S1)', async () => {
   await assert.rejects(() => keyExists('MGERR_KEY'), /keychain probe failed/);
 });
 
-test('a prompt-blocked legacy read is killed and raises MigrationRequiredError (#171)', async () => {
+test('a prompt-blocked read is killed and raises a locked-keychain error (#188)', async () => {
   const t0 = Date.now();
-  await assert.rejects(
-    () => resolveKey('GUIHANG_KEY'),
-    (err) => {
-      assert.ok(err instanceof MigrationRequiredError);
-      assert.match(err.message, /migrat/i);
-      assert.match(err.message, /akc set GUIHANG_KEY/);
-      return true;
-    }
-  );
-  // 有界: 60s の stub ハングに対し timeout(500ms) + kill で返る。
-  // 下限も検証 — 即時失敗するようなら timeout ではなく別の壊れ方をしている
+  await assert.rejects(() => resolveKey('MGHANG_KEY'), /locked|unavailable/);
   const elapsed = Date.now() - t0;
-  assert.ok(elapsed >= 400, `should actually wait for the timeout (took ${elapsed}ms)`);
+  // 有界: 60s の stub ハングに対し timeout(2000ms) + kill で返る。下限も検証。
+  assert.ok(elapsed >= 1500, `should actually wait for the timeout (took ${elapsed}ms)`);
   assert.ok(elapsed < 10_000, `bounded well under the 60s hang (took ${elapsed}ms)`);
-  const calls = await readFile(callsPath, 'utf8');
-  assert.equal(calls, 'com.aieo.aikeychain.managed|GUIHANG_KEY\ncom.aieo.aikeychain|GUIHANG_KEY\n');
-});
-
-test('a managed-tier timeout raises a locked-keychain error, not migration guidance (#171)', async () => {
-  const t0 = Date.now();
-  await assert.rejects(
-    () => resolveKey('MGHANG_KEY'),
-    (err) => {
-      assert.ok(!(err instanceof MigrationRequiredError)); // managed は所有問題ではない
-      assert.match(err.message, /locked|unavailable/);
-      return true;
-    }
-  );
-  const elapsed = Date.now() - t0;
-  assert.ok(elapsed >= 400 && elapsed < 10_000, `bounded (took ${elapsed}ms)`);
-  // fail-closed: レガシー段へは落ちない
   const calls = await readFile(callsPath, 'utf8');
   assert.equal(calls, 'com.aieo.aikeychain.managed|MGHANG_KEY\n');
 });
@@ -194,17 +118,13 @@ test('resolveRefs caches duplicate keys and enforces a command-level deadline (#
   const elapsed = Date.now() - t0;
   assert.equal(Object.keys(resolved).length, 0);
   assert.equal(failed.length, 6);
-  // deadline = timeout(2000ms) x 3 = 6s が効き、5 キーを無制限に直列待ちしない。
-  // 最初のキー(managed+gui の 2 段ハング ~4s)後に deadline 超過し残りは skip。
-  // 上限は並列テスト負荷のマージン込み。本質の検証は下の skip 理由の存在
-  assert.ok(elapsed < 14_000, `command-level deadline bounds the scan (took ${elapsed}ms)`);
-  // 後半のキーは deadline 超過でスキップされ、その旨の理由を持つ
+  // deadline = timeout(2000ms) x 3 = 6s。5 個別キー x 2s = 10s を大きく下回る。
+  assert.ok(elapsed < 12_000, `command-level deadline bounds the scan (took ${elapsed}ms)`);
   assert.ok(failed.some((f) => /deadline exceeded/.test(f.reason ?? '')));
-  // 重複キーは 1 回しか解決を試みない（キャッシュ）
+  // 重複キーは 1 回しか解決を試みない（キャッシュ）: managed 1 段 x 1 回のみ
   const calls = await readFile(callsPath, 'utf8');
   const hang1Calls = calls.split('\n').filter((l) => l.endsWith('|HANG1_KEY')).length;
-  assert.equal(hang1Calls, 2); // managed + GUI の 2 段 x 1 回のみ
-  // どちらの失敗も同じ理由を共有する
+  assert.equal(hang1Calls, 1);
   const v1 = failed.find((f) => f.varName === 'V1');
   const v1b = failed.find((f) => f.varName === 'V1B');
   assert.equal(v1.reason, v1b.reason);

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -59,7 +59,7 @@ test('collectRefs picks only keychain:// values', () => {
 });
 
 test('scanShellConfig finds keychain:// refs and managed export lines (v2.0 #188)', () => {
-  const { keys, warnings } = scanShellConfig(`
+  const { keys } = scanShellConfig(`
 export GITHUB_TOKEN=keychain://GITHUB_TOKEN
 export ANTHROPIC_API_KEY=$(security find-generic-password -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -w)
 # export COMMENTED=$(security find-generic-password -s "com.aieo.aikeychain.managed" -a "COMMENTED" -w)
@@ -67,7 +67,6 @@ export ANTHROPIC_API_KEY=$(security find-generic-password -s "com.aieo.aikeychai
   // managed export line: real key name is on -a, not the shared service name.
   assert.deepEqual(keys, ['ANTHROPIC_API_KEY', 'GITHUB_TOKEN']);
   assert.ok(!keys.includes('com.aieo.aikeychain.managed'));
-  assert.equal(warnings.length, 0);
 });
 
 test('scanShellConfig ignores non-managed security lookups (#187: managed only)', () => {

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -1,13 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  parseDump,
-  maskValue,
-  findAmbiguousDuplicates,
-  findUnmigratedKeys,
-  MANUAL_NAME_PATTERN,
-  GUI_SERVICE,
-} from '../src/keychain.js';
+import { parseDump, maskValue, MANAGED_SERVICE } from '../src/keychain.js';
 import { collectRefs } from '../src/run.js';
 import {
   scanShellConfig,
@@ -19,15 +12,8 @@ const SAMPLE_DUMP = `keychain: "/Users/x/Library/Keychains/login.keychain-db"
 version: 512
 class: "genp"
 attributes:
-    0x00000007 <blob>="com.aieo.aikeychain"
     "acct"<blob>="GITHUB_TOKEN"
-    "svce"<blob>="com.aieo.aikeychain"
-keychain: "/Users/x/Library/Keychains/login.keychain-db"
-version: 512
-class: "genp"
-attributes:
-    "acct"<blob>="takehiro"
-    "svce"<blob>="QIITA_TOKEN"
+    "svce"<blob>="com.aieo.aikeychain.managed"
 keychain: "/Users/x/Library/Keychains/login.keychain-db"
 version: 512
 class: "inet"
@@ -44,16 +30,9 @@ attributes:
 
 test('parseDump extracts genp service/account pairs only', () => {
   const records = parseDump(SAMPLE_DUMP);
-  assert.equal(records.length, 3); // inet record excluded
-  assert.deepEqual(records[0], { service: GUI_SERVICE, account: 'GITHUB_TOKEN' });
-  assert.deepEqual(records[1], { service: 'QIITA_TOKEN', account: 'takehiro' });
-});
-
-test('MANUAL_NAME_PATTERN accepts env-var names and rejects bundle ids', () => {
-  assert.ok(MANUAL_NAME_PATTERN.test('GITHUB_TOKEN'));
-  assert.ok(MANUAL_NAME_PATTERN.test('X_POCOLOCO_CONSUMER_KEY'));
-  assert.ok(!MANUAL_NAME_PATTERN.test('com.apple.something'));
-  assert.ok(!MANUAL_NAME_PATTERN.test('lowercase_token'));
+  assert.equal(records.length, 2); // inet record excluded
+  assert.deepEqual(records[0], { service: MANAGED_SERVICE, account: 'GITHUB_TOKEN' });
+  assert.deepEqual(records[1], { service: 'com.apple.something', account: 'user@example.com' });
 });
 
 test('maskValue never includes the value nor its length', () => {
@@ -64,89 +43,6 @@ test('maskValue never includes the value nor its length', () => {
   // 桁数が出力に含まれないこと
   assert.doesNotMatch(maskValue('super-secret'), /\d/);
   assert.doesNotMatch(maskValue('super-secret'), /chars/);
-});
-
-test('findUnmigratedKeys reports legacy-only keys and skips migrated ones (#171)', () => {
-  const records = [
-    // managed 済み → 対象外（GUI store に古いコピーが残っていても）
-    { service: 'com.aieo.aikeychain.managed', account: 'MIGRATED_KEY' },
-    { service: 'com.aieo.aikeychain', account: 'MIGRATED_KEY' },
-    // GUI store のみ → 未移行
-    { service: 'com.aieo.aikeychain', account: 'GUI_ONLY_KEY' },
-    // manual スキームのみ → 未移行
-    { service: 'MANUAL_ONLY_KEY', account: 'takehiro' },
-    // 両レガシーに存在 → 1 件にまとめて両 store を列挙
-    { service: 'com.aieo.aikeychain', account: 'BOTH_LEGACY_KEY' },
-    { service: 'BOTH_LEGACY_KEY', account: null },
-    // env 変数形でない service は manual と見なさない（他アプリのアイテム）
-    { service: 'com.vendor.other', account: 'x' },
-    { service: 'lowercase_svc', account: 'x' },
-  ];
-  const { keys, unparseable } = findUnmigratedKeys(records);
-  assert.deepEqual(keys, [
-    { name: 'BOTH_LEGACY_KEY', stores: ['gui', 'manual'] },
-    { name: 'GUI_ONLY_KEY', stores: ['gui'] },
-    { name: 'MANUAL_ONLY_KEY', stores: ['manual'] },
-  ]);
-  assert.equal(unparseable, 0);
-});
-
-test('findUnmigratedKeys returns empty when everything is migrated', () => {
-  const records = [
-    { service: 'com.aieo.aikeychain.managed', account: 'A_KEY' },
-    { service: 'com.aieo.aikeychain.managed', account: 'B_KEY' },
-  ];
-  assert.deepEqual(findUnmigratedKeys(records), { keys: [], unparseable: 0 });
-});
-
-test('findUnmigratedKeys never reports the app-reserved service names (#185 S10)', () => {
-  // KeyShareService の予約 service（共有秘密鍵/署名鍵）はドット+小文字を含み、
-  // MANUAL_NAME_PATTERN（大文字スネーク限定）が除外する。パターンが緩む回帰が
-  // 入ると「akc set com.aieo.aikeychain.sharekey しろ」と誤案内する事故になる。
-  const records = [
-    { service: 'com.aieo.aikeychain.sharekey', account: 'private_key' },
-    { service: 'com.aieo.aikeychain.signkey', account: 'signing_key' },
-  ];
-  assert.deepEqual(findUnmigratedKeys(records), { keys: [], unparseable: 0 });
-});
-
-test('findUnmigratedKeys counts unparseable store records instead of dropping them (#185 S8)', () => {
-  // GUI/managed store のレコードで acct が解析できない場合、そのキーが未移行か
-  // どうか判定できない。黙って捨てると「未移行なし」の false negative になる。
-  const records = [
-    { service: 'com.aieo.aikeychain', account: null },
-    { service: 'com.aieo.aikeychain.managed', account: null },
-    { service: 'com.aieo.aikeychain', account: 'GUI_ONLY_KEY' },
-  ];
-  const { keys, unparseable } = findUnmigratedKeys(records);
-  assert.equal(unparseable, 2);
-  assert.deepEqual(keys, [{ name: 'GUI_ONLY_KEY', stores: ['gui'] }]);
-});
-
-test('findAmbiguousDuplicates flags same-service multi-acct entries (issue #91)', () => {
-  // The exact #91 scenario: CLOUDFLARE_API_TOKEN exists twice with different accts.
-  const records = [
-    { service: 'CLOUDFLARE_API_TOKEN', account: 'takehiro' },
-    { service: 'CLOUDFLARE_API_TOKEN', account: 'CLOUDFLARE_API_TOKEN' },
-    { service: 'GITHUB_TOKEN', account: 'GITHUB_TOKEN' }, // single → fine
-    { service: GUI_SERVICE, account: 'ANTHROPIC_API_KEY' }, // GUI store → ignored
-    { service: GUI_SERVICE, account: 'OPENAI_API_KEY' },
-    { service: 'com.apple.foo', account: 'a' }, // non-env-var service → ignored
-    { service: 'com.apple.foo', account: 'b' },
-  ];
-  const dups = findAmbiguousDuplicates(records);
-  assert.equal(dups.length, 1);
-  assert.equal(dups[0].service, 'CLOUDFLARE_API_TOKEN');
-  assert.deepEqual(dups[0].accounts, ['CLOUDFLARE_API_TOKEN', 'takehiro']);
-});
-
-test('findAmbiguousDuplicates returns empty when every service is unique', () => {
-  const records = [
-    { service: 'GITHUB_TOKEN', account: 'GITHUB_TOKEN' },
-    { service: 'QIITA_TOKEN', account: 'takehiro' },
-    { service: GUI_SERVICE, account: 'GITHUB_TOKEN' }, // app+manual for same key is not a same-service dup
-  ];
-  assert.deepEqual(findAmbiguousDuplicates(records), []);
 });
 
 test('collectRefs picks only keychain:// values', () => {
@@ -162,29 +58,28 @@ test('collectRefs picks only keychain:// values', () => {
   ]);
 });
 
-test('scanShellConfig finds refs, security lookups, and the -a $USER pitfall', () => {
+test('scanShellConfig finds keychain:// refs and managed export lines (v2.0 #188)', () => {
   const { keys, warnings } = scanShellConfig(`
 export GITHUB_TOKEN=keychain://GITHUB_TOKEN
-export QIITA_TOKEN=$(security find-generic-password -s "QIITA_TOKEN" -w)
-export BAD_TOKEN=$(security find-generic-password -s "BAD_TOKEN" -a "$USER" -w)
-# export COMMENTED=$(security find-generic-password -s "COMMENTED" -w)
+export ANTHROPIC_API_KEY=$(security find-generic-password -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -w)
+# export COMMENTED=$(security find-generic-password -s "com.aieo.aikeychain.managed" -a "COMMENTED" -w)
 `);
-  assert.deepEqual(keys, ['BAD_TOKEN', 'GITHUB_TOKEN', 'QIITA_TOKEN']);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /BAD_TOKEN/);
+  // managed export line: real key name is on -a, not the shared service name.
+  assert.deepEqual(keys, ['ANTHROPIC_API_KEY', 'GITHUB_TOKEN']);
+  assert.ok(!keys.includes('com.aieo.aikeychain.managed'));
+  assert.equal(warnings.length, 0);
 });
 
-test('scanShellConfig extracts the key from -a for GUI-pinned lines', () => {
-  // AI KeyChain GUI が生成する新形式: -s は共通サービス名なので、実キー名は -a 側。
-  const { keys, warnings } = scanShellConfig(`
-export ANTHROPIC_API_KEY=$(security find-generic-password -s "com.aieo.aikeychain" -a "ANTHROPIC_API_KEY" -w)
-export OPENAI_API_KEY=$(security find-generic-password -s "com.aieo.aikeychain" -a "OPENAI_API_KEY" -w)
+test('scanShellConfig ignores non-managed security lookups (#187: managed only)', () => {
+  // v2.0: legacy GUI store / manual scheme lines are not scanned. Crucially the
+  // managed service name must NOT be registered as a key (the #187 misparse).
+  const { keys } = scanShellConfig(`
+export A=$(security find-generic-password -s "com.aieo.aikeychain.managed" -a "A" -w)
+export B=$(security find-generic-password -s "com.aieo.aikeychain" -a "B" -w)
+export C=$(security find-generic-password -s "C" -w)
 `);
-  // 共通サービス名 "com.aieo.aikeychain" ではなく、各キー名が採取される
-  assert.deepEqual(keys, ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']);
-  assert.ok(!keys.includes('com.aieo.aikeychain'));
-  // 新形式は -a "$USER" を使わないので警告なし
-  assert.equal(warnings.length, 0);
+  assert.deepEqual(keys, ['A']);
+  assert.ok(!keys.includes('com.aieo.aikeychain.managed'));
 });
 
 // --- issue #131: doctor MCP registration path-independence checks (hermetic) ---

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -115,21 +115,15 @@ sequenceDiagram
     Zshrc->>Shell: export ANTHROPIC_API_KEY="keychain://ANTHROPIC_API_KEY"
     Shell->>Akc: akc run -- claude
     Akc->>Akc: env をスキャン (keychain:// プレフィックス検出 / collectRefs)
-    Note over Akc,Keychain: 3 段ルックアップ (resolveKey, issue #91/#167)
-    Akc->>Security: ① security find-generic-password -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -w
+    Note over Akc,Keychain: 単一 namespace ルックアップ (resolveKey / v2.0 #188)
+    Akc->>Security: security find-generic-password -s "com.aieo.aikeychain.managed" -a "ANTHROPIC_API_KEY" -w
     Security->>Keychain: SecItemCopyMatching
-    alt managed namespace で見つかった
-        Keychain-->>Akc: シークレット値
-    else 見つからない (exit 44)
-        Akc->>Security: ② -s "com.aieo.aikeychain" -a "..."（旧 GUI ストア）→ ③ -s "ANTHROPIC_API_KEY"（手動登録キー）
-        Security->>Keychain: SecItemCopyMatching
-        Keychain-->>Akc: シークレット値
-    end
+    Keychain-->>Akc: シークレット値
     Akc->>Child: 子プロセスの env にのみ値を注入して spawn (親 env は不変)
     Child->>API: curl -H "x-api-key: $ANTHROPIC_API_KEY"
 ```
 
-> **3 段ルックアップ（`resolveKey` / v1.9+ #167）**: ① managed namespace `-s "com.aieo.aikeychain.managed" -a "<KEY>"`（akc/GUI の新規保存先）→ ② 旧 GUI ストア `-s "com.aieo.aikeychain" -a "<KEY>"` → ③ 手動登録キー `-s "<KEY>"`（service 名のみ、`-a` は付けない）。**各段は exit 44 (not found) のときだけ次へ落ちる** — それ以外の失敗は権威的として fail-closed（#147/#150）。手動登録キーは `acct` 値が一定しない（$USER / service 名）ため account を固定すると古い/無効な値を掴む恐れがあり、これを避ける（issue #91）。npm CLI（`cli/src/keychain.js`）と `scripts/akc` は同一手順。
+> **単一 namespace ルックアップ（`resolveKey` / v2.0 #188）**: `-s "com.aieo.aikeychain.managed" -a "<KEY>"` のみ。security 所有なのでヘッドレス読取はプロンプト/ハングしない。exit 44 (not found) は `null`、それ以外の失敗は権威的として fail-closed（#147/#150）。npm CLI（`cli/src/keychain.js`）と `scripts/akc` は同一手順。旧 v1.x の GUI ストア / manual スキームは読まない（旧ユーザーはキーを再登録する）。
 
 ### AI エージェント経由 (MCP + akc run)
 

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -19,7 +19,7 @@ npx aikeychain <command>
 | `akc init` | **マシン全体**のセットアップ: `~/.claude/CLAUDE.md` + `~/.codex/AGENTS.md` にスニペット、Claude MCP を user スコープ登録、`~/.codex/config.toml` に Codex MCP 追記（冪等）。`--print` プレビュー / `--no-register` / `--local`（プロジェクト単位） |
 | `akc run [--dry-run] -- <cmd>` | env の `keychain://` 参照を解決してコマンド実行（値は子プロセスのみに注入） |
 | `akc list` | キー名一覧（値は一切表示しない） |
-| `akc check <KEY>` | キーの存在・格納先（app / manual）確認 |
+| `akc check <KEY>` | キーの存在確認（managed namespace） |
 | `akc get <KEY>` | `keychain://<KEY>` 参照を出力（`--reveal` で生値） |
 | `akc set <KEY>` | キー登録・更新（隠し入力 or stdin。値は `security -i` に stdin + hex で渡すため**どのプロセスの argv にも露出しない**。`-U` 相当の上書きで重複防止） |
 | `akc delete <KEY>` | キー削除 |
@@ -32,9 +32,9 @@ npx aikeychain <command>
 bash 版 `scripts/akc` と互換（issue #91/#167 対応済み）。各段は exit 44
 (not found) のときだけ次へ落ちる（それ以外の失敗は fail-closed / #150）:
 
-1. `service="com.aieo.aikeychain.managed"` + `account=<KEY>`（managed namespace、v1.9+ の保存先）
-2. `service="com.aieo.aikeychain"` + `account=<KEY>`（旧 GUI ストア）
-3. `service=<KEY>` のみ・**account 非指定**（手動登録キー）
+1. `service="com.aieo.aikeychain.managed"` + `account=<KEY>`（managed namespace = 唯一の保管場所 / v2.0）
+
+旧 v1.x の GUI ストア / manual スキームは読まない（旧ユーザーはキーを再登録する）。
 
 ## MCP サーバー
 

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aieo.aikeychain
-        MARKETING_VERSION: "1.8.1"
+        MARKETING_VERSION: "2.0.0"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/scripts/akc
+++ b/scripts/akc
@@ -10,12 +10,10 @@
 # via macOS Keychain (security find-generic-password) and injected into the
 # child process environment. The parent process env is never modified.
 #
-# Lookup order (各段は exit 44/not-found の場合のみ次へ / #150):
-#   1. service="com.aieo.aikeychain.managed" account="<KEY_NAME>"  (managed namespace, v1.9+ / #167)
-#   2. service="com.aieo.aikeychain" account="<KEY_NAME>"  (旧 AI KeyChain GUI store)
-#   3. service="<KEY_NAME>"  (旧 manual スキーム; account 非指定)
-#      -a は付けない: 手動登録キーは acct の値が一定しないため、
-#      service 名のみで引く方が安定する (issue #91)
+# v2.0 (#188): managed namespace が唯一の保管場所。
+#   service="com.aieo.aikeychain.managed" account="<KEY_NAME>"
+# security 所有なのでヘッドレス読取はプロンプト/ハングしない。旧 v1.x の
+# GUI store / manual スキームは読まない（旧ユーザーはキーを再登録する）。
 
 set -euo pipefail
 
@@ -28,7 +26,7 @@ readonly SECURITY_BIN="/usr/bin/security"
 # `VAR=keychain://KEY` 行を捏造して任意の Keychain 値を解決・export させられる。
 readonly ENV_BIN="/usr/bin/env"
 
-VERSION="1.8.1"
+VERSION="2.0.0"
 
 usage() {
     cat <<'USAGE'
@@ -54,9 +52,9 @@ Examples:
 USAGE
 }
 
-# security の有界実行 (#171): GUI 所有のレガシーキーの読取は SecurityAgent の
-# 同意プロンプトで無期限にブロックし得る。macOS に timeout(1) は無いため、
-# watchdog サブシェル + SIGKILL で上限を設ける。
+# security の有界実行 (#171): keychain がロック中等では読取が無期限にブロック
+# し得る。macOS に timeout(1) は無いため、watchdog サブシェル + SIGKILL で
+# 上限を設ける（防御。managed=security 所有なので通常はプロンプトしない）。
 #
 # 設計上の不変条件 (#185 レビュー B1): シークレット値は**ディスクに書かない**。
 # 値は command substitution のパイプ内だけを流れる（一時ファイル方式は同一 UID
@@ -125,35 +123,15 @@ resolve_keychain() {
     local value
     local rc
 
-    # managed namespace (#167, v1.9+): akc/GUI の新規保存は全てここ。
-    # 44 (not found) のときだけ次の段へ落ちる（それ以外は権威的失敗 / #150）。
-    # timeout の意味は段で異なる (#171/#185 S1): managed は security 所有で
-    # プロンプトし得ない → 124 は「keychain ロック等」= 125 に変換して区別。
-    # レガシー段の 124 は「GUI 所有キーのプロンプト待ち = migration required」。
+    # v2.0 (#188): managed namespace が唯一の保管場所。security 所有なので
+    # プロンプトし得ない。124(timeout) は keychain ロック等 = 125 に変換。
+    # それ以外の非 0/44 は権威的失敗 (#150) としてそのまま返す。
     if value=$(security_bounded find-generic-password -s "com.aieo.aikeychain.managed" -a "$key_name" -w); then
         [ -n "$value" ] && { printf '%s' "$value"; return 0; }
         return 1
     else
         rc=$?
         [ "$rc" -eq 124 ] && return 125
-        [ "$rc" -eq 44 ] || return "$rc"
-    fi
-
-    if value=$(security_bounded find-generic-password -s "com.aieo.aikeychain" -a "$key_name" -w); then
-        [ -n "$value" ] && { printf '%s' "$value"; return 0; }
-        return 1
-    else
-        rc=$?
-        [ "$rc" -eq 44 ] || return "$rc"
-    fi
-
-    # 手動登録キーのフォールバック。-a はあえて指定しない: acct の値が
-    # エントリごとに一定しないため、service 名のみで引く方が安定する (issue #91)
-    if value=$(security_bounded find-generic-password -s "$key_name" -w); then
-        [ -n "$value" ] && { printf '%s' "$value"; return 0; }
-        return 1
-    else
-        rc=$?
         return "$rc"
     fi
 }
@@ -229,12 +207,8 @@ cmd_run() {
                     fi
                 else
                     failed_count=$((failed_count + 1))
-                    if [ "$rk_rc" -eq 124 ]; then
-                        # 有界失敗 (#171): レガシー段がプロンプト待ちで kill された
-                        # = GUI 所有キー。移行を明示的に案内する。
-                        echo "  ❌ $var_name — keychain://$key_name: legacy GUI-owned key blocked on a keychain prompt (killed after timeout). Migrate with: akc set $key_name" >&2
-                    elif [ "$rk_rc" -eq 125 ]; then
-                        # managed 段の timeout = keychain ロック/不可用（移行では直らない）
+                    if [ "$rk_rc" -eq 125 ]; then
+                        # managed 段の timeout = keychain ロック/不可用 (#188)
                         echo "  ❌ $var_name — keychain://$key_name: managed read timed out — keychain locked or unavailable. Unlock the login keychain and retry." >&2
                     elif [ "$rk_rc" -eq 1 ] || [ "$rk_rc" -eq 44 ]; then
                         echo "  ❌ $var_name — keychain://$key_name not found in Keychain" >&2

--- a/scripts/test_akc.sh
+++ b/scripts/test_akc.sh
@@ -45,7 +45,7 @@ echo "--- Basic commands ---"
 assert_exit 0 "$AKC" help
 assert_exit 0 "$AKC" version
 assert_exit 0 "$AKC" --help
-assert_contains "akc 1.0.0" "$AKC" version
+assert_contains "akc 2.0.0" "$AKC" version
 
 echo ""
 echo "--- Error handling ---"


### PR DESCRIPTION
Closes #188。移行アシスタント #172 は作らない判断でクローズ済み。

## 背景
DL 実測（GitHub DMG 全バージョン合計 ~12・v1.7 以降ほぼ 0／npm CLI 203・実ユーザー数人〜十数人／Homebrew・App Store なし）から**旧バージョンは実質未使用**と確認。オーナー判断で後方互換を捨て、完全リニューアル（方針 A: 旧キーは読まない・消さない・再登録）に倒す。

## ⚠️ BREAKING
v1.x で登録したキーは読まれなくなる。**GUI アプリまたは `akc set <KEY>` で再登録**が必要。旧キーは Keychain に残るが参照しない。`akc set --manual` / MCP `manual` フィールド廃止。

## 変更
`com.aieo.aikeychain.managed`（security 所有・ヘッドレス読取が無音）を**唯一の保管場所**に。

**CLI (`cli/`, `scripts/akc`)**
- `resolveKey` 3 段 → managed 1 段。`keyExists`/`deleteKey` も managed のみ。`deleteKey` は bool 返却
- `findUnmigratedKeys`/`findAmbiguousDuplicates`/`MigrationRequiredError`/`GUI_SERVICE`/`MANUAL_NAME_PATTERN` 撤去
- `doctor` の migration/legacy scan 撤去 → **legacy 由来の既存バグ #186/#187 は経路ごと解消**
- `bin/akc.js` の check 表示・`mcp-server` の stores 簡素化・usage-guide 更新

**Swift (`AIkeychain/`)**
- `SecurityCLIKeychainService`: delete を managed 単一化・`legacyGUIService`/`manualServices()` 撤去
- `KeyListViewModel`: manual 発見撤去 / `APIKey.StorageScheme` 撤去 / `ZshrcExporter` は managed 形のみ / `KeyEditorViewModel.deletesManualEntryToo` 撤去 / `SetupManager.readSystemKeychainValue` 撤去 / protocol・Mock の `manualServices` 撤去 / 未使用の `isManualSchemeCandidate` 撤去

**docs/version**: architecture を単一 namespace に。CHANGELOG に v2.0 破壊的変更。MARKETING_VERSION / akc VERSION / npm version を 2.0.0 に

## 維持（非対象）
managed への stdin+hex 書込・printable ASCII+8192・read-back 検証・security_bounded の有界化・Proxy の quarantine/coalescing・KeyShareService（内部鍵）・#117 絶対パス・#94 argv 非露出・fail-closed 契約。

## 差分・テスト
- **287 追加 / 1259 削除**（互換撤去で正味 -972 行）
- **Swift 178/178・CLI 79/79 green**（mcp.test.js は既知 sandbox タイムアウトで除外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPwWFBAo9d5u87LAAUb6WM