### PR TITLE
feat(cli): akc migrate — v1 キー（旧 GUI store / manual）を managed へ一括引き継ぎ (#196)

### DIFF
--- a/AIkeychain/Views/UpgradeTourView.swift
+++ b/AIkeychain/Views/UpgradeTourView.swift
@@ -98,7 +98,9 @@ struct UpgradeTourView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(L10n.s(ja: "登録方法", en: "How to re-register"))
                     .font(.system(size: 13, weight: .medium))
-                Label(L10n.s(ja: "このアプリの「+」から追加する", en: "Add from the “+” in this app"), systemImage: "plus.circle")
+                Label(L10n.s(ja: "一括で引き継ぐ: ターミナルで  akc migrate", en: "Migrate them all at once — in a terminal:  akc migrate"), systemImage: "square.stack.3d.up")
+                    .font(.system(size: 12, weight: .medium))
+                Label(L10n.s(ja: "このアプリの「+」から 1 件ずつ追加する", en: "Or add one by one from the “+” in this app"), systemImage: "plus.circle")
                     .font(.system(size: 12))
                 Label(L10n.s(ja: "またはターミナルで  akc set <KEY>", en: "Or in a terminal:  akc set <KEY>"), systemImage: "terminal")
                     .font(.system(size: 12))

--- a/AIkeychain/Views/UpgradeTourView.swift
+++ b/AIkeychain/Views/UpgradeTourView.swift
@@ -98,7 +98,7 @@ struct UpgradeTourView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(L10n.s(ja: "登録方法", en: "How to re-register"))
                     .font(.system(size: 13, weight: .medium))
-                Label(L10n.s(ja: "一括で引き継ぐ: ターミナルで  akc migrate", en: "Migrate them all at once — in a terminal:  akc migrate"), systemImage: "square.stack.3d.up")
+                Label(L10n.s(ja: "一括で引き継ぐ: ターミナルで  akc migrate（akc 未導入なら npx -y aikeychain migrate）", en: "Migrate them all at once — in a terminal:  akc migrate  (no CLI yet? npx -y aikeychain migrate)"), systemImage: "square.stack.3d.up")
                     .font(.system(size: 12, weight: .medium))
                 Label(L10n.s(ja: "このアプリの「+」から 1 件ずつ追加する", en: "Or add one by one from the “+” in this app"), systemImage: "plus.circle")
                     .font(.system(size: 12))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to AI KeyChain are documented in this file.
 - これに伴い legacy 由来の既知バグ（#186 manual 重複削除・#187 doctor の managed 行誤解析）は経路ごと解消
 
 ### 注記
-- 移行アシスタント（旧 #172 C5）は、旧バージョンの利用実績がほぼ無いこと（DL 実測）を踏まえ**作らない判断**とした。互換の複雑さ（secret oracle・移行の crash-safe 化など）を丸ごと回避している。
+- 移行アシスタント **UI**（旧 #172 C5）は、旧バージョンの利用実績がほぼ無いこと（DL 実測）を踏まえ作らない判断とした（互換の複雑さを丸ごと回避）。一括引き継ぎは CLI の `akc migrate`（#196）が担う。
 
 ## [1.8.1] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to AI KeyChain are documented in this file.
 - `akc set --manual` / MCP の `manual` フィールドを廃止（すべて managed namespace に書き込む）。
 
 ### Added
+- **`akc migrate`** — v1.x のキー（旧 GUI store / manual スキーム）を managed namespace へ一括移行。値は端末・argv・ファイルに出さず、旧アイテムは削除しない。managed 済み/重複（GUI 優先）は skip、ACL 許可ダイアログが必要なキーは `--interactive --only` で個別続行、`--dry-run` で計画のみ表示。アップグレードツアーからも案内 (#196)
 - **アップグレード・ツアー** — v1.x から更新したユーザーの初回起動時、旧方式（旧 GUI store / manual スキーム）にしか無いキーを**読み取り専用・無音で検出**し、「再登録が必要なキー一覧」と v2.0 の使い方を案内するツアーを表示。新規インストール（旧キー無し）は従来の onboarding のまま。検出は `dump-keychain` 相当の属性照会のみで値は読まない（プロンプトゼロ）(#188)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Download the latest release from [Releases](https://github.com/aieo-product/AIke
 
 > **Note:** Since v1.8.0, releases are signed with a Developer ID certificate (Team `34J49FY7U7`), notarized by Apple, and stapled, so Gatekeeper accepts the app without any manual `xattr` workaround. If macOS warns that the app is damaged or from an unidentified developer, do **not** bypass Gatekeeper — verify the asset with `spctl --assess --type open --context context:primary-signature -vv AIKeyChain-vX.Y.Z.dmg` (expect `accepted / Notarized Developer ID`) and re-download the latest release.
 >
-> **Upgrading from v1.x:** v2.0 stores keys in a new single namespace and no longer reads keys registered by older versions (they are not deleted). On first launch the app shows an upgrade tour listing the keys to re-register — re-add each with the app's **+** or `akc set <KEY>`.
+> **Upgrading from v1.x:** v2.0 stores keys in a new single namespace and no longer reads keys registered by older versions (they are not deleted). On first launch the app shows an upgrade tour listing the keys to re-register — run **`akc migrate`** in a terminal to bulk-migrate them all (values never printed, old items kept), or re-add each with the app's **+** / `akc set <KEY>`.
 
 ### Verify your download
 
@@ -145,7 +145,8 @@ export OPENAI_API_KEY=keychain://OPENAI_API_KEY
 akc run -- claude            # real value injected into the child process only
 # Headless contract: every key is in the managed namespace and resolves silently
 # — no prompts, no hangs. (v2.0 dropped the v1.x GUI store / manual scheme; if you
-# upgraded, re-register your keys with `akc set <KEY>`.)
+# upgraded, bulk-migrate your keys with `akc migrate` — or one by one
+# with `akc set <KEY>`.)
 
 akc list                     # key names (never prints values)
 akc set GITHUB_TOKEN         # hidden prompt, overwrites in place

--- a/cli/README.md
+++ b/cli/README.md
@@ -51,6 +51,11 @@ akc run -- claude
 # Preview what would resolve (values masked)
 akc run --dry-run
 
+# Bulk-migrate keys registered by v1.x (old GUI store / manual scheme)
+akc migrate --dry-run     # show the plan only
+akc migrate               # migrate; values stay in memory/pipes, old items kept
+akc migrate --interactive --only KEY1,KEY2   # keys that need a Keychain approval dialog
+
 # Manage keys
 akc list                  # key names only — never prints values
 akc check GITHUB_TOKEN    # exists? in which store?
@@ -74,7 +79,10 @@ akc guide
 Every key lives at `service="com.aieo.aikeychain.managed"`, `account=<KEY>` — the
 single managed namespace, created by `/usr/bin/security` so headless reads never
 prompt. The old v1.x GUI store / manual scheme are no longer read; upgrading users
-re-register their keys with `akc set <KEY>`.
+re-register their keys — run **`akc migrate`** to bulk-migrate everything the
+old versions stored (old GUI store + manual scheme) into the managed namespace,
+or `akc set <KEY>` one by one. `akc migrate` never prints secret values and
+never deletes the old items.
 
 ## MCP server
 

--- a/cli/bin/akc.js
+++ b/cli/bin/akc.js
@@ -26,6 +26,7 @@ const USAGE = `akc — AI KeyChain CLI (secret references, key management, MCP s
 Usage:
   akc init [--print] [--no-register] [--local]
   akc run [--dry-run] -- <command> [args...]
+  akc migrate [--dry-run] [--yes] [--interactive] [--only KEY,...]
   akc list
   akc check <KEY>
   akc get <KEY> [--reveal]
@@ -43,6 +44,8 @@ Commands:
            scope + ~/.codex/config.toml). --local scopes it to the current project,
            --print previews, --no-register skips MCP registration.
   run      Resolve keychain:// env references and execute a command
+  migrate  Bulk-migrate v1.x keys (old GUI store / manual scheme) into the
+           managed namespace. Values stay in memory/pipes; old items are kept.
   list     List known key names (never prints values)
   check    Check whether a key exists in the managed namespace
   get      Print the keychain:// reference for a key (--reveal prints the raw value)
@@ -216,6 +219,10 @@ async function main() {
   switch (command) {
     case 'run':
       return cmdRun(rest);
+    case 'migrate': {
+      const { cmdMigrate } = await import('../src/migrate.js');
+      return cmdMigrate(rest);
+    }
     case 'list':
       return cmdList();
     case 'check': {

--- a/cli/src/migrate.js
+++ b/cli/src/migrate.js
@@ -1,0 +1,222 @@
+// `akc migrate` (#196) — v1.x のキー（旧 GUI store / manual スキーム）を managed
+// namespace へ一括移行する。値はプロセスメモリと pipe のみを通り、argv / env /
+// ファイル / 端末には決して出さない。旧キーは削除しない（読み取りのみ）。
+//
+// v2.0 で keychain.js は「managed のみ」に絞られたため、レガシー読み取りは
+// このモジュールに閉じ込める（migrate が唯一の正当なレガシー消費者）。
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createInterface } from 'node:readline';
+import {
+  dumpRecords,
+  setKey,
+  KeychainError,
+  MANAGED_SERVICE,
+  SECURITY_BIN,
+  SUBPROCESS_TIMEOUT_MS,
+  KEY_NAME_PATTERN,
+} from './keychain.js';
+
+const pExecFile = promisify(execFile);
+
+/** v1.x の GUI store service 名（v2 は読まない・migrate だけが参照する）。 */
+export const LEGACY_GUI_SERVICE = 'com.aieo.aikeychain';
+
+// v1 の manual スキーム判定と同一の厳格パターン（#160/#163、GUI/CLI 共通規則）:
+// 大文字スネークケース限定。緩くすると iCloud / com.apple.* 等のシステム項目を
+// 「キー」と誤認して無関係なアイテムへ read が波及するため、ここは広げない。
+export const MANUAL_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+// --interactive での 1 キーあたりの許可ダイアログ待ち上限。
+const INTERACTIVE_TIMEOUT_MS = 600_000;
+
+/**
+ * dump-keychain の属性レコード（値は含まない）から移行計画を作る純関数。
+ * - 旧 GUI store: service=LEGACY_GUI_SERVICE の account（akc set 可能な名前のみ）
+ * - manual: service が MANUAL_NAME_PATTERN に一致
+ * - managed に同名があれば skip、GUI/manual 重複は GUI 優先（v1 の解決順と同じ）
+ */
+export function planMigration(records) {
+  const managed = new Set();
+  const gui = new Set();
+  const manual = new Set();
+  for (const { service, account } of records) {
+    if (!service) continue;
+    if (service === MANAGED_SERVICE) {
+      if (account) managed.add(account);
+    } else if (service === LEGACY_GUI_SERVICE) {
+      if (account && KEY_NAME_PATTERN.test(account)) gui.add(account);
+    } else if (MANUAL_NAME_PATTERN.test(service)) {
+      manual.add(service);
+    }
+  }
+  const entries = [];
+  for (const name of [...gui].sort()) {
+    entries.push({ name, source: 'gui', action: managed.has(name) ? 'skip-managed' : 'migrate' });
+  }
+  for (const name of [...manual].sort()) {
+    if (gui.has(name)) {
+      entries.push({ name, source: 'manual', action: 'skip-duplicate' });
+    } else {
+      entries.push({ name, source: 'manual', action: managed.has(name) ? 'skip-managed' : 'migrate' });
+    }
+  }
+  return entries;
+}
+
+/**
+ * 旧位置から値を読む。timeout 超過（= ACL 許可ダイアログ待ち）は 'needs-approval'。
+ * 値は返り値のフィールドにのみ載る（ログ等へは出さない）。
+ */
+async function readLegacyValue(name, source, timeoutMs) {
+  const args =
+    source === 'gui'
+      ? ['find-generic-password', '-s', LEGACY_GUI_SERVICE, '-a', name, '-w']
+      : ['find-generic-password', '-s', name, '-w'];
+  try {
+    const { stdout } = await pExecFile(SECURITY_BIN, args, {
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: timeoutMs,
+      killSignal: 'SIGKILL',
+    });
+    const value = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+    return value ? { status: 'ok', value } : { status: 'empty' };
+  } catch (err) {
+    if (err.killed === true) return { status: 'needs-approval' };
+    if (err.code === 44) return { status: 'not-found' };
+    return { status: 'read-failed', detail: (err.stderr ?? String(err)).trim().split('\n')[0] };
+  }
+}
+
+function confirm(question) {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, yes: false, interactive: false, only: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--yes') opts.yes = true;
+    else if (a === '--interactive') opts.interactive = true;
+    else if (a === '--only') {
+      const v = argv[++i];
+      if (!v) return { error: '--only requires a comma-separated key list' };
+      opts.only = new Set((opts.only ? [...opts.only] : []).concat(v.split(',').map((s) => s.trim()).filter(Boolean)));
+    } else return { error: `unknown option: ${a}` };
+  }
+  return { opts };
+}
+
+const planLine = (e) => {
+  const label =
+    e.action === 'migrate'
+      ? `migrate (${e.source})`
+      : e.action === 'skip-managed'
+        ? 'skip — already managed'
+        : 'skip — duplicate (GUI store version wins)';
+  return `  ${e.name.padEnd(36)} ${label}`;
+};
+
+export async function cmdMigrate(argv) {
+  const { opts, error } = parseArgs(argv);
+  if (error) {
+    process.stderr.write(`akc: ${error}\nUsage: akc migrate [--dry-run] [--yes] [--interactive] [--only KEY,...]\n`);
+    return 1;
+  }
+  const out = (s) => process.stdout.write(s);
+
+  let plan = planMigration(await dumpRecords());
+  if (opts.only) {
+    for (const name of opts.only) {
+      if (!plan.some((e) => e.name === name)) {
+        process.stderr.write(`akc: --only ${name}: not found in the migration plan (ignored)\n`);
+      }
+    }
+    plan = plan.filter((e) => opts.only.has(e.name));
+  }
+  const targets = plan.filter((e) => e.action === 'migrate');
+
+  out(`Migration plan (v1 → managed namespace "${MANAGED_SERVICE}"):\n`);
+  for (const e of plan) out(`${planLine(e)}\n`);
+  out(`Plan: ${targets.length} to migrate, ${plan.length - targets.length} skipped.\n`);
+  out('Old items are never deleted — they stay in the Keychain untouched.\n');
+
+  if (opts.dryRun) {
+    out('(dry-run) Nothing written.\n');
+    return 0;
+  }
+  if (targets.length === 0) {
+    out('Nothing to migrate.\n');
+    return 0;
+  }
+  if (!opts.yes) {
+    if (process.stdin.isTTY && process.stderr.isTTY) {
+      if (!(await confirm(`Migrate ${targets.length} key(s) now? [y/N] `))) {
+        process.stderr.write('akc: cancelled\n');
+        return 1;
+      }
+    } else {
+      process.stderr.write('akc: refusing to migrate without confirmation on a non-interactive terminal — re-run with --yes\n');
+      return 1;
+    }
+  }
+
+  const tally = { ok: 0, unsupported: 0, failed: 0 };
+  const needsApproval = [];
+  for (const { name, source } of targets) {
+    if (opts.interactive) {
+      process.stderr.write(`⏳ ${name}: Keychain の許可ダイアログが出たら「常に許可」を選んでください…\n`);
+    }
+    const r = await readLegacyValue(name, source, opts.interactive ? INTERACTIVE_TIMEOUT_MS : SUBPROCESS_TIMEOUT_MS);
+    if (r.status === 'needs-approval') {
+      needsApproval.push(name);
+      out(`  ⚠️  ${name.padEnd(36)} needs-approval — 読み取りに Keychain の許可が必要です\n`);
+      continue;
+    }
+    if (r.status === 'not-found' || r.status === 'empty') {
+      tally.failed += 1;
+      out(`  ✖  ${name.padEnd(36)} ${r.status === 'empty' ? 'empty value in the old item' : 'old item disappeared'}\n`);
+      continue;
+    }
+    if (r.status === 'read-failed') {
+      tally.failed += 1;
+      out(`  ✖  ${name.padEnd(36)} read failed: ${r.detail || 'unknown error'}\n`);
+      continue;
+    }
+    try {
+      await setKey(name, r.value); // 検証（printable/長さ/読み戻し）と redact は setKey 側 (#191/#193)
+      tally.ok += 1;
+      out(`  ✅ ${name.padEnd(36)} migrated (${source})\n`);
+    } catch (err) {
+      if (!(err instanceof KeychainError)) throw err;
+      const msg = err.message.split('\n')[0];
+      if (/printable ASCII|character limit/.test(msg)) {
+        tally.unsupported += 1;
+        out(`  ✖  ${name.padEnd(36)} unsupported value: ${msg}\n`);
+      } else {
+        tally.failed += 1;
+        out(`  ✖  ${name.padEnd(36)} save failed: ${msg}\n`);
+      }
+    }
+  }
+
+  out(
+    `Done: migrated=${tally.ok} needs-approval=${needsApproval.length} ` +
+      `unsupported=${tally.unsupported} failed=${tally.failed}\n`
+  );
+  if (needsApproval.length > 0) {
+    out(
+      '次のコマンドで、許可ダイアログに応答しながら残りを移行できます:\n' +
+        `  akc migrate --interactive --only ${needsApproval.join(',')}\n`
+    );
+  }
+  return needsApproval.length + tally.unsupported + tally.failed > 0 ? 1 : 0;
+}

--- a/cli/src/migrate.js
+++ b/cli/src/migrate.js
@@ -1,6 +1,6 @@
 // `akc migrate` (#196) — v1.x のキー（旧 GUI store / manual スキーム）を managed
 // namespace へ一括移行する。値はプロセスメモリと pipe のみを通り、argv / env /
-// ファイル / 端末には決して出さない。旧キーは削除しない（読み取りのみ）。
+// ファイル / stdout / stderr には決して出さない。旧キーは削除しない（読み取りのみ）。
 //
 // v2.0 で keychain.js は「managed のみ」に絞られたため、レガシー読み取りは
 // このモジュールに閉じ込める（migrate が唯一の正当なレガシー消費者）。
@@ -32,69 +32,147 @@ export const MANUAL_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 const INTERACTIVE_TIMEOUT_MS = 600_000;
 
 /**
- * dump-keychain の属性レコード（値は含まない）から移行計画を作る純関数。
- * - 旧 GUI store: service=LEGACY_GUI_SERVICE の account（akc set 可能な名前のみ）
- * - manual: service が MANUAL_NAME_PATTERN に一致
- * - managed に同名があれば skip、GUI/manual 重複は GUI 優先（v1 の解決順と同じ）
+ * manual スキーム項目として妥当な account か (#196 レビュー M2)。
+ * service 名だけで判定すると `SSH` のような他アプリの大文字 service を誤認し、
+ * 無関係なシークレットの読み取り（= 許可ダイアログ誘発）や、prompt-free な
+ * managed namespace への複製が起きる。v1 が実際に書いた account の形
+ * （空 / $USER / キー名形）に限定する。
  */
-export function planMigration(records) {
+function isPlausibleManualAccount(account, user) {
+  if (account == null || account === '') return true;
+  if (user && account === user) return true;
+  return KEY_NAME_PATTERN.test(account);
+}
+
+/**
+ * dump-keychain の属性レコード（値は含まない）から移行計画を作る純関数。
+ * - 旧 GUI store: service=LEGACY_GUI_SERVICE の account
+ *   - v2 のキー名文法に合わない account は `unsupported-name`（黙って落とすと
+ *     「移行不要」に見える — レビュー指摘）
+ * - manual: service が MANUAL_NAME_PATTERN に一致し、かつ全 account が
+ *   v1 の書き込み形として妥当なもの。妥当でない account が混じる service は
+ *   他アプリ由来とみなし対象外。妥当な account が複数ある service は #91 の
+ *   重複事故で、service-only read はどれを返すか不定なので `ambiguous`。
+ * - managed に同名があれば skip、GUI/manual 重複は GUI 優先（v1 の解決順）。
+ *   GUI 側 entry には manualCopy を立て、GUI 読み取り失敗時のフォールバックに使う。
+ */
+export function planMigration(records, { user } = {}) {
   const managed = new Set();
   const gui = new Set();
-  const manual = new Set();
+  const guiBadName = new Set();
+  const manualAccounts = new Map(); // service -> Set(accounts)
+  const manualForeign = new Set(); // 妥当でない account を含む service
   for (const { service, account } of records) {
     if (!service) continue;
     if (service === MANAGED_SERVICE) {
       if (account) managed.add(account);
     } else if (service === LEGACY_GUI_SERVICE) {
-      if (account && KEY_NAME_PATTERN.test(account)) gui.add(account);
+      if (!account) continue; // account 無しはキー名として扱えない
+      if (KEY_NAME_PATTERN.test(account)) gui.add(account);
+      else guiBadName.add(account);
     } else if (MANUAL_NAME_PATTERN.test(service)) {
-      manual.add(service);
+      if (!isPlausibleManualAccount(account, user)) {
+        manualForeign.add(service);
+        continue;
+      }
+      if (!manualAccounts.has(service)) manualAccounts.set(service, new Set());
+      manualAccounts.get(service).add(account ?? '');
     }
   }
+  const manual = new Set([...manualAccounts.keys()].filter((s) => !manualForeign.has(s)));
   const entries = [];
   for (const name of [...gui].sort()) {
-    entries.push({ name, source: 'gui', action: managed.has(name) ? 'skip-managed' : 'migrate' });
+    entries.push({
+      name,
+      source: 'gui',
+      action: managed.has(name) ? 'skip-managed' : 'migrate',
+      manualCopy: manual.has(name),
+    });
+  }
+  for (const name of [...guiBadName].sort()) {
+    entries.push({ name, source: 'gui', action: 'unsupported-name' });
   }
   for (const name of [...manual].sort()) {
     if (gui.has(name)) {
       entries.push({ name, source: 'manual', action: 'skip-duplicate' });
+    } else if (managed.has(name)) {
+      entries.push({ name, source: 'manual', action: 'skip-managed' });
+    } else if (manualAccounts.get(name).size > 1) {
+      entries.push({ name, source: 'manual', action: 'ambiguous' });
     } else {
-      entries.push({ name, source: 'manual', action: managed.has(name) ? 'skip-managed' : 'migrate' });
+      entries.push({ name, source: 'manual', action: 'migrate' });
     }
   }
   return entries;
 }
 
+const HEX_SHAPED = /^(?:[0-9a-fA-F]{2})+$/;
+
+function securityArgs(name, source, flag) {
+  return source === 'gui'
+    ? ['find-generic-password', '-s', LEGACY_GUI_SERVICE, '-a', name, flag]
+    : ['find-generic-password', '-s', name, flag];
+}
+
+async function runSecurity(args, timeoutMs) {
+  return pExecFile(SECURITY_BIN, args, {
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
+  });
+}
+
 /**
  * 旧位置から値を読む。timeout 超過（= ACL 許可ダイアログ待ち）は 'needs-approval'。
- * 値は返り値のフィールドにのみ載る（ログ等へは出さない）。
+ * 値は返り値のフィールドにのみ載る（出力へは決して流さない）。
+ *
+ * `find-generic-password -w` は値に非印字/非 ASCII バイトが含まれると **無印の
+ * hex** を出力するため、hex 形の出力はそのままでは「hex 文字列そのものが値」と
+ * 区別できない（#196 レビュー High: 黙って hex を保存すると成功と報告しつつ値を
+ * 壊す）。その場合のみ `-g` を追加実行し、stderr の `password: "…"`（印字可能な
+ * 文字列リテラル）か `password: 0x…`（バイナリ）かで判別する。判別できなければ
+ * fail-closed で 'unsupported-encoding'。-g の stderr は値を含むため、パース
+ * 以外に使わず、いかなる出力にも流さない。
  */
 async function readLegacyValue(name, source, timeoutMs) {
-  const args =
-    source === 'gui'
-      ? ['find-generic-password', '-s', LEGACY_GUI_SERVICE, '-a', name, '-w']
-      : ['find-generic-password', '-s', name, '-w'];
+  let stdout;
   try {
-    const { stdout } = await pExecFile(SECURITY_BIN, args, {
-      maxBuffer: 16 * 1024 * 1024,
-      timeout: timeoutMs,
-      killSignal: 'SIGKILL',
-    });
-    const value = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
-    return value ? { status: 'ok', value } : { status: 'empty' };
+    ({ stdout } = await runSecurity(securityArgs(name, source, '-w'), timeoutMs));
   } catch (err) {
     if (err.killed === true) return { status: 'needs-approval' };
     if (err.code === 44) return { status: 'not-found' };
-    return { status: 'read-failed', detail: (err.stderr ?? String(err)).trim().split('\n')[0] };
+    // stderr は値や診断を含み得るため決して転送しない。exit code のみ返す。
+    return { status: 'read-failed', code: typeof err.code === 'number' ? err.code : null };
+  }
+  const value = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+  if (!value) return { status: 'empty' };
+  if (!HEX_SHAPED.test(value)) return { status: 'ok', value };
+  // hex 形: -g で「リテラル文字列」か「バイナリの hex 表現」かを判別する。
+  try {
+    const g = await runSecurity(securityArgs(name, source, '-g'), timeoutMs);
+    if (/^password: "/m.test(g.stderr)) return { status: 'ok', value }; // 値そのものが hex 文字列
+    if (/^password: 0x/m.test(g.stderr)) return { status: 'unsupported-encoding' };
+    return { status: 'unsupported-encoding' }; // 判別不能は fail-closed
+  } catch {
+    return { status: 'unsupported-encoding' };
   }
 }
 
 function confirm(question) {
   return new Promise((resolve) => {
     const rl = createInterface({ input: process.stdin, output: process.stderr });
+    let settled = false;
+    const settle = (v) => {
+      if (!settled) {
+        settled = true;
+        resolve(v);
+      }
+    };
+    // EOF (Ctrl-D) では question のコールバックが呼ばれない — close をキャンセル扱いに。
+    rl.on('close', () => settle(false));
     rl.question(question, (answer) => {
       rl.close();
-      resolve(/^y(es)?$/i.test(answer.trim()));
+      settle(/^y(es)?$/i.test(answer.trim()));
     });
   });
 }
@@ -108,54 +186,76 @@ function parseArgs(argv) {
     else if (a === '--interactive') opts.interactive = true;
     else if (a === '--only') {
       const v = argv[++i];
-      if (!v) return { error: '--only requires a comma-separated key list' };
-      opts.only = new Set((opts.only ? [...opts.only] : []).concat(v.split(',').map((s) => s.trim()).filter(Boolean)));
+      if (!v || v.startsWith('-')) return { error: '--only requires a comma-separated key list' };
+      const names = v.split(',').map((s) => s.trim()).filter(Boolean);
+      if (names.length === 0) return { error: '--only requires at least one key name' };
+      opts.only = new Set((opts.only ? [...opts.only] : []).concat(names));
     } else return { error: `unknown option: ${a}` };
   }
   return { opts };
 }
 
+const PLAN_LABELS = {
+  'skip-managed': 'skip — already managed',
+  'skip-duplicate': 'skip — duplicate (the GUI store copy is used)',
+  'unsupported-name': 'cannot migrate — name not supported by v2 (re-register: akc set)',
+  ambiguous: 'cannot migrate — multiple keychain items share this service (#91); re-register: akc set',
+};
 const planLine = (e) => {
-  const label =
-    e.action === 'migrate'
-      ? `migrate (${e.source})`
-      : e.action === 'skip-managed'
-        ? 'skip — already managed'
-        : 'skip — duplicate (GUI store version wins)';
+  const label = e.action === 'migrate' ? `migrate (${e.source})` : PLAN_LABELS[e.action];
   return `  ${e.name.padEnd(36)} ${label}`;
+};
+
+const FAILURE_TEXT = {
+  'not-found': 'old item disappeared',
+  empty: 'empty value in the old item',
+  'unsupported-encoding':
+    'value is not printable single-line ASCII (non-ASCII or multi-line) — re-register with: akc set',
 };
 
 export async function cmdMigrate(argv) {
   const { opts, error } = parseArgs(argv);
   if (error) {
-    process.stderr.write(`akc: ${error}\nUsage: akc migrate [--dry-run] [--yes] [--interactive] [--only KEY,...]\n`);
+    process.stderr.write(
+      `akc: ${error}\nUsage: akc migrate [--dry-run] [--yes] [--interactive] [--only KEY,...]\n`
+    );
     return 1;
   }
   const out = (s) => process.stdout.write(s);
 
-  let plan = planMigration(await dumpRecords());
+  let plan = planMigration(await dumpRecords(), { user: process.env.USER });
+  let missingOnly = 0;
   if (opts.only) {
     for (const name of opts.only) {
       if (!plan.some((e) => e.name === name)) {
-        process.stderr.write(`akc: --only ${name}: not found in the migration plan (ignored)\n`);
+        missingOnly += 1;
+        process.stderr.write(`akc: --only ${name}: not found in the migration plan\n`);
       }
     }
     plan = plan.filter((e) => opts.only.has(e.name));
   }
   const targets = plan.filter((e) => e.action === 'migrate');
+  const notMigratable = plan.filter(
+    (e) => e.action === 'unsupported-name' || e.action === 'ambiguous'
+  );
 
   out(`Migration plan (v1 → managed namespace "${MANAGED_SERVICE}"):\n`);
   for (const e of plan) out(`${planLine(e)}\n`);
-  out(`Plan: ${targets.length} to migrate, ${plan.length - targets.length} skipped.\n`);
+  out(
+    `Plan: ${targets.length} to migrate, ${plan.length - targets.length - notMigratable.length} skipped` +
+      (notMigratable.length ? `, ${notMigratable.length} cannot be migrated (see above)` : '') +
+      '.\n'
+  );
   out('Old items are never deleted — they stay in the Keychain untouched.\n');
 
+  const attention = notMigratable.length + missingOnly;
   if (opts.dryRun) {
     out('(dry-run) Nothing written.\n');
-    return 0;
+    return attention > 0 ? 1 : 0;
   }
   if (targets.length === 0) {
     out('Nothing to migrate.\n');
-    return 0;
+    return attention > 0 ? 1 : 0;
   }
   if (!opts.yes) {
     if (process.stdin.isTTY && process.stderr.isTTY) {
@@ -164,47 +264,75 @@ export async function cmdMigrate(argv) {
         return 1;
       }
     } else {
-      process.stderr.write('akc: refusing to migrate without confirmation on a non-interactive terminal — re-run with --yes\n');
+      process.stderr.write(
+        'akc: refusing to migrate without confirmation on a non-interactive terminal — re-run with --yes\n'
+      );
       return 1;
     }
   }
 
   const tally = { ok: 0, unsupported: 0, failed: 0 };
   const needsApproval = [];
-  for (const { name, source } of targets) {
-    if (opts.interactive) {
-      process.stderr.write(`⏳ ${name}: Keychain の許可ダイアログが出たら「常に許可」を選んでください…\n`);
-    }
-    const r = await readLegacyValue(name, source, opts.interactive ? INTERACTIVE_TIMEOUT_MS : SUBPROCESS_TIMEOUT_MS);
-    if (r.status === 'needs-approval') {
-      needsApproval.push(name);
-      out(`  ⚠️  ${name.padEnd(36)} needs-approval — 読み取りに Keychain の許可が必要です\n`);
-      continue;
-    }
-    if (r.status === 'not-found' || r.status === 'empty') {
-      tally.failed += 1;
-      out(`  ✖  ${name.padEnd(36)} ${r.status === 'empty' ? 'empty value in the old item' : 'old item disappeared'}\n`);
-      continue;
-    }
-    if (r.status === 'read-failed') {
-      tally.failed += 1;
-      out(`  ✖  ${name.padEnd(36)} read failed: ${r.detail || 'unknown error'}\n`);
-      continue;
-    }
-    try {
-      await setKey(name, r.value); // 検証（printable/長さ/読み戻し）と redact は setKey 側 (#191/#193)
-      tally.ok += 1;
-      out(`  ✅ ${name.padEnd(36)} migrated (${source})\n`);
-    } catch (err) {
-      if (!(err instanceof KeychainError)) throw err;
-      const msg = err.message.split('\n')[0];
-      if (/printable ASCII|character limit/.test(msg)) {
-        tally.unsupported += 1;
-        out(`  ✖  ${name.padEnd(36)} unsupported value: ${msg}\n`);
-      } else {
-        tally.failed += 1;
-        out(`  ✖  ${name.padEnd(36)} save failed: ${msg}\n`);
+  const timeoutMs = opts.interactive ? INTERACTIVE_TIMEOUT_MS : SUBPROCESS_TIMEOUT_MS;
+
+  for (const target of targets) {
+    const { name } = target;
+    // GUI 側の読み取りに失敗しても、manual 側にコピーがあればフォールバックする
+    // （#196 レビュー M4: 計画時に GUI 優先で固定すると、読めない GUI 項目の裏に
+    // ある読める manual 値へ到達する手段が無くなる）。
+    const sources = [target.source, ...(target.manualCopy ? ['manual'] : [])];
+    let done = false;
+    let sawNeedsApproval = false;
+    let lastFailureLine = null;
+    for (const source of sources) {
+      if (opts.interactive) {
+        process.stderr.write(
+          `waiting for ${name} (${source}): approve the Keychain dialog ("Always Allow") to continue...\n`
+        );
       }
+      const r = await readLegacyValue(name, source, timeoutMs);
+      if (r.status === 'ok') {
+        try {
+          await setKey(name, r.value); // printable/長さ/読み戻し検証と redact は setKey 側 (#191/#193)
+          const via = source === target.source ? source : `${source} fallback`;
+          out(`  ok  ${name.padEnd(36)} migrated (${via})\n`);
+          tally.ok += 1;
+          done = true;
+        } catch (err) {
+          if (!(err instanceof KeychainError)) throw err;
+          const msg = err.message.split('\n')[0];
+          if (/printable ASCII|character limit/.test(msg)) {
+            lastFailureLine = `  --  ${name.padEnd(36)} unsupported value: ${msg}\n`;
+            tally.unsupported += 1;
+            done = true; // 値そのものが対象外 — 別ソースを試しても同じ扱いにしない
+          } else {
+            lastFailureLine = `  NG  ${name.padEnd(36)} save failed: ${msg}\n`;
+            tally.failed += 1;
+            done = true;
+          }
+        }
+        break;
+      }
+      if (r.status === 'needs-approval') {
+        sawNeedsApproval = true;
+        continue; // 別ソースがあれば試す
+      }
+      lastFailureLine = `  NG  ${name.padEnd(36)} ${
+        r.status === 'read-failed'
+          ? `read failed (security exit ${r.code ?? 'unknown'})`
+          : FAILURE_TEXT[r.status]
+      }\n`;
+    }
+    if (done) {
+      if (lastFailureLine) out(lastFailureLine);
+      continue;
+    }
+    if (sawNeedsApproval) {
+      needsApproval.push(name);
+      out(`  !!  ${name.padEnd(36)} needs-approval — reading it requires a Keychain permission dialog\n`);
+    } else if (lastFailureLine) {
+      tally.failed += 1;
+      out(lastFailureLine);
     }
   }
 
@@ -214,9 +342,9 @@ export async function cmdMigrate(argv) {
   );
   if (needsApproval.length > 0) {
     out(
-      '次のコマンドで、許可ダイアログに応答しながら残りを移行できます:\n' +
+      'Re-run the remaining keys while answering the Keychain permission dialogs:\n' +
         `  akc migrate --interactive --only ${needsApproval.join(',')}\n`
     );
   }
-  return needsApproval.length + tally.unsupported + tally.failed > 0 ? 1 : 0;
+  return needsApproval.length + tally.unsupported + tally.failed + attention > 0 ? 1 : 0;
 }

--- a/cli/src/migrate.js
+++ b/cli/src/migrate.js
@@ -205,13 +205,16 @@ function parseArgs(argv) {
 
 const PLAN_LABELS = {
   'skip-managed': 'skip — already managed',
-  'skip-duplicate': 'skip — duplicate (the GUI store copy is used)',
+  'skip-duplicate': 'skip — duplicate (the GUI store copy is preferred)',
   'unsupported-name': 'cannot migrate — name not supported by v2 (re-register: akc set)',
   ambiguous: 'cannot migrate — multiple keychain items share this service (#91); re-register: akc set',
 };
+// unsupported-name の行だけは keychain 由来の未検証文字列が載るため、制御文字や
+// ANSI エスケープが端末に流れないよう印字可能 ASCII 以外を '?' に置換する (N4)。
+const printable = (name) => name.replace(/[^\x20-\x7e]/g, '?');
 const planLine = (e) => {
   const label = e.action === 'migrate' ? `migrate (${e.source})` : PLAN_LABELS[e.action];
-  return `  ${e.name.padEnd(36)} ${label}`;
+  return `  ${printable(e.name).padEnd(36)} ${label}`;
 };
 
 const FAILURE_TEXT = {
@@ -333,7 +336,9 @@ export async function cmdMigrate(argv) {
             };
     }
     if (migrated) continue; // 成功: 途中ソースの失敗は出力しない（矛盾行の防止）
-    if (sawNeedsApproval && !lastFailure) {
+    if (sawNeedsApproval) {
+      // fallback 側が失敗していても、許可ダイアログへの応答が実効的な回復手段
+      // なので needs-approval を優先して案内する（両レビュー一致指摘 N2）。
       needsApproval.push(name);
       out(`  !!  ${name.padEnd(36)} needs-approval — reading it requires a Keychain permission dialog\n`);
     } else if (lastFailure) {

--- a/cli/src/migrate.js
+++ b/cli/src/migrate.js
@@ -80,13 +80,19 @@ export function planMigration(records, { user } = {}) {
     }
   }
   const manual = new Set([...manualAccounts.keys()].filter((s) => !manualForeign.has(s)));
+  // フォールバックに使える manual コピー = account が一意なもののみ。複数 account
+  // (#91) は service-only read がどれを返すか不定なので、フォールバックでも使わない
+  // （Codex 再レビュー High: gui 重複側で曖昧さが skip-duplicate に隠れていた）。
+  const manualUnambiguous = new Set(
+    [...manual].filter((name) => manualAccounts.get(name).size === 1)
+  );
   const entries = [];
   for (const name of [...gui].sort()) {
     entries.push({
       name,
       source: 'gui',
       action: managed.has(name) ? 'skip-managed' : 'migrate',
-      manualCopy: manual.has(name),
+      manualCopy: manualUnambiguous.has(name),
     });
   }
   for (const name of [...guiBadName].sort()) {
@@ -158,9 +164,9 @@ async function readLegacyValue(name, source, timeoutMs) {
   }
 }
 
-function confirm(question) {
+export function confirm(question, { input = process.stdin, output = process.stderr } = {}) {
   return new Promise((resolve) => {
-    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const rl = createInterface({ input, output });
     let settled = false;
     const settle = (v) => {
       if (!settled) {
@@ -171,8 +177,10 @@ function confirm(question) {
     // EOF (Ctrl-D) では question のコールバックが呼ばれない — close をキャンセル扱いに。
     rl.on('close', () => settle(false));
     rl.question(question, (answer) => {
-      rl.close();
+      // rl.close() は同期的に 'close' を emit するため、先に settle しないと
+      // 肯定回答でも false が確定してしまう（Codex 再レビューで実証）。
       settle(/^y(es)?$/i.test(answer.trim()));
+      rl.close();
     });
   });
 }
@@ -281,9 +289,9 @@ export async function cmdMigrate(argv) {
     // （#196 レビュー M4: 計画時に GUI 優先で固定すると、読めない GUI 項目の裏に
     // ある読める manual 値へ到達する手段が無くなる）。
     const sources = [target.source, ...(target.manualCopy ? ['manual'] : [])];
-    let done = false;
+    let migrated = false;
     let sawNeedsApproval = false;
-    let lastFailureLine = null;
+    let lastFailure = null; // { line, kind: 'failed' | 'unsupported' }
     for (const source of sources) {
       if (opts.interactive) {
         process.stderr.write(
@@ -297,42 +305,40 @@ export async function cmdMigrate(argv) {
           const via = source === target.source ? source : `${source} fallback`;
           out(`  ok  ${name.padEnd(36)} migrated (${via})\n`);
           tally.ok += 1;
-          done = true;
+          migrated = true;
+          break;
         } catch (err) {
           if (!(err instanceof KeychainError)) throw err;
           const msg = err.message.split('\n')[0];
-          if (/printable ASCII|character limit/.test(msg)) {
-            lastFailureLine = `  --  ${name.padEnd(36)} unsupported value: ${msg}\n`;
-            tally.unsupported += 1;
-            done = true; // 値そのものが対象外 — 別ソースを試しても同じ扱いにしない
-          } else {
-            lastFailureLine = `  NG  ${name.padEnd(36)} save failed: ${msg}\n`;
-            tally.failed += 1;
-            done = true;
-          }
+          lastFailure = /printable ASCII|character limit/.test(msg)
+            ? { line: `  --  ${name.padEnd(36)} unsupported value: ${msg}\n`, kind: 'unsupported' }
+            : { line: `  NG  ${name.padEnd(36)} save failed: ${msg}\n`, kind: 'failed' };
+          continue; // 別ソースの値は異なり得るので試す
         }
-        break;
       }
       if (r.status === 'needs-approval') {
         sawNeedsApproval = true;
-        continue; // 別ソースがあれば試す
+        continue;
       }
-      lastFailureLine = `  NG  ${name.padEnd(36)} ${
-        r.status === 'read-failed'
-          ? `read failed (security exit ${r.code ?? 'unknown'})`
-          : FAILURE_TEXT[r.status]
-      }\n`;
+      lastFailure =
+        r.status === 'unsupported-encoding'
+          ? { line: `  --  ${name.padEnd(36)} ${FAILURE_TEXT[r.status]}\n`, kind: 'unsupported' }
+          : {
+              line: `  NG  ${name.padEnd(36)} ${
+                r.status === 'read-failed'
+                  ? `read failed (security exit ${r.code ?? 'unknown'})`
+                  : FAILURE_TEXT[r.status]
+              }\n`,
+              kind: 'failed',
+            };
     }
-    if (done) {
-      if (lastFailureLine) out(lastFailureLine);
-      continue;
-    }
-    if (sawNeedsApproval) {
+    if (migrated) continue; // 成功: 途中ソースの失敗は出力しない（矛盾行の防止）
+    if (sawNeedsApproval && !lastFailure) {
       needsApproval.push(name);
       out(`  !!  ${name.padEnd(36)} needs-approval — reading it requires a Keychain permission dialog\n`);
-    } else if (lastFailureLine) {
-      tally.failed += 1;
-      out(lastFailureLine);
+    } else if (lastFailure) {
+      tally[lastFailure.kind] += 1;
+      out(lastFailure.line);
     }
   }
 

--- a/cli/src/usage-guide.js
+++ b/cli/src/usage-guide.js
@@ -40,7 +40,8 @@ Secrets must NEVER be written to .env files, shell scripts, code, or commits.
 Every key lives in the **managed namespace** (\`com.aieo.aikeychain.managed\`,
 created by \`akc set\` or the AI KeyChain app). These resolve **silently** — no
 prompts, no hangs, ever. (v2.0 dropped the old v1.x GUI store / manual scheme;
-if you upgraded from v1.x, re-register your keys with \`akc set <KEY>\`.)
+if you upgraded from v1.x, bulk-migrate with \`akc migrate\` or re-register
+with \`akc set <KEY>\`.)
 
 ## Where keys live
 
@@ -55,6 +56,7 @@ if you upgraded from v1.x, re-register your keys with \`akc set <KEY>\`.)
   akc list                    list known key names (never prints values)
   akc check <KEY>             check whether a key exists and where
   akc set <KEY>               store/update a key (value via hidden prompt or stdin)
+  akc migrate                 bulk-migrate v1.x keys into the managed namespace
   akc delete <KEY>            delete a key
   akc doctor                  diagnose env + ~/.zshrc keychain references
   akc mcp                     start the MCP server (stdio)

--- a/cli/test/migrate.test.js
+++ b/cli/test/migrate.test.js
@@ -59,6 +59,11 @@ case "$cmd" in
     emit "$USER" DUP_K
     emit "$USER" AMBIG_M
     emit AMBIG_M AMBIG_M
+    emit FALLBACK_H com.aieo.aikeychain
+    emit "$USER" FALLBACK_H
+    emit DUPAMB_I com.aieo.aikeychain
+    emit "$USER" DUPAMB_I
+    emit DUPAMB_I DUPAMB_I
     emit "/Users/x/.ssh/id_ed25519" SSH
     emit account com.apple.NetworkExtension
     emit account iCloud
@@ -88,6 +93,8 @@ case "$cmd" in
         READFAIL_G)
           echo "diagnostic leaking secret-sentinel-XYZ" >&2; exit 3 ;;
         HANG_B) sleep 60 ;;
+        FALLBACK_H) sleep 60 ;;
+        DUPAMB_I) sleep 60 ;;
         *) echo "could not be found" >&2; exit 44 ;;
       esac
     fi
@@ -95,6 +102,8 @@ case "$cmd" in
       MIG_C) $w && echo "value-of-MIG_C"; exit 0 ;;
       DUP_K) $w && echo "manual-value-of-DUP_K"; exit 0 ;;
       AMBIG_M) $w && echo "arbitrary-of-AMBIG_M"; exit 0 ;;
+      FALLBACK_H) $w && echo "manual-copy-of-FALLBACK_H"; exit 0 ;;
+      DUPAMB_I) $w && echo "arbitrary-of-DUPAMB_I"; exit 0 ;;
       SSH) echo "must never be read" >&2; exit 97 ;;
     esac
     echo "could not be found" >&2; exit 44 ;;
@@ -169,7 +178,14 @@ test('migrate --yes: gui+manual, gui wins dups, hex/binary handling, no value le
   assert.equal(await state('SSH'), null);
   assert.match(r.stdout, /HANG_B/);
   assert.match(r.stdout, /needs-approval/);
-  assert.match(r.stdout, /--interactive --only HANG_B/);
+  // GUI 側が読めない場合、一意な manual コピーがあればフォールバックで移行する
+  assert.equal(await state('FALLBACK_H'), 'manual-copy-of-FALLBACK_H');
+  assert.match(r.stdout, /FALLBACK_H.*manual fallback/);
+  assert.doesNotMatch(r.stdout, /FALLBACK_H.*(needs-approval|NG)/); // 成功時に矛盾する失敗行を出さない
+  // manual 側が #91 の複数 account ならフォールバックに使わない（不定値の混入防止）
+  assert.equal(await state('DUPAMB_I'), null);
+  assert.match(r.stdout, /DUPAMB_I.*needs-approval/);
+  assert.match(r.stdout, /--interactive --only .*HANG_B/);
   // 生値・エンコード値はどこにも出ない
   assert.doesNotMatch(r.stdout + r.stderr, /value-of-|gui-value|manual-value|arbitrary-of|6361660a|caf\\né/i);
   // 旧アイテムを削除しない
@@ -177,11 +193,12 @@ test('migrate --yes: gui+manual, gui wins dups, hex/binary handling, no value le
 });
 
 test('migrate is idempotent: a second full run migrates nothing new (#196)', async () => {
+  await rm(join(stubDir, 'state-MIG_A'), { force: true }); // 前テストの状態に依存しない
   const first = await runMigrate(['--yes']);
+  assert.notEqual((first.stdout.match(/migrated=(\d+)/) ?? [])[1], '0', first.stdout);
   const second = await runMigrate(['--yes']);
   assert.match(second.stdout, /MIG_A.*(skip|managed)/i);
   assert.match(second.stdout, /MIG_C.*(skip|managed)/i);
-  assert.ok(/migrated=\d+/.test(first.stdout), first.stdout);
   assert.equal((second.stdout.match(/migrated=(\d+)/) ?? [])[1], '0', 'second run must migrate 0 keys');
 });
 

--- a/cli/test/migrate.test.js
+++ b/cli/test/migrate.test.js
@@ -1,0 +1,151 @@
+// `akc migrate` (#196): v1 の旧 GUI store / manual スキームを managed へ一括移行。
+// stub security で検出・GUI 優先・needs-approval・dry-run・冪等を固定する。
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, chmod, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pExecFile = promisify(execFile);
+const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js');
+
+let stubDir;
+
+// dump-keychain: managed(EXISTING_KEY) + 旧 GUI store(MIG_A / HANG_B / EXISTING_KEY / DUP_K)
+// + manual(MIG_C / DUP_K) + ノイズ(com.apple.NetworkExtension, iCloud, lowercase-svc)。
+// find: 旧 GUI の HANG_B は sleep で ACL プロンプト待ちを模擬（テストは短い
+// AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS で timeout → needs-approval 分類を確認する）。
+const STUB = `#!/bin/bash
+state_dir="$(cd "$(dirname "$0")" && pwd)"
+if [ "$1" = "-i" ]; then
+  read -r line
+  case "$line" in
+    add-generic-password*-s\\ \\"com.aieo.aikeychain.managed\\"*-X\\ *)
+      acct=$(printf '%s' "$line" | sed -n 's/.*-a "\\([^"]*\\)".*/\\1/p')
+      printf '%s' "\${line##* }" | xxd -r -p > "$state_dir/state-$acct"
+      exit 0 ;;
+    *) echo "stub -i: unexpected: $line" >&2; exit 1 ;;
+  esac
+fi
+cmd="$1"; shift
+svc=""; acct=""; w=false
+while [ $# -gt 0 ]; do case "$1" in
+  -s) svc="$2"; shift 2 ;; -a) acct="$2"; shift 2 ;; -w) w=true; shift ;; *) shift ;;
+esac; done
+case "$cmd" in
+  dump-keychain)
+    emit() { printf 'keychain: "L"\\nclass: "genp"\\nattributes:\\n    "acct"<blob>="%s"\\n    "svce"<blob>="%s"\\n' "$1" "$2"; }
+    emit EXISTING_KEY com.aieo.aikeychain.managed
+    for f in "$state_dir"/state-*; do
+      [ -e "$f" ] || continue
+      emit "\${f##*/state-}" com.aieo.aikeychain.managed
+    done
+    emit MIG_A com.aieo.aikeychain
+    emit HANG_B com.aieo.aikeychain
+    emit EXISTING_KEY com.aieo.aikeychain
+    emit DUP_K com.aieo.aikeychain
+    emit "" com.aieo.aikeychain
+    emit "$USER" MIG_C
+    emit "$USER" DUP_K
+    emit account com.apple.NetworkExtension
+    emit account iCloud
+    emit account lowercase_svc
+    exit 0 ;;
+  find-generic-password)
+    if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
+      [ -e "$state_dir/state-$acct" ] || { echo "could not be found" >&2; exit 44; }
+      $w && cat "$state_dir/state-$acct" && echo; exit 0
+    fi
+    if [ "$svc" = "com.aieo.aikeychain" ]; then
+      case "$acct" in
+        MIG_A) $w && echo "value-of-MIG_A"; exit 0 ;;
+        DUP_K) $w && echo "gui-value-of-DUP_K"; exit 0 ;;
+        HANG_B) sleep 60 ;;
+        *) echo "could not be found" >&2; exit 44 ;;
+      esac
+    fi
+    case "$svc" in
+      MIG_C) $w && echo "value-of-MIG_C"; exit 0 ;;
+      DUP_K) $w && echo "manual-value-of-DUP_K"; exit 0 ;;
+    esac
+    echo "could not be found" >&2; exit 44 ;;
+  delete-generic-password) exit 44 ;;
+  *) echo "stub: unexpected $cmd" >&2; exit 1 ;;
+esac
+`;
+
+before(async () => {
+  stubDir = await mkdtemp(join(tmpdir(), 'akc-migrate-'));
+  const stub = join(stubDir, 'security');
+  await writeFile(stub, STUB);
+  await chmod(stub, 0o755);
+});
+
+const runMigrate = (args) =>
+  pExecFile(process.execPath, [AKC, 'migrate', ...args], {
+    env: {
+      PATH: process.env.PATH,
+      AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security'),
+      AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS: '1500',
+    },
+  }).then(
+    (r) => ({ code: 0, ...r }),
+    (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
+  );
+
+test('migrate --dry-run prints the plan and writes nothing (#196)', async () => {
+  const r = await runMigrate(['--dry-run']);
+  assert.equal(r.code, 0, r.stderr);
+  assert.match(r.stdout, /MIG_A/);
+  assert.match(r.stdout, /MIG_C/);
+  // GUI 優先: manual 側 DUP_K は duplicate skip
+  assert.match(r.stdout, /DUP_K.*(dup|duplicate|GUI)/i);
+  // managed 済みは skip
+  assert.match(r.stdout, /EXISTING_KEY.*(skip|managed)/i);
+  // ノイズ service はそもそも出ない
+  assert.doesNotMatch(r.stdout, /NetworkExtension|iCloud|lowercase_svc/);
+  const written = await readFile(join(stubDir, 'state-MIG_A'), 'utf8').catch(() => null);
+  assert.equal(written, null, 'dry-run must not write');
+});
+
+test('migrate --yes migrates gui+manual, gui wins duplicates, hang -> needs-approval (#196)', async () => {
+  const r = await runMigrate(['--yes']);
+  // needs-approval が残るので exit 1（未完了の合図）
+  assert.equal(r.code, 1, r.stdout + r.stderr);
+  assert.equal(await readFile(join(stubDir, 'state-MIG_A'), 'utf8'), 'value-of-MIG_A');
+  assert.equal(await readFile(join(stubDir, 'state-MIG_C'), 'utf8'), 'value-of-MIG_C');
+  assert.equal(await readFile(join(stubDir, 'state-DUP_K'), 'utf8'), 'gui-value-of-DUP_K');
+  assert.match(r.stdout, /HANG_B/);
+  assert.match(r.stdout, /needs-approval|許可/);
+  assert.match(r.stdout, /--interactive --only HANG_B/);
+  // 値・hex はどこにも出ない
+  assert.doesNotMatch(r.stdout + r.stderr, /value-of-|gui-value|manual-value|76616c/);
+});
+
+test('migrate is idempotent: second run skips everything migrated (#196)', async () => {
+  const r = await runMigrate(['--yes']);
+  assert.match(r.stdout, /MIG_A.*(skip|managed)/i);
+  assert.match(r.stdout, /MIG_C.*(skip|managed)/i);
+});
+
+test('migrate --only filters targets (#196)', async () => {
+  await rm(join(stubDir, 'state-MIG_A'), { force: true });
+  await rm(join(stubDir, 'state-MIG_C'), { force: true });
+  const r = await runMigrate(['--yes', '--only', 'MIG_A']);
+  assert.equal(r.code, 0, r.stdout + r.stderr);
+  assert.equal(await readFile(join(stubDir, 'state-MIG_A'), 'utf8'), 'value-of-MIG_A');
+  const c = await readFile(join(stubDir, 'state-MIG_C'), 'utf8').catch(() => null);
+  assert.equal(c, null, '--only で絞ったキー以外は書かない');
+});
+
+test('migrate without --yes on a non-TTY refuses to write (#196)', async () => {
+  await rm(join(stubDir, 'state-MIG_C'), { force: true });
+  const r = await runMigrate([]);
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /--yes/);
+  const c = await readFile(join(stubDir, 'state-MIG_C'), 'utf8').catch(() => null);
+  assert.equal(c, null);
+});

--- a/cli/test/migrate.test.js
+++ b/cli/test/migrate.test.js
@@ -64,6 +64,8 @@ case "$cmd" in
     emit DUPAMB_I com.aieo.aikeychain
     emit "$USER" DUPAMB_I
     emit DUPAMB_I DUPAMB_I
+    emit FBFAIL_J com.aieo.aikeychain
+    emit "$USER" FBFAIL_J
     emit "/Users/x/.ssh/id_ed25519" SSH
     emit account com.apple.NetworkExtension
     emit account iCloud
@@ -95,6 +97,7 @@ case "$cmd" in
         HANG_B) sleep 60 ;;
         FALLBACK_H) sleep 60 ;;
         DUPAMB_I) sleep 60 ;;
+        FBFAIL_J) sleep 60 ;;
         *) echo "could not be found" >&2; exit 44 ;;
       esac
     fi
@@ -104,6 +107,7 @@ case "$cmd" in
       AMBIG_M) $w && echo "arbitrary-of-AMBIG_M"; exit 0 ;;
       FALLBACK_H) $w && echo "manual-copy-of-FALLBACK_H"; exit 0 ;;
       DUPAMB_I) $w && echo "arbitrary-of-DUPAMB_I"; exit 0 ;;
+      FBFAIL_J) echo "boom secret-sentinel-J" >&2; exit 3 ;;
       SSH) echo "must never be read" >&2; exit 97 ;;
     esac
     echo "could not be found" >&2; exit 44 ;;
@@ -185,7 +189,12 @@ test('migrate --yes: gui+manual, gui wins dups, hex/binary handling, no value le
   // manual 側が #91 の複数 account ならフォールバックに使わない（不定値の混入防止）
   assert.equal(await state('DUPAMB_I'), null);
   assert.match(r.stdout, /DUPAMB_I.*needs-approval/);
+  // GUI タイムアウト + fallback 失敗でも needs-approval を失わない（両レビュー N2）
+  assert.equal(await state('FBFAIL_J'), null);
+  assert.match(r.stdout, /FBFAIL_J.*needs-approval/);
   assert.match(r.stdout, /--interactive --only .*HANG_B/);
+  assert.match(r.stdout, /--interactive --only .*FBFAIL_J/);
+  assert.doesNotMatch(r.stdout + r.stderr, /secret-sentinel-J/);
   // 生値・エンコード値はどこにも出ない
   assert.doesNotMatch(r.stdout + r.stderr, /value-of-|gui-value|manual-value|arbitrary-of|6361660a|caf\\né/i);
   // 旧アイテムを削除しない

--- a/cli/test/migrate.test.js
+++ b/cli/test/migrate.test.js
@@ -1,6 +1,6 @@
 // `akc migrate` (#196): v1 の旧 GUI store / manual スキームを managed へ一括移行。
-// stub security で検出・GUI 優先・needs-approval・dry-run・冪等を固定する。
-import { test, before } from 'node:test';
+// stub security で検出・GUI 優先・needs-approval・hex 判別・dry-run・冪等を固定する。
+import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -14,10 +14,13 @@ const AKC = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'akc.js')
 
 let stubDir;
 
-// dump-keychain: managed(EXISTING_KEY) + 旧 GUI store(MIG_A / HANG_B / EXISTING_KEY / DUP_K)
-// + manual(MIG_C / DUP_K) + ノイズ(com.apple.NetworkExtension, iCloud, lowercase-svc)。
-// find: 旧 GUI の HANG_B は sleep で ACL プロンプト待ちを模擬（テストは短い
-// AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS で timeout → needs-approval 分類を確認する）。
+// dump-keychain の内容:
+//   managed: EXISTING_KEY（+ 移行で書かれた state ファイル）
+//   旧 GUI store: MIG_A / HANG_B(ACL 待ち) / EXISTING_KEY / DUP_K / HEXBIN_E(非印字値)
+//                 / HEXLIT_F(値そのものが hex 文字列) / READFAIL_G(read 失敗+stderr に値)
+//                 / "bad name!"(v2 名前文法外)
+//   manual: MIG_C / DUP_K / AMBIG_M(account 2 種 = #91 重複) / SSH(他アプリ: account がパス)
+//   ノイズ: com.apple.NetworkExtension / iCloud / lowercase_svc
 const STUB = `#!/bin/bash
 state_dir="$(cd "$(dirname "$0")" && pwd)"
 if [ "$1" = "-i" ]; then
@@ -31,9 +34,9 @@ if [ "$1" = "-i" ]; then
   esac
 fi
 cmd="$1"; shift
-svc=""; acct=""; w=false
+svc=""; acct=""; w=false; g=false
 while [ $# -gt 0 ]; do case "$1" in
-  -s) svc="$2"; shift 2 ;; -a) acct="$2"; shift 2 ;; -w) w=true; shift ;; *) shift ;;
+  -s) svc="$2"; shift 2 ;; -a) acct="$2"; shift 2 ;; -w) w=true; shift ;; -g) g=true; shift ;; *) shift ;;
 esac; done
 case "$cmd" in
   dump-keychain)
@@ -47,13 +50,22 @@ case "$cmd" in
     emit HANG_B com.aieo.aikeychain
     emit EXISTING_KEY com.aieo.aikeychain
     emit DUP_K com.aieo.aikeychain
+    emit HEXBIN_E com.aieo.aikeychain
+    emit HEXLIT_F com.aieo.aikeychain
+    emit READFAIL_G com.aieo.aikeychain
+    emit "bad name!" com.aieo.aikeychain
     emit "" com.aieo.aikeychain
     emit "$USER" MIG_C
     emit "$USER" DUP_K
+    emit "$USER" AMBIG_M
+    emit AMBIG_M AMBIG_M
+    emit "/Users/x/.ssh/id_ed25519" SSH
     emit account com.apple.NetworkExtension
     emit account iCloud
     emit account lowercase_svc
     exit 0 ;;
+  delete-generic-password)
+    echo "delete $svc|$acct" >> "$state_dir/deletes.log"; exit 44 ;;
   find-generic-password)
     if [ "$svc" = "com.aieo.aikeychain.managed" ]; then
       [ -e "$state_dir/state-$acct" ] || { echo "could not be found" >&2; exit 44; }
@@ -63,6 +75,18 @@ case "$cmd" in
       case "$acct" in
         MIG_A) $w && echo "value-of-MIG_A"; exit 0 ;;
         DUP_K) $w && echo "gui-value-of-DUP_K"; exit 0 ;;
+        HEXBIN_E)
+          # 非印字値: -w は無印 hex、-g は stderr に password: 0x...
+          $w && { echo "6361660ac3a9"; exit 0; }
+          $g && { echo 'password: 0x6361660AC3A9  "caf\\né"' >&2; exit 0; }
+          exit 0 ;;
+        HEXLIT_F)
+          # 値そのものが hex 文字列: -g は stderr に password: "..."
+          $w && { echo "4142434445464748"; exit 0; }
+          $g && { echo 'password: "4142434445464748"' >&2; exit 0; }
+          exit 0 ;;
+        READFAIL_G)
+          echo "diagnostic leaking secret-sentinel-XYZ" >&2; exit 3 ;;
         HANG_B) sleep 60 ;;
         *) echo "could not be found" >&2; exit 44 ;;
       esac
@@ -70,9 +94,10 @@ case "$cmd" in
     case "$svc" in
       MIG_C) $w && echo "value-of-MIG_C"; exit 0 ;;
       DUP_K) $w && echo "manual-value-of-DUP_K"; exit 0 ;;
+      AMBIG_M) $w && echo "arbitrary-of-AMBIG_M"; exit 0 ;;
+      SSH) echo "must never be read" >&2; exit 97 ;;
     esac
     echo "could not be found" >&2; exit 44 ;;
-  delete-generic-password) exit 44 ;;
   *) echo "stub: unexpected $cmd" >&2; exit 1 ;;
 esac
 `;
@@ -82,12 +107,20 @@ before(async () => {
   const stub = join(stubDir, 'security');
   await writeFile(stub, STUB);
   await chmod(stub, 0o755);
+  // 初回 exec は Gatekeeper スキャン等で 1 秒超かかることがあり、並列実行時に
+  // 短い AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS を食い潰す — ここで一度温めておく。
+  await pExecFile(stub, ['dump-keychain']);
+});
+
+after(async () => {
+  await rm(stubDir, { recursive: true, force: true });
 });
 
 const runMigrate = (args) =>
   pExecFile(process.execPath, [AKC, 'migrate', ...args], {
     env: {
       PATH: process.env.PATH,
+      USER: process.env.USER,
       AIKEYCHAIN_SECURITY_BIN: join(stubDir, 'security'),
       AIKEYCHAIN_SUBPROCESS_TIMEOUT_MS: '1500',
     },
@@ -96,39 +129,60 @@ const runMigrate = (args) =>
     (e) => ({ code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' })
   );
 
+const state = (name) => readFile(join(stubDir, `state-${name}`), 'utf8').catch(() => null);
+
 test('migrate --dry-run prints the plan and writes nothing (#196)', async () => {
   const r = await runMigrate(['--dry-run']);
-  assert.equal(r.code, 0, r.stderr);
+  // unsupported-name("bad name!") と ambiguous(AMBIG_M) が残るため exit 1（要対応の合図）
+  assert.equal(r.code, 1, r.stdout + r.stderr);
   assert.match(r.stdout, /MIG_A/);
   assert.match(r.stdout, /MIG_C/);
-  // GUI 優先: manual 側 DUP_K は duplicate skip
   assert.match(r.stdout, /DUP_K.*(dup|duplicate|GUI)/i);
-  // managed 済みは skip
   assert.match(r.stdout, /EXISTING_KEY.*(skip|managed)/i);
-  // ノイズ service はそもそも出ない
+  // 旧 v1 が許した名前は黙って落とさず可視化する
+  assert.match(r.stdout, /bad name!.*name not supported/);
+  // #91 の acct 重複は移行しない
+  assert.match(r.stdout, /AMBIG_M.*(ambiguous|multiple|#91)/i);
+  // 他アプリの service（大文字でも account がパス）は列挙すらしない
+  assert.doesNotMatch(r.stdout, /SSH/);
   assert.doesNotMatch(r.stdout, /NetworkExtension|iCloud|lowercase_svc/);
-  const written = await readFile(join(stubDir, 'state-MIG_A'), 'utf8').catch(() => null);
-  assert.equal(written, null, 'dry-run must not write');
+  assert.equal(await state('MIG_A'), null, 'dry-run must not write');
 });
 
-test('migrate --yes migrates gui+manual, gui wins duplicates, hang -> needs-approval (#196)', async () => {
+test('migrate --yes: gui+manual, gui wins dups, hex/binary handling, no value leaks (#196)', async () => {
   const r = await runMigrate(['--yes']);
-  // needs-approval が残るので exit 1（未完了の合図）
-  assert.equal(r.code, 1, r.stdout + r.stderr);
-  assert.equal(await readFile(join(stubDir, 'state-MIG_A'), 'utf8'), 'value-of-MIG_A');
-  assert.equal(await readFile(join(stubDir, 'state-MIG_C'), 'utf8'), 'value-of-MIG_C');
-  assert.equal(await readFile(join(stubDir, 'state-DUP_K'), 'utf8'), 'gui-value-of-DUP_K');
+  assert.equal(r.code, 1, r.stdout + r.stderr); // HANG_B(needs-approval) 等が残る
+  assert.equal(await state('MIG_A'), 'value-of-MIG_A');
+  assert.equal(await state('MIG_C'), 'value-of-MIG_C');
+  assert.equal(await state('DUP_K'), 'gui-value-of-DUP_K');
+  // 値そのものが hex 文字列 → そのまま移行（hex 推測復号はしない / #179 系）
+  assert.equal(await state('HEXLIT_F'), '4142434445464748');
+  // 非印字値（-w が hex を出すケース）→ 移行せず unsupported（黙った破損の防止）
+  assert.equal(await state('HEXBIN_E'), null);
+  assert.match(r.stdout, /HEXBIN_E.*(not printable|non-ASCII|akc set)/);
+  // read 失敗は security stderr を転送しない（exit code のみ）
+  assert.equal(await state('READFAIL_G'), null);
+  assert.match(r.stdout, /READFAIL_G.*read failed \(security exit 3\)/);
+  assert.doesNotMatch(r.stdout + r.stderr, /secret-sentinel-XYZ/);
+  // ambiguous / 他アプリは書かれない
+  assert.equal(await state('AMBIG_M'), null);
+  assert.equal(await state('SSH'), null);
   assert.match(r.stdout, /HANG_B/);
-  assert.match(r.stdout, /needs-approval|許可/);
+  assert.match(r.stdout, /needs-approval/);
   assert.match(r.stdout, /--interactive --only HANG_B/);
-  // 値・hex はどこにも出ない
-  assert.doesNotMatch(r.stdout + r.stderr, /value-of-|gui-value|manual-value|76616c/);
+  // 生値・エンコード値はどこにも出ない
+  assert.doesNotMatch(r.stdout + r.stderr, /value-of-|gui-value|manual-value|arbitrary-of|6361660a|caf\\né/i);
+  // 旧アイテムを削除しない
+  assert.equal(await readFile(join(stubDir, 'deletes.log'), 'utf8').catch(() => null), null);
 });
 
-test('migrate is idempotent: second run skips everything migrated (#196)', async () => {
-  const r = await runMigrate(['--yes']);
-  assert.match(r.stdout, /MIG_A.*(skip|managed)/i);
-  assert.match(r.stdout, /MIG_C.*(skip|managed)/i);
+test('migrate is idempotent: a second full run migrates nothing new (#196)', async () => {
+  const first = await runMigrate(['--yes']);
+  const second = await runMigrate(['--yes']);
+  assert.match(second.stdout, /MIG_A.*(skip|managed)/i);
+  assert.match(second.stdout, /MIG_C.*(skip|managed)/i);
+  assert.ok(/migrated=\d+/.test(first.stdout), first.stdout);
+  assert.equal((second.stdout.match(/migrated=(\d+)/) ?? [])[1], '0', 'second run must migrate 0 keys');
 });
 
 test('migrate --only filters targets (#196)', async () => {
@@ -136,9 +190,22 @@ test('migrate --only filters targets (#196)', async () => {
   await rm(join(stubDir, 'state-MIG_C'), { force: true });
   const r = await runMigrate(['--yes', '--only', 'MIG_A']);
   assert.equal(r.code, 0, r.stdout + r.stderr);
-  assert.equal(await readFile(join(stubDir, 'state-MIG_A'), 'utf8'), 'value-of-MIG_A');
-  const c = await readFile(join(stubDir, 'state-MIG_C'), 'utf8').catch(() => null);
-  assert.equal(c, null, '--only で絞ったキー以外は書かない');
+  assert.equal(await state('MIG_A'), 'value-of-MIG_A');
+  assert.equal(await state('MIG_C'), null, '--only で絞ったキー以外は書かない');
+});
+
+test('migrate --only with an unmatched name exits 1, not a silent no-op (#196)', async () => {
+  const r = await runMigrate(['--yes', '--only', 'TYPO_KEY']);
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /TYPO_KEY.*not found/);
+});
+
+test('migrate rejects malformed --only values and unknown flags (#196)', async () => {
+  for (const args of [['--only'], ['--only', ','], ['--only', '--yes'], ['--frobnicate']]) {
+    const r = await runMigrate(args);
+    assert.equal(r.code, 1, JSON.stringify(args));
+    assert.match(r.stderr, /Usage: akc migrate/);
+  }
 });
 
 test('migrate without --yes on a non-TTY refuses to write (#196)', async () => {
@@ -146,6 +213,5 @@ test('migrate without --yes on a non-TTY refuses to write (#196)', async () => {
   const r = await runMigrate([]);
   assert.equal(r.code, 1);
   assert.match(r.stderr, /--yes/);
-  const c = await readFile(join(stubDir, 'state-MIG_C'), 'utf8').catch(() => null);
-  assert.equal(c, null);
+  assert.equal(await state('MIG_C'), null);
 });

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -162,3 +162,30 @@ test('redactSecrets redacts bare hex runs, not only "-X <hex>" (#191)', () => {
   // short numeric diagnostics survive
   assert.equal(redactSecrets('exit 44: item not found'), 'exit 44: item not found');
 });
+
+// #196: planMigration — dump 属性からの検出分類（値は読まない・純関数）
+test('planMigration classifies gui/manual, gui wins duplicates, noise excluded (#196)', async () => {
+  const { planMigration, MANUAL_NAME_PATTERN, LEGACY_GUI_SERVICE } = await import('../src/migrate.js');
+  assert.equal(LEGACY_GUI_SERVICE, 'com.aieo.aikeychain');
+  // v1 と同一の厳格 manual 判定 (#160/#163): 大文字スネークケース限定
+  assert.ok(MANUAL_NAME_PATTERN.test('GITHUB_TOKEN'));
+  assert.ok(!MANUAL_NAME_PATTERN.test('iCloud'));
+  assert.ok(!MANUAL_NAME_PATTERN.test('com.apple.NetworkExtension'));
+  const plan = planMigration([
+    { service: 'com.aieo.aikeychain.managed', account: 'DONE' },
+    { service: 'com.aieo.aikeychain', account: 'DONE' },
+    { service: 'com.aieo.aikeychain', account: 'A_KEY' },
+    { service: 'com.aieo.aikeychain', account: '' },
+    { service: 'com.aieo.aikeychain', account: 'bad name!' },
+    { service: 'M_KEY', account: 'user' },
+    { service: 'A_KEY', account: 'user' },      // gui と重複 → gui 優先
+    { service: 'iCloud', account: 'user' },
+    { service: null, account: 'x' },
+  ]);
+  const byName = Object.fromEntries(plan.map((e) => [`${e.name}:${e.source}`, e.action]));
+  assert.equal(byName['A_KEY:gui'], 'migrate');
+  assert.equal(byName['DONE:gui'], 'skip-managed');
+  assert.equal(byName['A_KEY:manual'], 'skip-duplicate');
+  assert.equal(byName['M_KEY:manual'], 'migrate');
+  assert.ok(!plan.some((e) => e.name === 'iCloud' || e.name === 'bad name!' || e.name === ''));
+});

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -171,21 +171,35 @@ test('planMigration classifies gui/manual, gui wins duplicates, noise excluded (
   assert.ok(MANUAL_NAME_PATTERN.test('GITHUB_TOKEN'));
   assert.ok(!MANUAL_NAME_PATTERN.test('iCloud'));
   assert.ok(!MANUAL_NAME_PATTERN.test('com.apple.NetworkExtension'));
-  const plan = planMigration([
-    { service: 'com.aieo.aikeychain.managed', account: 'DONE' },
-    { service: 'com.aieo.aikeychain', account: 'DONE' },
-    { service: 'com.aieo.aikeychain', account: 'A_KEY' },
-    { service: 'com.aieo.aikeychain', account: '' },
-    { service: 'com.aieo.aikeychain', account: 'bad name!' },
-    { service: 'M_KEY', account: 'user' },
-    { service: 'A_KEY', account: 'user' },      // gui と重複 → gui 優先
-    { service: 'iCloud', account: 'user' },
-    { service: null, account: 'x' },
-  ]);
+  const plan = planMigration(
+    [
+      { service: 'com.aieo.aikeychain.managed', account: 'DONE' },
+      { service: 'com.aieo.aikeychain', account: 'DONE' },
+      { service: 'com.aieo.aikeychain', account: 'A_KEY' },
+      { service: 'com.aieo.aikeychain', account: '' },
+      { service: 'com.aieo.aikeychain', account: 'bad name!' },
+      { service: 'M_KEY', account: 'user' },
+      { service: 'A_KEY', account: 'user' },      // gui と重複 → gui 優先
+      { service: 'AMBIG', account: 'user' },      // #91: 同一 service に複数 account
+      { service: 'AMBIG', account: 'AMBIG' },
+      { service: 'SSH', account: '/Users/x/.ssh/id_ed25519' }, // 他アプリ: account がパス
+      { service: 'iCloud', account: 'user' },
+      { service: null, account: 'x' },
+    ],
+    { user: 'user' }
+  );
   const byName = Object.fromEntries(plan.map((e) => [`${e.name}:${e.source}`, e.action]));
   assert.equal(byName['A_KEY:gui'], 'migrate');
   assert.equal(byName['DONE:gui'], 'skip-managed');
   assert.equal(byName['A_KEY:manual'], 'skip-duplicate');
   assert.equal(byName['M_KEY:manual'], 'migrate');
-  assert.ok(!plan.some((e) => e.name === 'iCloud' || e.name === 'bad name!' || e.name === ''));
+  // gui と manual 両方にあるキーは manualCopy フラグでフォールバック可能に
+  assert.equal(plan.find((e) => e.name === 'A_KEY' && e.source === 'gui').manualCopy, true);
+  assert.equal(plan.find((e) => e.name === 'M_KEY').manualCopy, undefined);
+  // 名前文法外の旧 GUI account は黙って落とさない（unsupported-name として可視化）
+  assert.equal(byName['bad name!:gui'], 'unsupported-name');
+  // #91 の acct 重複 → ambiguous（読まない・書かない）
+  assert.equal(byName['AMBIG:manual'], 'ambiguous');
+  // 他アプリ由来（account がパス等）は列挙しない
+  assert.ok(!plan.some((e) => e.name === 'SSH' || e.name === 'iCloud' || e.name === ''));
 });

--- a/cli/test/unit.test.js
+++ b/cli/test/unit.test.js
@@ -202,4 +202,33 @@ test('planMigration classifies gui/manual, gui wins duplicates, noise excluded (
   assert.equal(byName['AMBIG:manual'], 'ambiguous');
   // 他アプリ由来（account がパス等）は列挙しない
   assert.ok(!plan.some((e) => e.name === 'SSH' || e.name === 'iCloud' || e.name === ''));
+  // gui 重複の manual 側が #91 の複数 account ならフォールバックにも使わない
+  const plan2 = planMigration(
+    [
+      { service: 'com.aieo.aikeychain', account: 'D_KEY' },
+      { service: 'D_KEY', account: 'user' },
+      { service: 'D_KEY', account: 'D_KEY' },
+    ],
+    { user: 'user' }
+  );
+  assert.equal(plan2.find((e) => e.name === 'D_KEY' && e.source === 'gui').manualCopy, false);
+});
+
+// #196 再レビュー: confirm() は肯定回答で true・EOF で false（close の同期 emit に負けない）
+test('confirm settles from the answer, not the synchronous close event (#196)', async () => {
+  const { PassThrough } = await import('node:stream');
+  const { confirm } = await import('../src/migrate.js');
+  const ask = (chunks) => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.resume();
+    const p = confirm('go? ', { input, output });
+    for (const c of chunks) input.write(c);
+    input.end();
+    return p;
+  };
+  assert.equal(await ask(['y\n']), true);
+  assert.equal(await ask(['YES\n']), true);
+  assert.equal(await ask(['n\n']), false);
+  assert.equal(await ask([]), false); // EOF (Ctrl-D)
 });

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -123,7 +123,7 @@ sequenceDiagram
     Child->>API: curl -H "x-api-key: $ANTHROPIC_API_KEY"
 ```
 
-> **単一 namespace ルックアップ（`resolveKey` / v2.0 #188）**: `-s "com.aieo.aikeychain.managed" -a "<KEY>"` のみ。security 所有なのでヘッドレス読取はプロンプト/ハングしない。exit 44 (not found) は `null`、それ以外の失敗は権威的として fail-closed（#147/#150）。npm CLI（`cli/src/keychain.js`）と `scripts/akc` は同一手順。旧 v1.x の GUI ストア / manual スキームは読まない（旧ユーザーはキーを再登録する）。
+> **単一 namespace ルックアップ（`resolveKey` / v2.0 #188）**: `-s "com.aieo.aikeychain.managed" -a "<KEY>"` のみ。security 所有なのでヘッドレス読取はプロンプト/ハングしない。exit 44 (not found) は `null`、それ以外の失敗は権威的として fail-closed（#147/#150）。npm CLI（`cli/src/keychain.js`）と `scripts/akc` は同一手順。旧 v1.x の GUI ストア / manual スキームは読まない（旧ユーザーは `akc migrate` で一括引き継ぎ（または `akc set` で再登録）する）。
 
 ### AI エージェント経由 (MCP + akc run)
 

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -22,8 +22,9 @@ npx aikeychain <command>
 | `akc check <KEY>` | キーの存在確認（managed namespace） |
 | `akc get <KEY>` | `keychain://<KEY>` 参照を出力（`--reveal` で生値） |
 | `akc set <KEY>` | キー登録・更新（隠し入力 or stdin。値は `security -i` に stdin + hex で渡すため**どのプロセスの argv にも露出しない**。`-U` 相当の上書きで重複防止） |
+| `akc migrate` | v1.x のキー（旧 GUI ストア / manual スキーム）を managed namespace へ**一括引き継ぎ**。値は表示せず旧アイテムは削除しない。`--dry-run` / `--yes` / `--interactive` / `--only KEY,...` (#196) |
 | `akc delete <KEY>` | キー削除 |
-| `akc doctor` | env / `~/.zshrc` の参照診断（`-a "$USER"` 落とし穴 + 同一サービス名の**重複エントリ検出**を含む。値は読まない） |
+| `akc doctor` | env / `~/.zshrc` の keychain 参照と MCP 登録の診断（値は読まない・マスク表示） |
 | `akc guide` | AI エージェント向け使い方ガイド表示 |
 | `akc mcp` | MCP サーバー起動（stdio） |
 

--- a/docs/guide/cli-mcp.md
+++ b/docs/guide/cli-mcp.md
@@ -34,7 +34,7 @@ bash 版 `scripts/akc` と互換（issue #91/#167 対応済み）。各段は ex
 
 1. `service="com.aieo.aikeychain.managed"` + `account=<KEY>`（managed namespace = 唯一の保管場所 / v2.0）
 
-旧 v1.x の GUI ストア / manual スキームは読まない（旧ユーザーはキーを再登録する）。
+旧 v1.x の GUI ストア / manual スキームは読まない。旧ユーザーは **`akc migrate`** で一括引き継ぎできる（値は表示されず、旧アイテムは削除されない）。個別には `akc set <KEY>`。
 
 ## MCP サーバー
 


### PR DESCRIPTION
Closes #196

## 概要
v2.0 の BREAKING（全キー再登録）を 1 コマンド化。`akc migrate [--dry-run] [--yes] [--interactive] [--only KEY,...]`

- **検出（無音・値は読まない）**: dump 属性から旧 GUI store + manual（v1 と同一の厳格パターン `^[A-Z][A-Z0-9_]*$` #160/#163）。managed 済み skip・GUI/manual 重複は GUI 優先（v1 の解決順）
- **移行**: `security find-generic-password -w`（10s bound）→ `setKey`。値はプロセスメモリのみ。#191/#193 の検証・redact がそのまま効く。**旧アイテムは削除しない**
- **needs-approval**: ACL 許可ダイアログ待ちで timeout したキーは分類して続行コマンド（`--interactive --only ...`、待ち 600s + 「常に許可」案内）を提示 — 実移行で 2 件実在したケース
- **安全装置**: `--dry-run` 計画のみ / 非 TTY は `--yes` 必須 / 冪等
- ツアー再登録ページに「一括で引き継ぐ: `akc migrate`」を追加。README(en/ja)/cli README/usage guide/CHANGELOG 更新

## 検証（issue の 💬 検証コメントにエビデンス添付）
- Red: 新テスト 6 件が実装前に fail → Green: CLI **89/89**・Swift **185/187**（#192 のみ）
- 実機 dry-run（54 件移行済み環境）: 58 skip / 1 migrate・書き込みなし

## スコープ外
旧キー削除・GUI 内移行 UI（#172 の判断維持）・MCP ツール化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1pTCauh7wfgUDASgHZ5Wx