### PR TITLE
fix(gui): アップグレードツアーを sheet(item:) で提示し「0 件」表示を修正 (#194)

### DIFF
--- a/AIkeychain/Views/Main/MainView.swift
+++ b/AIkeychain/Views/Main/MainView.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+/// アップグレードツアーの提示 payload (#194)。`.sheet(item:)` で使うため Identifiable。
+/// 1 起動につき高々 1 回の提示なので id は固定でよい。
+private struct UpgradeTourPayload: Identifiable {
+    var id: Int { 0 }
+    let keyNames: [String]
+}
+
 struct MainView: View {
     @State private var viewModel = KeyListViewModel()
     @State private var showingShare = false
@@ -8,9 +15,11 @@ struct MainView: View {
     // 先に再登録ツアーを出す。新規インストール（旧キー無し）は従来どおり onboarding。
     // スキャンは onAppear で 1 回だけ（@State のデフォルト式は struct 再構築のたびに
     // 評価され、全 keychain 列挙をメインスレッドで反復してしまうため空で初期化する）。
-    @State private var legacyKeys: [String] = []
+    // 提示は `.sheet(item:)` を使う: `.sheet(isPresented:)` + 別 @State だと、提示時に
+    // コンテンツクロージャが更新前の値（空配列）で評価され「再登録が必要なキー（0 件）」
+    // になる stale-sheet 挙動を実機で確認した (#194)。payload に検出結果を持たせる。
+    @State private var upgradeTour: UpgradeTourPayload?
     @State private var didScanLegacy = false
-    @State private var showingUpgradeTour = false
     @State private var showingOnboarding = false
     @State private var showingCleanup = false
     @State private var showingModeSelect = false
@@ -153,8 +162,8 @@ struct MainView: View {
         .sheet(isPresented: $showingOnboarding) {
             OnboardingView()
         }
-        .sheet(isPresented: $showingUpgradeTour) {
-            UpgradeTourView(legacyKeyNames: legacyKeys)
+        .sheet(item: $upgradeTour) { payload in
+            UpgradeTourView(legacyKeyNames: payload.keyNames)
         }
         .sheet(isPresented: $showingCleanup) {
             CleanupView()
@@ -174,9 +183,8 @@ struct MainView: View {
             Task.detached(priority: .utility) {
                 let found = LegacyKeyScanner.unmigratedKeyNames()
                 await MainActor.run {
-                    legacyKeys = found
                     if UpgradeTourView.shouldShow(legacyKeyNames: found) {
-                        showingUpgradeTour = true
+                        upgradeTour = UpgradeTourPayload(keyNames: found)
                     } else if !OnboardingViewModel.hasCompleted {
                         showingOnboarding = true
                     }


### PR DESCRIPTION
Closes #194

## 背景
v2.0.0 リリース前 GUI テストで、v1 キー 40 件の実機にてアップグレードツアーが「再登録が必要なキー（**0 件**）」と表示された。デバッグログで **スキャンは 40 件返しているのに sheet が空配列で描画**されていることを確認（`.sheet(isPresented:)` のコンテンツが提示トランザクションで更新前の `@State legacyKeys` を評価する stale-sheet 挙動）。

## 変更
- `MainView`: `@State legacyKeys` + `@State showingUpgradeTour` + `.sheet(isPresented:)` を廃し、検出キー名を持つ `UpgradeTourPayload`（Identifiable）+ **`.sheet(item:)`** で提示。payload が set された時点の値で描画されるため stale 参照が構造的に消える。

## 検証（Red/Green — issue の 💬 検証コメントにログ添付）
- Red: `MainView scan: found=40` → `UpgradeTourView.body renders with 0 keys`（毎回再現）
- Green: 同条件で `renders with 40 keys`
- Swift 187 中 185 pass（fail 2 = #192 既知・無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1pTCauh7wfgUDASgHZ5Wx